### PR TITLE
perf(layer1): preconnect jsDelivr and parallelise pandas load

### DIFF
--- a/src/layer1_wasm/pandas-56679/index.html
+++ b/src/layer1_wasm/pandas-56679/index.html
@@ -4,6 +4,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Vivarium PoC — pandas-dev/pandas#56679</title>
+    <!-- Warm the TLS/HTTP3 handshake to jsDelivr in parallel with HTML parse. -->
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <!-- Keep the version below in sync with PYODIDE_VERSION in repro.mjs. -->
+    <link
+      rel="modulepreload"
+      href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.mjs"
+      crossorigin
+    />
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>

--- a/src/layer1_wasm/pandas-56679/repro.mjs
+++ b/src/layer1_wasm/pandas-56679/repro.mjs
@@ -49,16 +49,16 @@ function setMeta(text) {
 }
 
 async function run() {
-  setVerdict("pending", "Loading Pyodide runtime…");
+  setVerdict("pending", "Loading Pyodide runtime and pandas…");
   setMeta(`Pyodide v${PYODIDE_VERSION} from cdn.jsdelivr.net`);
 
   const { loadPyodide } = await import(PYODIDE_URL);
+  // `packages` lets Pyodide fetch the pandas wheel in parallel with the
+  // runtime bootstrap, instead of serialising it after `loadPyodide` resolves.
   const pyodide = await loadPyodide({
     indexURL: `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/`,
+    packages: ["pandas"],
   });
-
-  setVerdict("pending", "Loading pandas package…");
-  await pyodide.loadPackage("pandas");
 
   setVerdict("pending", "Running reproduction script…");
   const proxy = await pyodide.runPythonAsync(REPRO_CODE);


### PR DESCRIPTION

Two cold-start improvements for the pandas-56679 PoC, both free:

- Add <link rel=preconnect> + <link rel=modulepreload> to index.html
  so the TLS/HTTP3 handshake to cdn.jsdelivr.net and the fetch of
  pyodide.mjs start in parallel with HTML parsing, instead of after
  repro.mjs evaluates.
- Pass packages: ['pandas'] to loadPyodide() so the pandas wheel
  (and its numpy/dateutil/six/pytz deps) downloads in parallel with
  the runtime bootstrap, instead of serialising via a follow-up
  loadPackage('pandas') call.

Verified locally with the layer1-pandas-56679 preview server: the
reproduction still resolves to verdict=pass (mismatch=true) on
pandas 2.3.3 / Python 3.13.2, with no failed requests and no
preload-mismatch warnings in the console.
