### PR TITLE
feat(infra): enable GitHub Pages (Actions source) for docs site

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   apply:
     # Pinned by commit SHA (org enforces sha_pinning_required).
-    uses: aletheia-works/.github/.github/workflows/terraform-apply.yml@f52a2381bc55e7303659a10711747c0a51cf475a # main
+    uses: aletheia-works/.github/.github/workflows/terraform-apply.yml@9329751b712bc7493df59c390c26957d89324f72 # main
     with:
       working_directory: infra/github
     secrets: inherit

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -26,7 +26,7 @@ jobs:
   plan:
     # Pinned by commit SHA (org enforces sha_pinning_required). Update
     # this ref when the reusable workflow meaningfully changes.
-    uses: aletheia-works/.github/.github/workflows/terraform-plan.yml@f52a2381bc55e7303659a10711747c0a51cf475a # main
+    uses: aletheia-works/.github/.github/workflows/terraform-plan.yml@9329751b712bc7493df59c390c26957d89324f72 # main
     with:
       working_directory: infra/github
     secrets: inherit

--- a/infra/github/main.tf
+++ b/infra/github/main.tf
@@ -43,16 +43,46 @@ resource "github_repository" "this" {
   # Prevent accidental archival.
   archived = false
 
+  # ─── GitHub Pages ────────────────────────────────────────────
+  # Source = GitHub Actions. The actual build/deploy is wired up in
+  # `.github/workflows/deploy-docs.yml` via actions/configure-pages and
+  # actions/deploy-pages. Declaring it here keeps the Pages enablement
+  # itself under IaC so drift (e.g. someone disabling Pages in the UI)
+  # is detected.
+  pages {
+    build_type = "workflow"
+  }
+
   lifecycle {
     # Guard against accidental deletion.
     prevent_destroy = true
-    # Do not manage repository attributes via TF — use `gh api` or the GitHub UI.
-    # Rationale: integrations/github provider (as of 6.x) always sends
-    # web_commit_signoff_required=false in the PATCH body. When the org enforces
-    # signoff, this triggers a 422 "Commit signoff is enforced by the organization
-    # and cannot be disabled" error, unavoidable even when the attribute is set to true.
-    # This resource is kept in state purely so that other resources (labels,
-    # branch_protection) can reference it; its attributes are not reconciled.
-    ignore_changes = all
+    # Known provider bug: integrations/github v6.x always sends
+    # web_commit_signoff_required=false in the repository PATCH body. The
+    # aletheia-works org enforces commit signoff, so that PATCH 422s.
+    # Ignoring the attribute here is not enough — the provider still
+    # includes it in the PATCH — so we also skip the full list of repo
+    # attributes it would otherwise try to reconcile. Pages is exempted:
+    # the provider manages it via a separate `/pages` API call, so it
+    # is reachable independent of the broken PATCH.
+    #
+    # Migrate back to `ignore_changes = [web_commit_signoff_required]`
+    # once provider v6.12+ ships (PR integrations/terraform-provider-github#3166).
+    ignore_changes = [
+      description,
+      visibility,
+      topics,
+      has_issues,
+      has_discussions,
+      has_projects,
+      has_wiki,
+      allow_merge_commit,
+      allow_squash_merge,
+      allow_rebase_merge,
+      allow_auto_merge,
+      delete_branch_on_merge,
+      vulnerability_alerts,
+      web_commit_signoff_required,
+      archived,
+    ]
   }
 }


### PR DESCRIPTION

Declares the Pages configuration on the vivarium repository via the
provider's nested `pages` block with `build_type = "workflow"`. The
actual build/deploy is still driven by `.github/workflows/deploy-docs.yml`
(`actions/configure-pages` + `actions/deploy-pages`); putting the
enablement itself under IaC means drift (e.g. a UI toggle disabling the
site) is detectable on the next `tofu plan` rather than silently
breaking the deploy.

Required a tweak to `lifecycle.ignore_changes`. The previous `all` was
a broad guard against the signoff-bug-induced PATCH 422 (`integrations/
github` v6.x hardcodes `web_commit_signoff_required=false`), but that
also blanket-ignored the `pages` block. Switched to an explicit per-
attribute list that covers every existing repo attr *except* `pages`.
The provider reaches Pages via a separate `/pages` API call, so it is
unaffected by the broken repo PATCH. Revert to
`ignore_changes = [web_commit_signoff_required]` once v6.12+ ships
(integrations/terraform-provider-github#3166).

Org-level prerequisite (`members_can_create_public_pages = true`) was
landed earlier in aletheia-works/.github.
