### PR TITLE
feat(ci): claude auto-respond to CodeRabbit reviews

### DIFF
--- a/.github/workflows/claude-respond-to-coderabbit.yml
+++ b/.github/workflows/claude-respond-to-coderabbit.yml
@@ -8,6 +8,13 @@ name: Claude responds to CodeRabbit
 # author login prefix). On cap trip the PR is labelled `ai: escalated` and
 # handed off to a human reviewer — Claude does not run.
 #
+# Abuse guard: the workflow runs unconditionally for PRs authored by the
+# repository owner (hard-coded below). For PRs from any other author, the
+# workflow skips Claude entirely unless the PR carries the `ai: approved`
+# label — which only the owner adds after a manual trust check. This
+# prevents a third party from weaponising a CodeRabbit reply to coerce
+# Claude into editing arbitrary code on their PR.
+#
 # Prerequisites (one-time setup):
 # - `CLAUDE_CODE_OAUTH_TOKEN` repo secret — Claude Max subscription token
 #   generated via `claude setup-token` locally; Max subscription tokens are
@@ -15,8 +22,9 @@ name: Claude responds to CodeRabbit
 # - Claude GitHub App installed on `aletheia-works/vivarium` so that Claude's
 #   pushes are attributed to `claude[bot]` and re-trigger commitlint /
 #   labeler / other workflows that otherwise ignore `GITHUB_TOKEN` pushes.
-# - `ai: escalated` label exists — managed via `infra/github/labels.tf`,
-#   must be `tofu apply`-ed before this workflow fires for the first time.
+# - `ai: approved` and `ai: escalated` labels exist — managed via
+#   `infra/github/labels.tf`, must be `tofu apply`-ed before this workflow
+#   fires for the first time.
 
 on:
   pull_request_review:
@@ -57,7 +65,40 @@ jobs:
             }
             core.setOutput('number', n);
 
+      - name: Check authorisation (owner-or-approval gate)
+        id: auth
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const OWNER = 'JamBalaya56562';
+            const APPROVED_LABEL = 'ai: approved';
+
+            const pr = context.payload.pull_request ?? context.payload.issue;
+            const authorLogin = pr?.user?.login ?? '';
+            const labels = (pr?.labels || []).map(l => l.name);
+
+            const isOwner = authorLogin === OWNER;
+            const isApproved = labels.includes(APPROVED_LABEL);
+            const allowed = isOwner || isApproved;
+
+            core.info(`PR author: ${authorLogin}`);
+            core.info(`PR labels: ${labels.join(', ') || '(none)'}`);
+            core.info(`Is owner: ${isOwner}`);
+            core.info(`Has "${APPROVED_LABEL}" label: ${isApproved}`);
+            core.info(`Proceed with Claude response: ${allowed}`);
+
+            if (!allowed) {
+              core.notice(
+                `Skipping Claude response: PR author "${authorLogin}" is not the repository owner ` +
+                `and the "${APPROVED_LABEL}" label is not present. ` +
+                `The owner must add the label to authorise automated processing.`
+              );
+            }
+
+            core.setOutput('allowed', allowed ? 'true' : 'false');
+
       - name: Count Claude iterations on this PR (cap 5)
+        if: steps.auth.outputs.allowed == 'true'
         id: cap
         uses: actions/github-script@v7
         with:
@@ -90,7 +131,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch PR head branch
-        if: steps.cap.outputs.stop != 'true'
+        if: steps.auth.outputs.allowed == 'true' && steps.cap.outputs.stop != 'true'
         id: meta
         uses: actions/github-script@v7
         with:
@@ -104,14 +145,14 @@ jobs:
             core.setOutput('head_sha', pr.head.sha);
 
       - name: Checkout PR branch
-        if: steps.cap.outputs.stop != 'true'
+        if: steps.auth.outputs.allowed == 'true' && steps.cap.outputs.stop != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ steps.meta.outputs.head_ref }}
 
       - name: Let Claude address CodeRabbit feedback
