### PR TITLE
feat(ci): add Issue and PR templates with Issue Type set

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Report a bug in an existing feature, workflow, or piece of documentation.
+title: "bug: "
+type: Bug
+labels:
+  - "type: bug"
+  - "status: triage"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report. This form asks for the structured
+        information Claude Code, CodeRabbit, and the human maintainer need
+        to act on the report without a round-trip.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: |
+        What observable behaviour is wrong or missing? State it in
+        bug-reproduction terms — something a script could check.
+      placeholder: |
+        When I run `foo bar`, the output is `X` but I expected `Y`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: The post-condition that indicates the bug is fixed.
+      placeholder: |
+        `foo bar` should return `Y` for the same input.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope boundary
+      description: What this Issue is *not* trying to do. Helps prevent scope creep.
+      placeholder: |
+        This is not about the broader refactor of `foo`, only the
+        observable behaviour of `foo bar` on this input.
+
+  - type: textarea
+    id: hints
+    attributes:
+      label: Hints
+      description: File paths, prior art, related Issues, reproduction URLs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Open discussion
+    url: https://github.com/aletheia-works/vivarium/discussions
+    about: For open-ended questions and strategic conversation, please use Discussions instead of Issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Propose a new feature or capability.
+title: "feat: "
+type: Feature
+labels:
+  - "type: feature"
+  - "status: triage"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a feature. This form asks for the structured
+        information needed to evaluate fit with the project's phased roadmap
+        and [non-goals](https://github.com/aletheia-works/vivarium/blob/main/docs/non-goals.md).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: |
+        What user-facing reproduction scenario does this feature enable or
+        improve? Keep the framing problem-centred per
+        [ADR-0001](https://github.com/aletheia-works/vivarium/blob/main/docs/decisions/0001-problem-centred-framing.md).
+      placeholder: |
+        Users want to reproduce `X` but currently cannot because `Y`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: What does a visitor see after this feature ships?
+      placeholder: |
+        A visitor can open `Z` URL and see the reproduction run end-to-end.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope boundary
+      description: What this Issue is *not* trying to do. Protects against drift.
+      placeholder: |
+        This is not the full multi-language story — only Python + SQLite
+        over Pyodide. Other runtimes are separate Issues.
+
+  - type: textarea
+    id: hints
+    attributes:
+      label: Hints
+      description: File paths, prior art, related Issues, relevant ADRs.

--- a/.github/ISSUE_TEMPLATE/reproduction_request.yml
+++ b/.github/ISSUE_TEMPLATE/reproduction_request.yml
@@ -1,0 +1,57 @@
+name: Reproduction request
+description: Ask the platform to reproduce a specific bug — Vivarium's core primitive.
+title: "repro: "
+type: Task
+labels:
+  - "status: triage"
+  - "status: needs-reproduction"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This form is the direct user-facing path into Vivarium. You are
+        saying "I have a bug, please reproduce it so I (and the maintainer)
+        can verify it is real." This may feel light on engineering detail;
+        that is intentional — Vivarium's job is to make reproduction cheap.
+
+  - type: input
+    id: source_issue
+    attributes:
+      label: Source Issue / PR
+      description: |
+        URL of the upstream Issue or PR whose bug you want reproduced.
+      placeholder: "https://github.com/<owner>/<repo>/issues/<n>"
+    validations:
+      required: true
+
+  - type: textarea
+    id: claim
+    attributes:
+      label: Claim to verify
+      description: |
+        In one sentence, what does the upstream claim? Keep it bug-shaped,
+        not opinion-shaped.
+      placeholder: |
+        `pandas.read_csv` crashes on a file with a BOM when `engine='c'`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: runtime
+    attributes:
+      label: Runtime and versions
+      description: |
+        Language, library, and version information. If unknown, say so — we
+        will guess defaults.
+      placeholder: |
+        Python 3.12, pandas 2.3.0
+
+  - type: textarea
+    id: minimal
+    attributes:
+      label: Minimal reproducer (if available)
+      description: |
+        Paste the smallest self-contained snippet that triggers the claim.
+        Optional — Vivarium will attempt to construct one from the source
+        Issue if you leave this blank.
+      render: python

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,50 @@
+name: Task
+description: Work that is neither a bug nor a feature — documentation, chore, refactor, test, infrastructure.
+title: "chore: "
+type: Task
+labels:
+  - "status: triage"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for: documentation, chore, refactor, test, and
+        infrastructure work. If you are not sure, start here.
+
+        The project uses Conventional Commits. Please prefix the title with
+        one of: `docs:`, `chore:`, `refactor:`, `test:`, `build:`, `ci:`,
+        `perf:`. Scope is optional: `docs(ci): add workflow`.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: |
+        What is the current state that needs to change, or the missing
+        artefact that needs to exist?
+      placeholder: |
+        The workflow in X does not pin actions by SHA.
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: The post-condition that indicates the task is done.
+      placeholder: |
+        Every `uses:` line in the workflow references a commit SHA.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope boundary
+      description: What this Issue is *not* trying to do.
+
+  - type: textarea
+    id: hints
+    attributes:
+      label: Hints
+      description: File paths, prior art, related Issues, relevant ADRs.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+Thanks for opening a PR on vivarium. A few notes so CI and reviewers can
+move quickly:
+
+- Title MUST follow Conventional Commits:
+    <type>(<scope>)?: <subject>
+  Types: feat, fix, docs, refactor, test, chore, build, ci, perf.
+  The repo's commitlint workflow will fail the check otherwise.
+
+- The scope-based `scope: *` label is applied automatically by
+  `.github/labeler.yml` from file paths. Do not hand-add it.
+
+- Labels are mechanical only (see ADR-0006). If you are about to apply a
+  label by judgement, stop and ask.
+-->
+
+## Summary
+
+<!-- 1–3 bullets on what this PR changes and why. -->
+
+Closes #<issue-number>.
+
+## Review focus
+
+<!-- A checklist of specific things you want the reviewer to verify. -->
+- [ ]
+- [ ]
+- [ ]
+
+## Process notes
+
+<!-- Delete the bullets that do not apply. -->
+- AI-authored? If yes, the `ai: generated` label must be set on this PR.
+- Scope-creep check: the diff still matches the title and linked Issue.
+- CodeRabbit agrees, or you have pushed back with a specific justification
+  on each disagreement (silent capitulation corrupts the review signal).


### PR DESCRIPTION
## Summary

Introduces `.github/ISSUE_TEMPLATE/` (four forms + `config.yml`) and `.github/PULL_REQUEST_TEMPLATE.md`. Every Issue form sets the **GitHub Issue Type** field at the top, so humans filing via the UI get the native Type assigned automatically alongside the `type: *` label.

The user required on 2026-04-19 that **Claude Code must always set Issue Type when creating Issues**. The matching agent-side rule is saved as a memory entry (`feedback_issue_type_required.md`); this PR covers the human-side path via templates.

Closes #9.

## Files

- `.github/ISSUE_TEMPLATE/config.yml` — disables blank Issues; routes open-ended questions to Discussions.
- `.github/ISSUE_TEMPLATE/bug_report.yml` — `type: Bug`
- `.github/ISSUE_TEMPLATE/feature_request.yml` — `type: Feature`
- `.github/ISSUE_TEMPLATE/task.yml` — `type: Task` (docs / chore / refactor / test / infrastructure)
- `.github/ISSUE_TEMPLATE/reproduction_request.yml` — `type: Task` (Vivarium's core user-facing primitive)
- `.github/PULL_REQUEST_TEMPLATE.md` — enforces Conventional-Commit title format, reminds about mechanical labelling (ADR-0006), AI-authorship disclosure.

## Design notes

Each form collects the four structured fields from [AI workflow § 3.1](https://github.com/aletheia-works/vivarium/blob/main/docs/AI_WORKFLOW.md) where applicable:

- **Problem** — what is observably wrong or missing, in bug-reproduction terms.
- **Desired outcome** — the post-condition indicating done.
- **Scope boundary** — what this Issue is *not* trying to do.
- **Hints** — file paths, prior art, related Issues.

The `reproduction_request.yml` form diverges slightly — it is the user-facing entry point where the user does *not* know the internals. Fields there are tuned for claim verification (source URL, claim, runtime, optional minimal reproducer) rather than engineering fields.

## Review focus

- [x] `type:` key value matches the org's available Issue Types (Bug / Feature / Task, verified via `repository.issueTypes` GraphQL query).
- [x] Each form's default labels exist in `infra/github/labels.tf`.
- [x] Default title prefixes (`bug: `, `feat: `, `chore: `, `repro: `) align with Conventional Commits.
- [x] `config.yml` correctly disables blank Issues (`blank_issues_enabled: false`).
- [x] The PR template does not duplicate commitlint's validation; it only nudges.

## Follow-up (not in this PR)

Existing open Issues (#2, #3, #4–#14, #19, #21) were created before templates existed and do not have the GitHub Issue Type field set. A batch-update pass via the `updateIssue` GraphQL mutation will set the Type for each existing open Issue based on its `type: *` label. Running this as a separate operational step after this PR merges.

## Process notes

- AI-authored. `ai: generated` label applied per `docs/AI_WORKFLOW.md` § 4.