### PR TITLE
feat: scaffold src/ directory with three-layer architecture stubs

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,49 @@
+# `src/` — Vivarium source tree
+
+> Scaffolding only. Phase 0 has not committed to any specific implementation
+> yet; this directory exists so layer boundaries are visible from day one.
+
+---
+
+## Why three layers?
+
+Vivarium is **problem-centred, not technology-centred**. Different
+reproduction problems have fundamentally different requirements:
+
+| Problem shape                               | Needs                        | Layer |
+|---------------------------------------------|------------------------------|-------|
+| Pure algorithm, parser, data-processing bug | Instant startup, in-browser  | 1     |
+| Whole-project bug with complex dependencies | Full OS fidelity, isolation  | 2     |
+| Concurrency, memory, or non-deterministic   | Deterministic replay, snapshots | 3  |
+
+Picking one layer as "the answer" would force square pegs into round
+holes. The three-layer split exists so each problem class can be solved
+on its own terms — see [`AGENTS.md § 5`](../AGENTS.md) and the eventual
+[`docs/ARCHITECTURE.md`](../docs/) for the longer-form argument.
+
+## Layout
+
+```
+src/
+├── layer1_wasm/      # browser-native, ms–s startup
+├── layer2_docker/    # container-backed, s–min startup
+└── layer3_thirdway/  # record-replay, microVM, deterministic
+```
+
+Each subdirectory has its own `README.md` describing the kinds of
+problems routed to that layer. None contain production code yet —
+bringing a layer online starts with a feature Issue, not with
+speculative scaffolding.
+
+## What does **not** live here
+
+- **Infrastructure-as-Code** — lives in [`infra/`](../infra/).
+- **Docs site** — lives in [`docs/`](../docs/).
+- **Tooling and build configuration** — project root.
+
+## Current phase
+
+Phase 0 (Bootstrap) will populate `layer1_wasm/` first, starting with a
+hand-picked Pyodide + pandas reproduction PoC
+([Issue #13](https://github.com/aletheia-works/vivarium/issues/13)).
+Layers 2 and 3 are expected but unscheduled.

--- a/src/layer1_wasm/README.md
+++ b/src/layer1_wasm/README.md
@@ -1,0 +1,44 @@
+# Layer 1 — WASM (browser-native)
+
+> Reproduction that runs entirely in the visitor's browser tab.
+> Startup: milliseconds to a few seconds. No backend required.
+
+---
+
+## What routes here
+
+- **Algorithmic bugs** — sorting, parsing, text processing, numerical
+  edge cases.
+- **Data-processing bugs** — pandas/polars shape regressions, SQLite
+  query anomalies, serialisation round-trip failures.
+- **Library-internal bugs** — pure-Python / pure-Rust / pure-JS logic
+  with no system-call dependency.
+- **Deterministic reproductions** where the bug does not need a real
+  filesystem, network, or process scheduler.
+
+## What does **not** route here
+
+- Anything needing real OS processes, sockets, or devices → Layer 2.
+- Anything whose repro depends on specific thread/scheduler interleavings
+  or on GDB/rr-style time travel → Layer 3.
+- Bugs that only manifest at GB+ data scales (WASM memory cap, browser
+  tab practicality) → Layer 2.
+
+## Candidate runtimes
+
+| Language | Runtime                         | Status   |
+|----------|---------------------------------|----------|
+| Python   | [Pyodide](https://pyodide.org)  | Phase 0 first target |
+| SQLite   | [sqlite-wasm](https://sqlite.org/wasm/) | Paired with Pyodide |
+| Rust     | `wasm32-wasi` / `wasm32-unknown-unknown` | Deferred |
+| Ruby     | [Ruby.wasm](https://github.com/ruby/ruby.wasm) | Deferred |
+| PHP      | [php-wasm](https://github.com/WordPress/wordpress-playground) | Deferred |
+
+Concrete runtime choices land in [`docs/`](../../docs/) as ADRs, not
+here.
+
+## Phase 0 scope
+
+First vertical is **Pyodide + a hand-picked pandas bug** ([Issue
+#13](https://github.com/aletheia-works/vivarium/issues/13)). This
+directory will gain its first real files when that Issue lands.

--- a/src/layer2_docker/README.md
+++ b/src/layer2_docker/README.md
@@ -1,0 +1,42 @@
+# Layer 2 — Docker (full-fidelity environment)
+
+> Reproduction inside a real container: real OS, real filesystem, real
+> package manager. Startup: seconds to minutes.
+
+---
+
+## What routes here
+
+- **Whole-project repros** — the bug needs the project's actual
+  `requirements.txt` / `package.json` / `Cargo.toml` resolved against a
+  real environment.
+- **System-call dependent bugs** — file locking, signals, permissions,
+  `fork`/`exec`, real TCP/UDP, epoll/kqueue edge cases.
+- **Toolchain-specific bugs** — a specific GCC/Clang/rustc version, a
+  specific glibc, a specific kernel-userspace ABI quirk.
+- **Cross-service bugs** — multi-container compose scenarios where the
+  interaction *between* processes is the bug.
+
+## What does **not** route here
+
+- Pure algorithmic bugs that would run in-browser in a fraction of the
+  time → Layer 1.
+- Concurrency or memory-ordering bugs that need deterministic replay to
+  be even *observable* → Layer 3.
+
+## Candidate runtimes
+
+| Runtime                                         | Role                          |
+|-------------------------------------------------|-------------------------------|
+| Devcontainer image (`mcr.microsoft.com/devcontainers/*`) | Baseline full-OS repro |
+| [Firecracker](https://firecracker-microvm.github.io) microVM | Faster boot, stronger isolation (exploration) |
+| [Kata Containers](https://katacontainers.io)   | OCI-compat microVM (exploration) |
+
+Concrete choices land as ADRs in [`docs/`](../../docs/), not here.
+
+## Phase 0 scope
+
+**Not in Phase 0.** Layer 2 is expected for later phases once Layer 1
+has demonstrated the reproduction primitive end-to-end in a browser.
+This directory stays empty until an Issue proposes a concrete Layer 2
+vertical.

--- a/src/layer3_thirdway/README.md
+++ b/src/layer3_thirdway/README.md
@@ -1,0 +1,47 @@
+# Layer 3 — "Third way" (record-replay, microVM, deterministic)
+
+> Reproduction for bugs Layers 1 and 2 cannot reach on their own:
+> concurrency, non-determinism, heisenbugs, time-travel debugging.
+
+---
+
+## What routes here
+
+- **Heisenbugs** — race conditions, memory-ordering bugs, use-after-free
+  where a naive rerun will not reproduce the failure.
+- **Long-replay scenarios** — an hour of production load condensed into
+  a replayable trace.
+- **Deterministic-simulation bugs** — distributed-system bugs where the
+  failure depends on a specific message interleaving across nodes
+  (Antithesis-style).
+- **Post-mortem forensic replay** — stepping backwards through a
+  captured execution, not forwards from a fresh run.
+
+## What does **not** route here
+
+- A bug you can reliably reproduce by running the program once → Layer 1
+  or Layer 2.
+- A bug whose fix is obvious from a single stack trace — Layer 3's cost
+  (capture-time overhead, storage, tooling) is only justified when
+  cheaper layers cannot observe the failure at all.
+
+## Candidate runtimes
+
+| Runtime / approach                              | Target                         |
+|-------------------------------------------------|--------------------------------|
+| [rr](https://rr-project.org)                    | Single-process record-replay    |
+| [Pernosco](https://pernos.co)-style analysis    | Hosted backward-step debugging  |
+| [Antithesis](https://antithesis.com)-style      | Deterministic distributed sim   |
+| WASI Preview 3+ with snapshot hooks             | Replayable WASM executions      |
+| CRIU                                            | Process snapshot & restore      |
+| Firecracker snapshots                           | microVM-level time travel       |
+
+Concrete choices land as ADRs in [`docs/`](../../docs/), not here.
+
+## Phase 0 scope
+
+**Not in Phase 0.** Layer 3 is the most speculative tier — it exists in
+the architecture so that when a bug appears that *only* Layer 3 can
+reach, we already have a place to put the work instead of inventing a
+fourth category. This directory stays empty until a concrete Issue
+proposes a Layer 3 vertical.


### PR DESCRIPTION
Closes #12.

## Summary

- `src/README.md` — rationale for the three-layer split (why problem-shape drives layer choice).
- `src/layer1_wasm/README.md`, `src/layer2_docker/README.md`, `src/layer3_thirdway/README.md` — one-page routing guides per layer.
- No `.gitkeep` files — every directory contains a real README.
- No production code. Each layer stays README-only until an Issue brings a concrete vertical online.

## Acceptance checklist (from #12)

- [x] `src/README.md` explains the layout and the problem-centred rationale.
- [x] Subdirectories `layer1_wasm/`, `layer2_docker/`, `layer3_thirdway/`.
- [x] Each subdirectory has a one-page `README.md`.
- [x] No production code; `.gitkeep` avoided because READMEs already anchor each directory.

## Test plan

- [x] CodeRabbit review passes.
- [x] commitlint passes (`feat:` prefix).
- [x] Labeler applies `type: docs` (all files are `.md`); `type: feature` will attach via the Conventional-Commit prefix on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architectural documentation outlining a three-layer framework for bug reproduction: Layer 1 for in-browser WASM solutions, Layer 2 for containerized full-fidelity environments, and Layer 3 for deterministic replay and forensic analysis.
  * Documented scope definitions, exclusions, and candidate runtimes for each layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->