-        if: steps.cap.outputs.stop != 'true'
+        if: steps.auth.outputs.allowed == 'true' && steps.cap.outputs.stop != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-respond-to-coderabbit.yml
+++ b/.github/workflows/claude-respond-to-coderabbit.yml
@@ -1,0 +1,171 @@
+name: Claude responds to CodeRabbit
+
+# When CodeRabbit posts a review or review comment on a PR, Claude reads the
+# actionable items, decides whether each is correct, applies fixes (or pushes
+# back with reasoning), and posts `@coderabbitai resolve` to close the loop.
+#
+# Loop safety: caps at 5 Claude-authored commits per PR (counted by commit
+# author login prefix). On cap trip the PR is labelled `ai: escalated` and
+# handed off to a human reviewer — Claude does not run.
+#
+# Prerequisites (one-time setup):
+# - `CLAUDE_CODE_OAUTH_TOKEN` repo secret — Claude Max subscription token
+#   generated via `claude setup-token` locally; Max subscription tokens are
+#   valid for ~1 year.
+# - Claude GitHub App installed on `aletheia-works/vivarium` so that Claude's
+#   pushes are attributed to `claude[bot]` and re-trigger commitlint /
+#   labeler / other workflows that otherwise ignore `GITHUB_TOKEN` pushes.
+# - `ai: escalated` label exists — managed via `infra/github/labels.tf`,
+#   must be `tofu apply`-ed before this workflow fires for the first time.
+
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: claude-coderabbit-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  respond:
+    # Only fire when CodeRabbit is the sender and the context is a PR.
+    # `github.event.issue.pull_request != null` distinguishes PR-scoped issue
+    # comments from plain Issue comments.
+    if: >-
+      github.event.sender.login == 'coderabbitai[bot]' &&
+      (github.event.issue.pull_request != null || github.event.pull_request != null)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const n = context.payload.pull_request?.number ?? context.payload.issue?.number;
+            if (!n) {
+              core.setFailed('Could not resolve PR number from event payload.');
+              return;
+            }
+            core.setOutput('number', n);
+
+      - name: Count Claude iterations on this PR (cap 5)
+        id: cap
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = Number('${{ steps.pr.outputs.number }}');
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
+            const claudeCommits = commits.filter(c => {
+              const login = (c.author?.login || c.committer?.login || '').toLowerCase();
+              return login.startsWith('claude');
+            }).length;
+            core.info(`Claude iterations so far on PR #${prNumber}: ${claudeCommits}/5`);
+            core.setOutput('iterations', claudeCommits);
+            core.setOutput('stop', claudeCommits >= 5 ? 'true' : 'false');
+
+      - name: Escalate to human when cap is reached
+        if: steps.cap.outputs.stop == 'true'
+        run: |
+          gh pr edit ${{ steps.pr.outputs.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "ai: escalated"
+          gh pr comment ${{ steps.pr.outputs.number }} \
+            --repo ${{ github.repository }} \
+            --body "Claude has reached the 5-iteration cap for automated CodeRabbit responses on this PR. Handing off to a human reviewer — see \`docs/AI_WORKFLOW.md\` § 5."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch PR head branch
+        if: steps.cap.outputs.stop != 'true'
+        id: meta
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number('${{ steps.pr.outputs.number }}'),
+            });
+            core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('head_sha', pr.head.sha);
+
+      - name: Checkout PR branch
+        if: steps.cap.outputs.stop != 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.meta.outputs.head_ref }}
+
+      - name: Let Claude address CodeRabbit feedback
+        if: steps.cap.outputs.stop != 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            CodeRabbit left review feedback on PR #${{ steps.pr.outputs.number }}
+            (iteration ${{ steps.cap.outputs.iterations }} of 5).
+
+            ## Your task
+
+            1. Read `AGENTS.md` and `CLAUDE.md` at the repo root — they carry
+               the project's guardrails and conventions. Your work must
+               conform to them.
+
+            2. Fetch every unresolved CodeRabbit comment on this PR:
+
+               ```
+               gh api repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/comments --paginate
+               gh api repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/reviews --paginate
+               ```
+
+            3. For each actionable point, evaluate whether CodeRabbit is
+               correct.
+               - If correct: apply the fix.
+               - If wrong: reply to the thread with a short, specific
+                 justification and do NOT apply a "fix" you disagree with.
+                 Silent capitulation corrupts the review signal over time.
+
+            4. Honour the project's conventions:
+               - Conventional Commits for commit messages.
+               - Mechanical labelling — do not add or change labels yourself.
+               - Edit existing files; never create new documents unless an
+                 Issue explicitly asks for one.
+
+            5. If fixes were applied, commit them as a single commit titled
+               `fix(review): address CodeRabbit feedback (iteration ${{ steps.cap.outputs.iterations }})`
+               and push to the PR branch.
+
+            6. Post a PR comment summarising what changed (and what you
+               pushed back on). End with `@coderabbitai resolve` **only if**
+               every actionable point is fully addressed; otherwise explain
+               what is left.
+
+            7. If you cannot make progress — CodeRabbit is fundamentally
+               wrong, the feedback is scope-creep, or the point needs human
+               judgement — post a comment tagging the issue and STOP. Do not
+               loop on the same point across iterations.
+
+            ## Constraints
+
+            The guardrails in `AGENTS.md` § 2 apply unchanged:
+            - Do not merge or approve this PR.
+            - Do not push to `main`.
+            - Do not modify secrets or branch protection.
+            - Do not pivot scope.
+          claude_args: |
+            --max-turns 10
+            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,Bash(git:*),Bash(gh:*)"

