### PR TITLE
docs(agents): open AI-authored PRs ready-for-review by default

### DIFF
--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -124,8 +124,17 @@ blocker and returns the Issue to `status: triage` rather than guessing.
   will fail the check otherwise.
 - `scope: *` labels attach automatically via path rules; do not hand-add
   them.
-- Draft PR opened early. Iterate in the draft; mark ready for review
-  when the implementer considers the work complete.
+- **PR state mirrors implementation state.** Open the PR **ready for
+  review** when the work meets the Issue's acceptance criteria and the
+  implementer is confident there is nothing substantive left to change.
+  Use **draft** mode only while implementation is still in progress or
+  pending non-trivial rework (known failing tests, missing pieces,
+  awaiting a human decision). If CodeRabbit or human review surfaces
+  substantive rework, flip the PR back to draft until the rework is
+  done, then flip it back to ready. Flipping between the two states is
+  the implementer's signal of "not done" vs "please review" — AI
+  implementers follow the same rule as humans; a draft is not a "polite"
+  default.
 
 ### 3.4 Review
 


### PR DESCRIPTION
## Summary

Flips the default PR state for AI-authored work. Before: always draft, human flips ready. After: **ready by default when the implementer is confident the work meets the Issue's acceptance criteria; draft only while something is genuinely in progress or pending non-trivial rework.**

Rationale (from the user, not my editorialising): a universal "draft" default obscures the useful signal. If a PR is ready, say so; if rework is pending, flip back to draft — the state should mean something.

## Scope

- `docs/ai-workflow.md § 3.3` only.
- The \`claude-implement.yml\` workflow prompt (PR #36, still unmerged) is being updated in the same PR to follow this rule.

## Meta

This PR itself opens as ready-for-review, applying the new rule to itself.

## Test plan

- [x] CodeRabbit review passes.
- [x] commitlint passes (\`docs(agents):\` prefix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI workflow documentation with revised PR readiness guidance. PRs must now be marked ready only after meeting acceptance criteria with implementer confidence. Draft mode is reserved for active implementation or pending rework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->