### PR TITLE
feat(ci): add .coderabbit.yaml review profile

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,139 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit review profile for aletheia-works/vivarium.
+#
+# Posture: strict on substance, light on style.
+# - Flag unverified claims, hallucinated APIs, invented citations, AI-slop
+#   signals, and PRs that look AI-authored without acknowledging it.
+# - Do NOT comment on indentation, line length, minor naming, prose style.
+#   Those belong in formatters/linters/tofu fmt, not review.
+#
+# Label policy: CodeRabbit must NOT apply labels automatically. Our label
+# taxonomy in infra/github/labels.tf is mechanical-only (path rules +
+# Conventional-Commit parsing + CI). See ADR-0006.
+
+language: en-US
+early_access: false
+
+tone_instructions: |
+  Prioritise substance over style. Flag unverified factual claims,
+  hallucinated APIs or function references, invented citations, generic
+  copy-paste advice, and PRs that look AI-authored without acknowledging it
+  via an `ai: generated` label. Do not comment on indentation, line length,
+  minor naming, comment formatting, or prose style — those are handled by
+  formatters and linters, not review.
+
+reviews:
+  # `chill` keeps feedback substantive; `assertive` reintroduces stylistic
+  # nitpicks that our tone_instructions explicitly suppress.
+  profile: chill
+
+  poem: false
+  in_progress_fortune: false
+  sequence_diagrams: false  # too noisy for a docs/infra repo
+
+  # OSS contributors should not be blocked by a bot review.
+  request_changes_workflow: false
+  high_level_summary: true
+  changed_files_summary: true
+  assess_linked_issues: true
+
+  # Mechanical-labelling policy (ADR-0006): never let CodeRabbit infer
+  # or apply labels. Humans or workflows set them; CodeRabbit stays out.
+  suggested_labels: false
+  auto_apply_labels: false
+  suggested_reviewers: false
+  auto_assign_reviewers: false
+
+  # Anti-slop detection (public GitHub repos only — vivarium qualifies).
+  # The label below must exist in infra/github/labels.tf; `ai: slop-risk`
+  # is our canonical label for this state. CodeRabbit will *suggest* this
+  # state, but per auto_apply_labels=false, a human still applies it.
+  slop_detection:
+    enabled: true
+    label: "ai: slop-risk"
+
+  path_filters:
+    - "!LICENSE"
+    - "!_context/**"       # local-only strategy memos; gitignored anyway
+    - "!.mise.toml"        # pinned-by-convention, no review value
+    - "!**/*.lock"
+    - "!**/bun.lock"
+
+  path_instructions:
+    - path: "**/*.md"
+      instructions: |
+        Review for factual accuracy, broken internal links, and
+        strategic coherence with VISION.md / NON_GOALS.md / the ADRs.
+        Do NOT flag prose style, line length, or heading-case preferences.
+    - path: ".github/workflows/**"
+      instructions: |
+        Flag insecure patterns: actions pinned by floating tag, missing
+        `permissions:` blocks, potential secret leaks, overly broad
+        `GITHUB_TOKEN` scopes. Do not flag whitespace or key ordering.
+    - path: "infra/**/*.tf"
+      instructions: |
+        Flag state-safety issues, missing provider pinning, overly broad
+        IAM / permissions, resources that could cause data loss on destroy.
+        Defer formatting to `tofu fmt`.
+    - path: "docs/decisions/**"
+      instructions: |
+        ADRs are historical records. Do not request edits to accepted
+        ADRs; instead request a superseding ADR.
+
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+
+  # commitlint and the conventional-commit caller workflow already
+  # validate PR titles; CodeRabbit should not duplicate that.
+  pre_merge_checks:
+    title:
+      mode: "off"
+    description:
+      mode: "off"
+    issue_assessment:
+      mode: "warning"
+
+tools:
+  # Defer style linting to the project's own CI and formatters.
+  markdownlint:
+    enabled: false
+  yamllint:
+    enabled: false
+  biome:
+    enabled: false
+  eslint:
+    enabled: false
+
+  # Prose checks — keep enabled but at `default` level (not `picky`),
+  # and suppress style/redundancy categories per tone_instructions.
+  languagetool:
+    enabled: true
+    level: default
+    disabled_categories:
+      - STYLE
+      - REDUNDANCY
+      - COLLOQUIALISMS
+
+  # Security and IaC scanners — keep on.
+  gitleaks:
+    enabled: true
+  trufflehog:
+    enabled: true
+  checkov:
+    enabled: true
+  tflint:
+    enabled: true
+
+chat:
+  auto_reply: true
+  allow_non_org_members: true   # OSS repo; accept contributor questions
+
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: true               # helps ground-check hallucinated references
+  learnings:
+    scope: local                # public repo; keep learnings repo-scoped


### PR DESCRIPTION
## Summary

Adds `.coderabbit.yaml` with a review profile tailored for this project:

- **Strict on substance** — anti-slop detection enabled, `tone_instructions` asks CodeRabbit to flag unverified claims, hallucinated APIs, invented citations, and unacknowledged AI authorship.
- **Light on style** — `profile: chill`, stylistic linters (markdownlint, yamllint, biome, eslint) disabled so they don't duplicate our own CI/formatters. LanguageTool kept at `default` level with `STYLE`/`REDUNDANCY`/`COLLOQUIALISMS` suppressed.
- **Mechanical labelling** — `suggested_labels`, `auto_apply_labels`, `suggested_reviewers`, `auto_assign_reviewers` all `false` per [ADR-0006](https://github.com/aletheia-works/vivarium/blob/main/docs/DECISIONS/ADR-0006-mechanical-labeling.md). CodeRabbit stays out of the label taxonomy.
- **Path filters** — exclude `LICENSE`, `_context/**`, `.mise.toml`, lock files from review.
- **Path instructions** — targeted review criteria for `**/*.md`, `.github/workflows/**`, `infra/**/*.tf`, and `docs/decisions/**` (ADRs are historical; request a superseding ADR rather than edits).
- **Slop detection** — enabled with `label: "ai: slop-risk"` (matches our taxonomy in `infra/github/labels.tf`).
- **Security scanners** — `gitleaks`, `trufflehog`, `checkov`, `tflint` all kept enabled.
- **Pre-merge checks** — `title.mode: "off"` and `description.mode: "off"` because commitlint and the Conventional-Commit caller workflow already validate PR titles; CodeRabbit should not duplicate.

Closes #10.

## Review focus

- [x] Profile choice (`chill` + path-scoped strictness via `tone_instructions` + `path_instructions`) actually delivers "strict on substance, light on style" rather than drifting toward nitpicks.
- [x] `slop_detection.label` value (`"ai: slop-risk"`) exists in `infra/github/labels.tf` and is the intended target for this signal.
- [x] Path filters don't accidentally exclude anything the project wants reviewed.
- [x] `auto_apply_labels: false` preserves ADR-0006 mechanical-labelling invariant.

## Notes

- The schema reference at the top of the file points at `schema.v2.json` (current as of 2026-04), which gives editors IDE-level validation.
- Slop detection is documented as **public-GitHub-only** by CodeRabbit; `vivarium` qualifies.
- AI-authored. `ai: generated` label applied per `docs/AI_WORKFLOW.md` § 4.
