### PR TITLE
fix(infra): manage Pages via gh CLI to sidestep signoff PATCH bug

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   apply:
     # Pinned by commit SHA (org enforces sha_pinning_required).
-    uses: aletheia-works/.github/.github/workflows/terraform-apply.yml@9329751b712bc7493df59c390c26957d89324f72 # main
+    uses: aletheia-works/.github/.github/workflows/terraform-apply.yml@db8aaaef0c0c8dc00152bfb37f1eee15f019a087 # main
     with:
       working_directory: infra/github
     secrets: inherit

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -26,7 +26,7 @@ jobs:
   plan:
     # Pinned by commit SHA (org enforces sha_pinning_required). Update
     # this ref when the reusable workflow meaningfully changes.
-    uses: aletheia-works/.github/.github/workflows/terraform-plan.yml@9329751b712bc7493df59c390c26957d89324f72 # main
+    uses: aletheia-works/.github/.github/workflows/terraform-plan.yml@db8aaaef0c0c8dc00152bfb37f1eee15f019a087 # main
     with:
       working_directory: infra/github
     secrets: inherit

--- a/infra/github/main.tf
+++ b/infra/github/main.tf
@@ -43,46 +43,22 @@ resource "github_repository" "this" {
   # Prevent accidental archival.
   archived = false
 
-  # ─── GitHub Pages ────────────────────────────────────────────
-  # Source = GitHub Actions. The actual build/deploy is wired up in
-  # `.github/workflows/deploy-docs.yml` via actions/configure-pages and
-  # actions/deploy-pages. Declaring it here keeps the Pages enablement
-  # itself under IaC so drift (e.g. someone disabling Pages in the UI)
-  # is detected.
-  pages {
-    build_type = "workflow"
-  }
-
   lifecycle {
     # Guard against accidental deletion.
     prevent_destroy = true
-    # Known provider bug: integrations/github v6.x always sends
-    # web_commit_signoff_required=false in the repository PATCH body. The
-    # aletheia-works org enforces commit signoff, so that PATCH 422s.
-    # Ignoring the attribute here is not enough — the provider still
-    # includes it in the PATCH — so we also skip the full list of repo
-    # attributes it would otherwise try to reconcile. Pages is exempted:
-    # the provider manages it via a separate `/pages` API call, so it
-    # is reachable independent of the broken PATCH.
+    # Do not manage repository attributes via TF — use `gh api` or the GitHub UI.
+    # Rationale: integrations/github provider (as of 6.x) always sends
+    # web_commit_signoff_required=false in the PATCH body. When the org enforces
+    # signoff, this triggers a 422 "Commit signoff is enforced by the organization
+    # and cannot be disabled" error, unavoidable even when the attribute is set to true.
+    # This resource is kept in state purely so that other resources (labels,
+    # branch_protection) can reference it; its attributes are not reconciled.
     #
-    # Migrate back to `ignore_changes = [web_commit_signoff_required]`
-    # once provider v6.12+ ships (PR integrations/terraform-provider-github#3166).
-    ignore_changes = [
-      description,
-      visibility,
-      topics,
-      has_issues,
-      has_discussions,
-      has_projects,
-      has_wiki,
-      allow_merge_commit,
-      allow_squash_merge,
-      allow_rebase_merge,
-      allow_auto_merge,
-      delete_branch_on_merge,
-      vulnerability_alerts,
-      web_commit_signoff_required,
-      archived,
-    ]
+    # NOTE: We tried using the nested `pages` block with a narrow
+    # `ignore_changes` list in PR #29, but the provider still issues a
+    # full repo PATCH whenever anything about the resource changes
+    # (including a pages-only diff), so the signoff 422 still fires.
+    # Pages is now managed via `pages.tf` using gh CLI instead.
+    ignore_changes = all
   }
 }

--- a/infra/github/pages.tf
+++ b/infra/github/pages.tf
@@ -1,0 +1,54 @@
+# GitHub Pages enablement (Actions source).
+#
+# The provider's nested `github_repository.pages` block cannot be used
+# right now: every change to the repo resource PATCHes `/repos/{owner}/
+# {repo}` with `web_commit_signoff_required=false` hardcoded, which the
+# org's enforced signoff rejects with 422 (see `main.tf` lifecycle
+# comment). `ignore_changes` does not suppress the PATCH itself — only
+# drift detection — so even a pages-only diff triggers the broken call.
+#
+# Workaround: drive the Pages API directly via `gh` over a
+# `terraform_data` provisioner. The Pages endpoint (`/repos/{owner}/
+# {repo}/pages`) is separate from the repo PATCH, so it succeeds. The
+# provisioner is idempotent (POST on create, PUT on update) so reruns
+# are safe.
+#
+# When integrations/github v6.12+ ships (PR #3166), this file can be
+# removed and replaced with a `pages {}` block on `github_repository.this`
+# plus `ignore_changes = [web_commit_signoff_required]`.
+
+resource "terraform_data" "pages" {
+  # Replace the resource (re-run the provisioner) whenever the desired
+  # Pages configuration changes.
+  triggers_replace = {
+    repository = github_repository.this.name
+    build_type = "workflow"
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    # gh auths from $GH_TOKEN (or $GITHUB_TOKEN as fallback), both of
+    # which CI sets to TF_TOKEN_GITHUB. The PAT must have the repo-level
+    # `Pages` permission (RW) in addition to whatever else this module
+    # uses, otherwise the API returns 403.
+    command = <<-EOT
+      set -euo pipefail
+      OWNER='${var.github_owner}'
+      REPO='${github_repository.this.name}'
+
+      if gh api "repos/$OWNER/$REPO/pages" >/dev/null 2>&1; then
+        echo "Pages already enabled — ensuring build_type=workflow"
+        gh api --method PUT \
+          -H 'Accept: application/vnd.github+json' \
+          "repos/$OWNER/$REPO/pages" \
+          -f build_type=workflow
+      else
+        echo "Pages not enabled — creating with build_type=workflow"
+        gh api --method POST \
+          -H 'Accept: application/vnd.github+json' \
+          "repos/$OWNER/$REPO/pages" \
+          -f build_type=workflow
+      fi
+    EOT
+  }
+}


### PR DESCRIPTION

PR #29 enabled Pages via the provider's nested `github_repository.pages`
block, expecting the provider to route through the dedicated `/pages`
API. In practice the provider issues a full repo PATCH on *any* diff
touching the repo resource — including a pages-only diff — so the
signoff bug still fires and CI apply 422s:

    Error: PATCH .../repos/aletheia-works/vivarium:
    422 Commit signoff is enforced by the organization and cannot be disabled

Switch to driving the Pages API directly through a `terraform_data`
provisioner that calls `gh api`. The `/pages` endpoint is separate
from the repo PATCH, so it is reachable. Reverts `github_repository.this`
to `ignore_changes = all`.

Provisioner is POST-on-missing / PUT-on-existing so reruns are
idempotent. This file can be deleted in favour of the provider's
nested `pages` block once integrations/github v6.12+ ships (PR #3166)
and the signoff regression is gone.

Note: the TF_TOKEN_GITHUB PAT needs `Pages` (RW) repo permission for
the apply step to succeed; this PR does not change that.
