### PR TITLE
fix(ci): pin docs-build workflows by SHA + replace jdx/mise-action

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,8 +4,13 @@ name: deploy-docs
 #
 # Prerequisites (one-time setup):
 # - Repo Settings → Pages → Source: "GitHub Actions".
-# - `.mise.toml` pins Node and Bun versions.
-# - `bun.lock` committed.
+# - `bun.lock` committed (first run generates it; see note on install step).
+#
+# Tool versions:
+# - `.mise.toml` declares `bun = "latest"` for local development.
+# - CI uses `oven-sh/setup-bun` directly (an allowlisted action) rather
+#   than `jdx/mise-action`, which is not on the repo's `selected-actions`
+#   patterns. Keep `bun-version` in sync with the intent of `.mise.toml`.
 
 on:
   push:
@@ -33,29 +38,31 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # for `lastUpdated` timestamps
 
-      - name: Install Node and Bun via mise
-        uses: jdx/mise-action@v2
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Install dependencies
         # First-run note: `bun.lock` does not exist yet on the initial deploy.
         # We install without `--frozen-lockfile` so the first run can generate
         # a lockfile. Commit the generated `bun.lock` and switch this to
         # `bun install --frozen-lockfile` once the lockfile is in version
-        # control. Tracked: see deployment-ordering note in the PR.
+        # control.
         run: bun install
 
       - name: Build docs
         run: bun run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: doc_build
 
@@ -67,4 +74,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/test-docs-build.yml
+++ b/.github/workflows/test-docs-build.yml
@@ -8,6 +8,9 @@ name: Test docs build
 # This workflow does NOT deploy — it only runs `bun run build` and
 # discards the output. Actual deployment happens from `deploy-docs.yml`
 # on pushes to main.
+#
+# Tool versions: CI uses `oven-sh/setup-bun` (allowlisted) with
+# `bun-version: latest`, matching the intent of `.mise.toml` locally.
 
 on:
   pull_request:
@@ -34,12 +37,14 @@ jobs:
     name: Build docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - name: Install Bun via mise
-        uses: jdx/mise-action@v2
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
 
       - name: Install dependencies
         # First-run note: `bun.lock` does not yet exist in version control.


### PR DESCRIPTION
## Summary

Re-submits the workflow-file changes that were lost in the PR #22 merge. GitHub's PR head-SHA lagged behind the branch's actual remote tip when the merge commit was formed, so the last commit (`e87fa82`) containing the SHA-pin fixes did not land on `main`. This PR re-applies those exact changes.

## Why this is urgent

`deploy-docs.yml` and `test-docs-build.yml` on main currently:

1. Reference actions by floating tag (`@v4`, `@v5`, etc.), which violates the repo's `sha_pinning_required: true` policy — runs will hit `startup_failure`.
2. Use `jdx/mise-action@v2`, which is not in `patterns_allowed` (only `opentofu/setup-opentofu@*` and `oven-sh/setup-bun@*` are allowlisted).

Net effect: the docs-deploy pipeline cannot run at all until this PR lands.

## Changes

### `deploy-docs.yml` and `test-docs-build.yml`

- Replaced `jdx/mise-action@v2` (not allowlisted) with `oven-sh/setup-bun@0c5077e5… # v2.2.0` (already allowlisted), using `bun-version: latest` to match `.mise.toml`.
- SHA-pinned every github-owned action to its latest version:

  | Action | Before | After |
  |---|---|---|
  | `actions/checkout` | `@v4` | `@de0fac2e… # v6.0.2` |
  | `actions/configure-pages` | `@v5` | `@45bfe019… # v6.0.0` |
  | `actions/upload-pages-artifact` | `@v3` | `@fc324d35… # v5.0.0` |
  | `actions/deploy-pages` | `@v4` | `@cd2ce8fc… # v5.0.0` |

- Updated header comments to reflect the `.mise.toml` (local) vs. allowlisted-action (CI) split.

## Review focus

- [x] SHAs resolve to the claimed tag in each action's repo.
- [x] `oven-sh/setup-bun@0c5077e5…` is in `patterns_allowed` (verify via `gh api repos/aletheia-works/vivarium/actions/permissions/selected-actions`).
- [x] `bun-version: latest` matches the intent of `.mise.toml: bun = "latest"`.
- [x] No regressions to trigger paths, permissions blocks, or concurrency keys.

## Process notes

- AI-authored. `ai: generated` label applied per `docs/ai-workflow.md` § 4.
- This is a re-submit, not a new change — diff should be byte-identical to commit `e87fa82` from PR #22.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to pin action versions to specific commits for improved stability.
  * Modified build toolchain installation configuration in CI workflows.
  * Updated CI documentation comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->