### PR TITLE
chore(docs): enable rspress checkDeadLinks for internal link rot

### DIFF
--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -13,6 +13,11 @@ export default defineConfig({
   base: '/vivarium/',
   title: 'Vivarium',
   description: 'Universal bug reproduction — any language, any environment, any scale.',
+  markdown: {
+    link: {
+      checkDeadLinks: true,
+    },
+  },
   themeConfig: {
     socialLinks: [
       {


### PR DESCRIPTION
## Summary

- Enables rspress&#39;s built-in `markdown.link.checkDeadLinks` in `docs/rspress.config.ts`.
- Internal (relative) link 404s in `docs/docs/**/*.md(x)` now fail `bun run build`, which is already the PR gate via `test-docs-build.yml`. No new workflow needed.
- Replaces the lychee-action approach originally scoped in #43 (closed as not-planned). External-link rot detection is deferred to org level (`aletheia-works/.github`) once a second repo wants the same coverage.

## Test plan

- [x] `bun run build` succeeds on a clean tree.
- [x] Sanity check: appended `[broken](./does-not-exist.md)` to `docs/docs/index.md`, confirmed `bun run build` exits non-zero, then reverted.
- [x] CI `test-docs-build` green on this PR.

Closes #54.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxwQyTXNXrHFFqfvRBjYCR)_