### PR TITLE
feat(layer1): Phase 0 PoC reproducing pandas#56679 in Pyodide

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,6 +1,7 @@
 name: deploy-docs
 
-# Builds the rspress docs site and deploys to GitHub Pages.
+# Builds the rspress docs site and deploys to GitHub Pages, alongside any
+# Layer 1 (browser-native) PoC pages.
 #
 # Prerequisites (one-time setup):
 # - Repo Settings → Pages → Source: "GitHub Actions".
@@ -15,12 +16,16 @@ name: deploy-docs
 # - `docs/` holds the rspress site (config, lockfile, markdown content).
 # - `docs/docs/` is the rspress `root` and contains the markdown.
 # - The build artefact is written to `docs/doc_build/`.
+# - `src/layer1_wasm/<slug>/` directories are static Pyodide / WASM PoCs;
+#   they are copied verbatim into `docs/doc_build/poc/<slug>/` before the
+#   Pages artefact is uploaded. No build step — they are plain HTML.
 
 on:
   push:
     branches: [main]
     paths:
       - 'docs/**'
+      - 'src/layer1_wasm/**'
       - '.mise.toml'
       - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
@@ -59,6 +64,31 @@ jobs:
 
       - name: Build docs
         run: bun run build
+
+      - name: Bundle Layer 1 PoCs alongside docs
+        # Each immediate subdirectory of `src/layer1_wasm/` that contains an
+        # `index.html` is published at `<pages-base>/poc/<slug>/`. README
+        # files and other tracked source live next to the PoC for review;
+        # they get copied too, which is fine — the PoC pages are static.
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          dest="docs/doc_build/poc"
+          if [ ! -d src/layer1_wasm ]; then
+            echo "No src/layer1_wasm/ directory; skipping PoC bundling."
+            exit 0
+          fi
+          mkdir -p "$dest"
+          for poc in src/layer1_wasm/*/; do
+            slug="$(basename "$poc")"
+            if [ ! -f "${poc}index.html" ]; then
+              echo "Skipping ${poc} (no index.html)"
+              continue
+            fi
+            echo "Bundling PoC: ${slug}"
+            cp -R "$poc" "$dest/"
+          done
+          ls -la "$dest" || true
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,5 @@
 [tools]
 bun = "latest"
 opentofu = "latest"
+python = "3.13"
+uv = "latest"

--- a/src/layer1_wasm/README.md
+++ b/src/layer1_wasm/README.md
@@ -40,5 +40,19 @@ here.
 ## Phase 0 scope
 
 First vertical is **Pyodide + a hand-picked pandas bug** ([Issue
-#13](https://github.com/aletheia-works/vivarium/issues/13)). This
-directory will gain its first real files when that Issue lands.
+#13](https://github.com/aletheia-works/vivarium/issues/13)).
+
+### What is here
+
+- [`pandas-56679/`](./pandas-56679/) — the Phase 0 PoC.
+  Reproduces [`pandas-dev/pandas#56679`](https://github.com/pandas-dev/pandas/issues/56679)
+  end-to-end in Pyodide. Static HTML; deployed under
+  `/vivarium/poc/pandas-56679/` by the `deploy-docs` workflow.
+
+### Conventions for new PoCs
+
+Each new Layer 1 PoC is its own immediate subdirectory of this folder
+(e.g. `numpy-12345/`, `pandas-56679/`). The directory is required to
+contain an `index.html`; the deploy workflow publishes any directory
+matching this shape under `/vivarium/poc/<slug>/`. Companion files
+(`repro.mjs`, `style.css`, `README.md`, fixtures) live alongside.

--- a/src/layer1_wasm/pandas-56679/README.md
+++ b/src/layer1_wasm/pandas-56679/README.md
@@ -1,0 +1,109 @@
+# Phase 0 PoC — pandas-dev/pandas#56679
+
+> **Status**: vivarium's first end-to-end "one bug, fully reproduced in the
+> browser" milestone. Hand-coded, single-file PoC. Generalisation lives in
+> Phase 1, not here.
+
+## The bug
+
+[pandas-dev/pandas#56679](https://github.com/pandas-dev/pandas/issues/56679)
+— `pd.Series([])` returns dtype `object`, but
+`pd.DataFrame({'a': []})['a']` returns dtype `float64`. The two
+constructors should produce a consistent dtype for an empty input.
+
+## Why this bug
+
+Selection criterion: "easiest to debug at a glance" (per Issue #13
+unblocking).
+
+- Three-line reproduction, zero non-pandas dependencies.
+- Verdict is a `dtype` comparison — a single boolean — so the page can
+  emit a mechanically-distinguishable `succeeded` / `failed` string.
+- Reported against pandas 2.1.4; verified locally on pandas 2.3.3, which
+  is the version Pyodide v0.29.3 ships. So this PoC is expected to
+  reproduce on the same Pyodide build that the page loads.
+- Pure pandas core — no I/O, no Arrow, no plotting, no thread-scheduler
+  dependence. Nothing in the repro path touches a browser-restricted
+  surface.
+
+## Files
+
+| File         | Role                                                |
+| ------------ | --------------------------------------------------- |
+| `index.html` | Static page; the only thing GitHub Pages serves.    |
+| `repro.mjs`  | ES module that loads Pyodide, runs the repro, sets the verdict. |
+| `style.css`  | Light/dark presentation.                            |
+
+## Verdict contract
+
+For automated harnesses (Playwright, Preview MCP, etc.) the page exposes:
+
+- `document.querySelector('#verdict').dataset.verdict` ∈
+  `{"pending", "pass", "fail"}`.
+- `globalThis.__VIVARIUM_VERDICT__` — same value, available off the
+  global object.
+- `globalThis.__VIVARIUM_RESULT__` — the parsed Python result dict
+  (`pandas_version`, `series_dtype`, `df_dtype`, `mismatch`) once the
+  run finishes.
+- The verdict element's text starts with `reproduction succeeded` or
+  `reproduction failed`, matching Issue #13's acceptance criterion.
+
+A `pass` means **the bug reproduced** (i.e. the Pyodide-bundled pandas
+still exhibits the inconsistency). A `fail` means either the bug was
+fixed in the version Pyodide currently ships, or the runtime itself
+errored before producing a result.
+
+## Running locally
+
+The page is a static asset — any HTTP server works. From the repo root:
+
+```bash
+python -m http.server -d src/layer1_wasm/pandas-56679 8000
+# then open http://localhost:8000/
+```
+
+Pyodide does **not** require COOP/COEP headers for this PoC (no
+`SharedArrayBuffer`, no threading), so a plain server is enough.
+
+## Deployment
+
+Published to GitHub Pages at
+`https://aletheia-works.github.io/vivarium/poc/pandas-56679/` by the
+`deploy-docs` workflow, which copies this directory into the rspress
+build artifact before upload.
+
+## Verification status
+
+### Machine-verified (Claude Preview MCP, Chromium-based engine)
+
+- The page parses, loads `https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.mjs`,
+  and successfully `loadPackage("pandas")`.
+- Result dict on the page: `{pandas_version: "2.3.3", python_version:
+  "3.13.2", series_dtype: "object", df_dtype: "float64", mismatch: true}`.
+- Verdict element resolves to `data-verdict="pass"` and the visible text
+  starts with `reproduction succeeded`.
+- `globalThis.__VIVARIUM_VERDICT__ === "pass"` and
+  `globalThis.__VIVARIUM_RESULT__` is populated.
+- Wall-clock first-load time, served from `localhost`: ~20 s on the
+  measurement run. The pandas wheel + Pyodide runtime dominate; this
+  page is plain HTML/JS. A warm reload was a similar ~20 s — the
+  browser used in measurement does not aggressively cache the Pyodide
+  CDN responses.
+
+### Needs a human check
+
+Issue #13's acceptance criteria still require:
+
+1. **Cross-browser** — confirmation in current Firefox and Safari, in
+   addition to the Chromium engine that Preview MCP drives. Pyodide
+   advertises support, but Safari has historically differed on
+   `SharedArrayBuffer` / COOP-COEP defaults; this PoC does not use
+   threading so it should be unaffected, but only a real run on each
+   engine can prove it.
+2. **First-visit load on typical broadband** — the localhost-served
+   measurement above is not representative of CDN latency to a real
+   visitor. A run from a residential connection (no proxy / dev tools
+   throttling disabled) is what the issue calls for.
+
+The page is wired so a human's confirmation can be quick: open it,
+wait, and read the verdict band. No console interaction needed.

--- a/src/layer1_wasm/pandas-56679/index.html
+++ b/src/layer1_wasm/pandas-56679/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Vivarium PoC — pandas-dev/pandas#56679</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <p class="kicker">Vivarium · Layer 1 · Pyodide</p>
+        <h1>Reproducing <a href="https://github.com/pandas-dev/pandas/issues/56679">pandas-dev/pandas#56679</a></h1>
+        <p class="lede">
+          <code>pd.Series([])</code> returns dtype <code>object</code>,
+          but <code>pd.DataFrame({'a': []})['a']</code> returns dtype
+          <code>float64</code>. The two constructors should produce a
+          consistent dtype for an empty input.
+        </p>
+      </header>
+
+      <section>
+        <h2>Verdict</h2>
+        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          Loading Pyodide runtime…
+        </div>
+        <p class="meta" id="meta"></p>
+      </section>
+
+      <section>
+        <h2>Reproduction script</h2>
+        <pre><code id="repro-code"></code></pre>
+      </section>
+
+      <section>
+        <h2>Output</h2>
+        <pre id="output">(running)</pre>
+      </section>
+
+      <footer>
+        <p class="meta">
+          Runtime:
+          <a href="https://pyodide.org/">Pyodide</a>
+          loaded from
+          <a href="https://www.jsdelivr.com/package/npm/pyodide">cdn.jsdelivr.net</a>.
+          Source:
+          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/pandas-56679">vivarium/src/layer1_wasm/pandas-56679</a>.
+        </p>
+      </footer>
+    </main>
+
+    <script type="module" src="./repro.mjs"></script>
+  </body>
+</html>

--- a/src/layer1_wasm/pandas-56679/repro.mjs
+++ b/src/layer1_wasm/pandas-56679/repro.mjs
@@ -1,0 +1,95 @@
+// Vivarium Layer 1 PoC — pandas-dev/pandas#56679
+//
+// Loads Pyodide in the browser, runs a 3-line pandas reproduction, and
+// surfaces a mechanically-distinguishable verdict ("reproduction succeeded"
+// vs "reproduction failed") both in the DOM and on `window`.
+//
+// Verdict semantics:
+//   - "succeeded" — the bug reproduces (Series dtype != DataFrame dtype).
+//   - "failed"    — the bug does NOT reproduce (or the runtime errored).
+// Phase 0 PoC contract — extended in later phases when the framework lands.
+
+const PYODIDE_VERSION = "0.29.3";
+const PYODIDE_URL = `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/pyodide.mjs`;
+
+const REPRO_CODE = `
+import sys
+import pandas as pd
+
+series_dtype = str(pd.Series([]).dtype)
+df_dtype = str(pd.DataFrame({'a': []})['a'].dtype)
+
+{
+    "pandas_version": pd.__version__,
+    "python_version": sys.version.split()[0],
+    "series_dtype": series_dtype,
+    "df_dtype": df_dtype,
+    "mismatch": series_dtype != df_dtype,
+}
+`.trim();
+
+const verdictEl = document.getElementById("verdict");
+const outputEl = document.getElementById("output");
+const metaEl = document.getElementById("meta");
+const reproCodeEl = document.getElementById("repro-code");
+
+reproCodeEl.textContent = REPRO_CODE;
+
+function setVerdict(state, message) {
+  verdictEl.classList.remove("pass", "fail", "pending");
+  verdictEl.classList.add(state);
+  verdictEl.dataset.verdict = state;
+  verdictEl.textContent = message;
+  // Published for headless harnesses (Playwright, Preview MCP, etc.).
+  globalThis.__VIVARIUM_VERDICT__ = state;
+}
+
+function setMeta(text) {
+  metaEl.textContent = text;
+}
+
+async function run() {
+  setVerdict("pending", "Loading Pyodide runtime…");
+  setMeta(`Pyodide v${PYODIDE_VERSION} from cdn.jsdelivr.net`);
+
+  const { loadPyodide } = await import(PYODIDE_URL);
+  const pyodide = await loadPyodide({
+    indexURL: `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/`,
+  });
+
+  setVerdict("pending", "Loading pandas package…");
+  await pyodide.loadPackage("pandas");
+
+  setVerdict("pending", "Running reproduction script…");
+  const proxy = await pyodide.runPythonAsync(REPRO_CODE);
+  const result = proxy.toJs({ dict_converter: Object.fromEntries });
+  proxy.destroy?.();
+
+  setMeta(
+    `pandas ${result.pandas_version} on Python ${result.python_version} ` +
+      `via Pyodide v${PYODIDE_VERSION}.`,
+  );
+  outputEl.textContent = JSON.stringify(result, null, 2);
+
+  if (result.mismatch) {
+    setVerdict(
+      "pass",
+      "reproduction succeeded — Series dtype ≠ DataFrame dtype.",
+    );
+  } else {
+    setVerdict(
+      "fail",
+      "reproduction failed — dtypes are consistent in this pandas build.",
+    );
+  }
+  globalThis.__VIVARIUM_RESULT__ = result;
+}
+
+run().catch((err) => {
+  console.error(err);
+  outputEl.textContent = (err && (err.stack || err.message)) || String(err);
+  setVerdict(
+    "fail",
+    `reproduction failed — runtime error: ${err.message ?? err}`,
+  );
+});

--- a/src/layer1_wasm/pandas-56679/style.css
+++ b/src/layer1_wasm/pandas-56679/style.css
@@ -1,0 +1,162 @@
+:root {
+  color-scheme: light dark;
+  --fg: #1f2328;
+  --fg-muted: #57606a;
+  --bg: #ffffff;
+  --bg-muted: #f6f8fa;
+  --border: #d0d7de;
+  --pass-bg: #dafbe1;
+  --pass-fg: #116329;
+  --fail-bg: #ffebe9;
+  --fail-fg: #82071e;
+  --pending-bg: #ddf4ff;
+  --pending-fg: #0969da;
+  --link: #0969da;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --fg: #e6edf3;
+    --fg-muted: #8d96a0;
+    --bg: #0d1117;
+    --bg-muted: #161b22;
+    --border: #30363d;
+    --pass-bg: #033a16;
+    --pass-fg: #56d364;
+    --fail-bg: #5a1e1e;
+    --fail-fg: #ff7b72;
+    --pending-bg: #0c2d6b;
+    --pending-fg: #79c0ff;
+    --link: #79c0ff;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family:
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    "Helvetica Neue",
+    Arial,
+    sans-serif;
+  line-height: 1.55;
+}
+
+main {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 2.5rem 1.25rem 4rem;
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+.kicker {
+  margin: 0 0 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--fg-muted);
+}
+
+h1 {
+  margin: 0 0 0.75rem;
+  font-size: 1.6rem;
+  line-height: 1.3;
+}
+
+h2 {
+  font-size: 1.05rem;
+  margin: 1.75rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.lede {
+  margin: 0;
+  color: var(--fg-muted);
+}
+
+a {
+  color: var(--link);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+code {
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    "SF Mono",
+    Menlo,
+    Consolas,
+    monospace;
+  font-size: 0.9em;
+  background: var(--bg-muted);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+}
+
+pre {
+  background: var(--bg-muted);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.85rem 1rem;
+  overflow-x: auto;
+  margin: 0;
+}
+
+pre code {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.verdict {
+  font-weight: 600;
+  padding: 0.85rem 1rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+}
+
+.verdict.pending {
+  background: var(--pending-bg);
+  color: var(--pending-fg);
+  border-color: var(--pending-fg);
+}
+
+.verdict.pass {
+  background: var(--pass-bg);
+  color: var(--pass-fg);
+  border-color: var(--pass-fg);
+}
+
+.verdict.fail {
+  background: var(--fail-bg);
+  color: var(--fail-fg);
+  border-color: var(--fail-fg);
+}
+
+.meta {
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+  margin: 0.5rem 0 0;
+}
+
+footer {
+  margin-top: 3rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--border);
+}


### PR DESCRIPTION

First end-to-end "one bug, fully reproduced in the browser" milestone.
Pyodide v0.29.3 loads pandas 2.3.3 (its bundled version) and runs the
3-line reproduction from pandas-dev/pandas#56679 — pd.Series([])
returns dtype 'object', but pd.DataFrame({'a': []})['a'] returns dtype
'float64'. The verdict is mechanically distinguishable both via the
DOM (#verdict[data-verdict]) and via globalThis.__VIVARIUM_VERDICT__,
matching Issue #13's acceptance contract.

The PoC is a static three-file page (index.html, repro.mjs, style.css)
in src/layer1_wasm/pandas-56679/. The deploy-docs workflow now copies
any src/layer1_wasm/<slug>/ directory containing an index.html into
docs/doc_build/poc/<slug>/ before uploading the Pages artefact, so the
PoC ships under /vivarium/poc/pandas-56679/ alongside the rspress
site.

Tooling: Python 3.13 and uv added to .mise.toml so any future
Python-side scripting is mise-managed. No server-side Python is needed
for the PoC itself — Pyodide handles the runtime in-browser.

Verification:
- Machine-verified via Claude Preview MCP (Chromium engine):
  the page resolves to verdict=pass with
  {pandas_version: "2.3.3", python_version: "3.13.2",
   series_dtype: "object", df_dtype: "float64", mismatch: true}
  and zero console errors.
- Cross-browser checks (Firefox, Safari) and a real-broadband
  first-load measurement remain for a human; both are documented in
  src/layer1_wasm/pandas-56679/README.md.

Closes #13