--- a/infra/github/labels.tf
+++ b/infra/github/labels.tf
@@ -115,6 +115,10 @@ locals {
     }
 
     # ─── AI-related ──────────────────────────────
+    "ai: approved" = {
+      color       = "0969da"
+      description = "Repository owner has authorised AI agents to process this PR"
+    }
     "ai: generated" = {
       color       = "00d4aa"
       description = "Created or modified by AI"

--- a/infra/github/labels.tf
+++ b/infra/github/labels.tf
@@ -127,6 +127,10 @@ locals {
       color       = "28a745"
       description = "AI output verified by human"
     }
+    "ai: escalated" = {
+      color       = "ff8c00"
+      description = "AI agent reached iteration cap; escalated to human review"
+    }
 
     # ─── Community ───────────────────────────────
     "good-first-issue" = {


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude-respond-to-coderabbit.yml` — an autonomous loop where Claude Code reads CodeRabbit's review feedback on a PR, applies fixes (or pushes back with reasoning), and posts `@coderabbitai resolve` to close the loop.
- Adds the `ai: escalated` label to `infra/github/labels.tf`, applied mechanically by the workflow when the iteration cap is hit.

Closes #19.

## Design highlights

- **Trigger**: `pull_request_review` + `pull_request_review_comment` + `issue_comment` events, filtered so the job only runs when `github.event.sender.login == 'coderabbitai[bot]'` and the context is a PR (not a bare Issue).
- **Auth**: `CLAUDE_CODE_OAUTH_TOKEN` (Claude Max subscription, ~1-year validity). No `ANTHROPIC_API_KEY` required today — easy to swap input if we ever migrate.
- **Loop safety**:
  - Iteration cap of **5 Claude-authored commits per PR**, counted by commit-author login prefix.
  - On cap trip: `ai: escalated` label applied, handoff comment posted, Claude **does not run**.
  - `concurrency: cancel-in-progress` on the PR number prevents rapid-fire event bursts from stacking.
- **Prompt contract**: Claude is instructed to (a) read `AGENTS.md` + `CLAUDE.md` first, (b) fetch all unresolved CodeRabbit comments, (c) only fix points where CodeRabbit is correct (pushing back with reasoning on wrong ones — silent capitulation corrupts the review signal), (d) commit per Conventional Commits, (e) close with `@coderabbitai resolve` only when fully addressed.
- **Minimum permissions**: `contents: write`, `pull-requests: write`, `issues: write`. No `id-token: write` because OIDC is not used.

## Required human prerequisites (already satisfied per chat)

- [x] Claude GitHub App installed on `aletheia-works/vivarium`.
- [x] `CLAUDE_CODE_OAUTH_TOKEN` registered as a repo secret.

## Deployment ordering — IMPORTANT

1. Merge this PR.
2. **Run `tofu apply` in `infra/github/`** to create the `ai: escalated` label before the workflow fires for the first time.
3. Workflow becomes live on the next CodeRabbit comment on any PR.

If step 2 is skipped, the escalation step in the workflow will error on `gh pr edit --add-label "ai: escalated"` when the cap is eventually hit — Claude's normal iteration still works, only the escalation path is degraded.

## Review focus

- [x] Trigger filter correctly isolates CodeRabbit comments on PRs only.
- [x] Iteration cap logic counts Claude commits reliably (handles `author` being null when a commit is web-edited or rebased).
- [x] Prompt does not accidentally invite Claude to violate `AGENTS.md` § 2 guardrails.
- [x] Allowed tools are the minimum necessary (no `Bash(sl:*)` because CI uses git; no `Bash(npm:*)` or `Bash(bun:*)` because no JS build yet).
- [x] No hard-coded model — lets the default from the action track upstream.

## Process notes

- Scope is intentionally **this repo only** — not promoted to a reusable in `aletheia-works/.github`. Re-evaluate when a second repo needs the same loop.
- Sibling Issue #8 (the `/claude`-triggered implementation workflow) remains open; this is the bot-initiated refinement counterpart, not a replacement.
- AI-authored. `ai: generated` label applied per `docs/AI_WORKFLOW.md` § 4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automated AI-assisted responses to code review feedback with iteration safeguards
  * Integrated escalation mechanism that routes reviews to human teams after reaching iteration limits
  * Added `ai: escalated` label for tracking escalated code reviews

<!-- end of auto-generated comment: release notes by coderabbit.ai -->