### PR TITLE
feat(python): extract shared scaffolding for Phase 1 reproduction gallery

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,6 +19,10 @@ name: deploy-docs
 # - `src/layer1_wasm/<slug>/` directories are static Pyodide / WASM PoCs;
 #   they are copied verbatim into `docs/doc_build/poc/<slug>/` before the
 #   Pages artefact is uploaded. No build step — they are plain HTML.
+# - Underscore-prefixed subdirectories (e.g. `src/layer1_wasm/_shared/`)
+#   hold scaffolding shared across reproductions. They are bundled under
+#   the same `poc/` prefix without requiring an `index.html`, so each
+#   reproduction can reference them via `../_shared/…`.
 
 on:
   push:
@@ -66,10 +70,16 @@ jobs:
         run: bun run build
 
       - name: Bundle Layer 1 PoCs alongside docs
-        # Each immediate subdirectory of `src/layer1_wasm/` that contains an
-        # `index.html` is published at `<pages-base>/poc/<slug>/`. README
-        # files and other tracked source live next to the PoC for review;
-        # they get copied too, which is fine — the PoC pages are static.
+        # Each immediate subdirectory of `src/layer1_wasm/` is published at
+        # `<pages-base>/poc/<slug>/`. README files and other tracked source
+        # live next to the PoC for review; they get copied too, which is
+        # fine — the PoC pages are static.
+        #
+        # Two flavours of subdirectory:
+        # 1. Reproduction pages — must contain `index.html`. Skipped if not.
+        # 2. Underscore-prefixed scaffolding (e.g. `_shared/`) — bundled
+        #    unconditionally so each reproduction can reference shared
+        #    modules via `../_shared/…` after deploy.
         working-directory: ${{ github.workspace }}
         run: |
           set -euo pipefail
@@ -81,12 +91,20 @@ jobs:
           mkdir -p "$dest"
           for poc in src/layer1_wasm/*/; do
             slug="$(basename "$poc")"
-            if [ ! -f "${poc}index.html" ]; then
-              echo "Skipping ${poc} (no index.html)"
-              continue
-            fi
-            echo "Bundling PoC: ${slug}"
-            cp -R "$poc" "$dest/"
+            case "$slug" in
+              _*)
+                echo "Bundling shared module: ${slug}"
+                cp -R "$poc" "$dest/"
+                ;;
+              *)
+                if [ ! -f "${poc}index.html" ]; then
+                  echo "Skipping ${poc} (no index.html)"
+                  continue
+                fi
+                echo "Bundling PoC: ${slug}"
+                cp -R "$poc" "$dest/"
+                ;;
+            esac
           done
           ls -la "$dest" || true
 

--- a/src/layer1_wasm/_shared/README.md
+++ b/src/layer1_wasm/_shared/README.md
@@ -1,0 +1,75 @@
+# `_shared/` — Phase 1 reproduction gallery scaffolding
+
+Shared modules used by every reproduction page in `src/layer1_wasm/`.
+The leading underscore is the convention for "this directory is not a
+reproduction" — `deploy-docs.yml` recognises it and bundles the contents
+under `<pages-base>/poc/_shared/` without requiring an `index.html`.
+
+## Contents
+
+| File | Purpose |
+| --- | --- |
+| `verdict.mjs` | `setVerdict()` / `setResult()` helpers + the `VivariumResultV1` JSDoc typedef. |
+| `loader.mjs` | `loadVivariumPyodide()` — Pyodide bootstrap with version pin and package preload. |
+| `style.css` | Shared CSS for the gallery's visual presentation. |
+| `_test/` | Smoke test that validates the contract-v1 surface without loading Pyodide. |
+
+## Vivarium contract v1
+
+These helpers publish the **vivarium contract v1** surface. Each page
+that uses them must declare:
+
+```html
+<meta name="vivarium-contract" content="v1" />
+```
+
+The contract surface is canonical here. Reproduction pages should not
+hand-roll the verdict logic — import from `_shared/verdict.mjs` so a
+future `v2` migrates in one place.
+
+The full surface (DOM, globals, envelope shape) is documented in the
+`verdict.mjs` JSDoc and in the maintainer's private ADR-0008.
+
+## Verdict semantics
+
+- `pass` — the bug **reproduces**. The behaviour the upstream issue
+  describes is observable in the runtime this page loaded.
+- `fail` — the bug does **not** reproduce. Either the runtime ships a
+  fixed version, or it errored before producing a result.
+- `pending` — the run has not yet produced a verdict.
+
+`pass` meaning "the bug is still there" is counterintuitive in
+isolation but matches the project's domain noun: a *reproduction*
+succeeds when it reproduces.
+
+## Smoke test
+
+Open `<pages-base>/poc/_shared/_test/` in a browser. Expected:
+
+- The verdict band shows `reproduction succeeded — _shared helpers
+  wired up.` and `data-verdict="pass"`.
+- `globalThis.__VIVARIUM_VERDICT__ === "pass"`.
+- `globalThis.__VIVARIUM_RESULT__.contract === "v1"`.
+
+The smoke test does **not** load Pyodide — it only validates the
+helper plumbing. Reproduction-level smoke tests live in each per-bug
+page.
+
+## Local serving
+
+Any static HTTP server works — there are no build steps, no bundlers,
+no cookies, no COOP/COEP requirements:
+
+```bash
+python -m http.server -d src/layer1_wasm/_shared 8000
+# then open http://localhost:8000/_test/
+```
+
+## Deployment path
+
+`deploy-docs.yml` iterates immediate subdirectories of
+`src/layer1_wasm/`. The default rule (must contain `index.html`) is
+relaxed for underscore-prefixed directories so that shared scaffolding
+ships without pretending to be a reproduction. The shared modules end
+up at `<pages-base>/poc/_shared/`, reachable from each reproduction at
+the relative path `../_shared/…`.

--- a/src/layer1_wasm/_shared/_test/index.html
+++ b/src/layer1_wasm/_shared/_test/index.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="vivarium-contract" content="v1" />
+    <title>Vivarium _shared smoke test</title>
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <p class="kicker">Vivarium · Layer 1 · Smoke test</p>
+        <h1>_shared/ contract-v1 smoke test</h1>
+        <p class="lede">
+          Verifies that <code>_shared/verdict.mjs</code> publishes the
+          contract-v1 surface (<code>data-verdict</code>,
+          <code>__VIVARIUM_VERDICT__</code>, <code>__VIVARIUM_RESULT__</code>)
+          correctly. No upstream bug is exercised — Pyodide is not loaded.
+        </p>
+      </header>
+
+      <section>
+        <h2>Verdict</h2>
+        <div
+          id="verdict"
+          class="verdict pending"
+          data-verdict="pending"
+          role="status"
+          aria-live="polite"
+        >
+          Initialising…
+        </div>
+        <p class="meta" id="meta"></p>
+      </section>
+
+      <section>
+        <h2>Output</h2>
+        <pre id="output">(running)</pre>
+      </section>
+
+      <footer>
+        <p class="meta">
+          Source:
+          <a
+            href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/_shared"
+            >vivarium/src/layer1_wasm/_shared</a
+          >.
+        </p>
+      </footer>
+    </main>
+
+    <script type="module" src="./repro.mjs"></script>
+  </body>
+</html>

--- a/src/layer1_wasm/_shared/_test/repro.mjs
+++ b/src/layer1_wasm/_shared/_test/repro.mjs
@@ -1,0 +1,53 @@
+// Smoke test for `_shared/verdict.mjs`.
+//
+// Validates that the helpers wire up the contract-v1 surface:
+// - DOM `#verdict[data-verdict]`
+// - `globalThis.__VIVARIUM_VERDICT__`
+// - `globalThis.__VIVARIUM_RESULT__` envelope
+//
+// Pyodide is intentionally NOT loaded here — the goal is to verify the
+// helper plumbing in isolation. Reproduction-level smoke tests live in
+// each per-bug page.
+
+import { setResult, setVerdict } from "../verdict.mjs";
+
+const startedAt = new Date();
+const outputEl = document.getElementById("output");
+const metaEl = document.getElementById("meta");
+
+try {
+  setVerdict("pass", "reproduction succeeded — _shared helpers wired up.");
+
+  const finishedAt = new Date();
+  /** @type {import('../verdict.mjs').VivariumResultV1} */
+  const envelope = {
+    contract: "v1",
+    bug: {
+      project: "vivarium",
+      issue: 0,
+      upstream_url:
+        "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/_shared",
+    },
+    runtime: {
+      name: "browser",
+      version: navigator.userAgent,
+      extras: {},
+    },
+    result: { smoke_test: "ok" },
+    timing: {
+      started_at: startedAt.toISOString(),
+      finished_at: finishedAt.toISOString(),
+      duration_ms: finishedAt.getTime() - startedAt.getTime(),
+    },
+  };
+  setResult(envelope);
+
+  metaEl.textContent =
+    "Smoke test ran without loading Pyodide — only the helper plumbing is exercised.";
+  outputEl.textContent = JSON.stringify(envelope, null, 2);
+} catch (err) {
+  console.error(err);
+  outputEl.textContent =
+    (err && (err.stack || err.message)) || String(err);
+  setVerdict("fail", `smoke test failed: ${err.message ?? err}`);
+}

--- a/src/layer1_wasm/_shared/loader.mjs
+++ b/src/layer1_wasm/_shared/loader.mjs
@@ -1,0 +1,59 @@
+// Vivarium contract v1 — Pyodide loader.
+//
+// Loads Pyodide from the jsDelivr CDN with a pinned version and an optional
+// list of preload packages. On any load failure, the helper sets the verdict
+// to "fail" with the error text so the caller does not have to duplicate
+// that plumbing — and re-throws so the caller can also short-circuit.
+//
+// Pages should still also wrap their reproduction code in `try/catch` and
+// call `setVerdict("fail", ...)` themselves on REPRODUCTION-time errors —
+// this helper only owns load-time errors.
+
+import { setVerdict } from "./verdict.mjs";
+
+const DEFAULT_PYODIDE_VERSION = "0.29.3";
+
+/**
+ * @typedef {Object} LoadOptions
+ * @property {string} [version]      Pyodide version to load (default "0.29.3").
+ *   Keep in sync with the `<link rel="modulepreload">` in the page's `<head>`.
+ * @property {string[]} [packages]   Packages to preload alongside the runtime
+ *   (e.g. `["pandas"]`). Loaded in parallel with the Pyodide bootstrap.
+ * @property {string} [pendingText]  Verdict message shown while loading
+ *   (default "Loading Pyodide runtime…").
+ */
+
+/**
+ * Load Pyodide and return the runtime instance.
+ *
+ * @param {LoadOptions} [options]
+ * @returns {Promise<{ pyodide: any, version: string }>}
+ *   The Pyodide instance and the version string actually used.
+ * @throws Re-throws the underlying error after setting the verdict to "fail".
+ */
+export async function loadVivariumPyodide(options = {}) {
+  const version = options.version ?? DEFAULT_PYODIDE_VERSION;
+  const packages = options.packages ?? [];
+  const pendingText = options.pendingText ?? "Loading Pyodide runtime…";
+
+  setVerdict("pending", pendingText);
+
+  const pyodideUrl = `https://cdn.jsdelivr.net/pyodide/v${version}/full/pyodide.mjs`;
+  const indexURL = `https://cdn.jsdelivr.net/pyodide/v${version}/full/`;
+
+  try {
+    const { loadPyodide } = await import(pyodideUrl);
+    const pyodide = await loadPyodide({ indexURL, packages });
+    return { pyodide, version };
+  } catch (err) {
+    const message =
+      (err && (err.stack || err.message)) || String(err);
+    setVerdict(
+      "fail",
+      `reproduction failed — runtime error during Pyodide load: ${message}`,
+    );
+    throw err;
+  }
+}
+
+export { DEFAULT_PYODIDE_VERSION };

--- a/src/layer1_wasm/_shared/style.css
+++ b/src/layer1_wasm/_shared/style.css
@@ -1,0 +1,162 @@
+:root {
+  color-scheme: light dark;
+  --fg: #1f2328;
+  --fg-muted: #57606a;
+  --bg: #ffffff;
+  --bg-muted: #f6f8fa;
+  --border: #d0d7de;
+  --pass-bg: #dafbe1;
+  --pass-fg: #116329;
+  --fail-bg: #ffebe9;
+  --fail-fg: #82071e;
+  --pending-bg: #ddf4ff;
+  --pending-fg: #0969da;
+  --link: #0969da;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --fg: #e6edf3;
+    --fg-muted: #8d96a0;
+    --bg: #0d1117;
+    --bg-muted: #161b22;
+    --border: #30363d;
+    --pass-bg: #033a16;
+    --pass-fg: #56d364;
+    --fail-bg: #5a1e1e;
+    --fail-fg: #ff7b72;
+    --pending-bg: #0c2d6b;
+    --pending-fg: #79c0ff;
+    --link: #79c0ff;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family:
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    "Helvetica Neue",
+    Arial,
+    sans-serif;
+  line-height: 1.55;
+}
+
+main {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 2.5rem 1.25rem 4rem;
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+.kicker {
+  margin: 0 0 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--fg-muted);
+}
+
+h1 {
+  margin: 0 0 0.75rem;
+  font-size: 1.6rem;
+  line-height: 1.3;
+}
+
+h2 {
+  font-size: 1.05rem;
+  margin: 1.75rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.lede {
+  margin: 0;
+  color: var(--fg-muted);
+}
+
+a {
+  color: var(--link);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+code {
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    "SF Mono",
+    Menlo,
+    Consolas,
+    monospace;
+  font-size: 0.9em;
+  background: var(--bg-muted);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+}
+
+pre {
+  background: var(--bg-muted);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.85rem 1rem;
+  overflow-x: auto;
+  margin: 0;
+}
+
+pre code {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.verdict {
+  font-weight: 600;
+  padding: 0.85rem 1rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+}
+
+.verdict.pending {
+  background: var(--pending-bg);
+  color: var(--pending-fg);
+  border-color: var(--pending-fg);
+}
+
+.verdict.pass {
+  background: var(--pass-bg);
+  color: var(--pass-fg);
+  border-color: var(--pass-fg);
+}
+
+.verdict.fail {
+  background: var(--fail-bg);
+  color: var(--fail-fg);
+  border-color: var(--fail-fg);
+}
+
+.meta {
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+  margin: 0.5rem 0 0;
+}
+
+footer {
+  margin-top: 3rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--border);
+}

--- a/src/layer1_wasm/_shared/verdict.mjs
+++ b/src/layer1_wasm/_shared/verdict.mjs
@@ -1,0 +1,82 @@
+// Vivarium contract v1 — verdict and result envelope helpers.
+//
+// Pages must include `<meta name="vivarium-contract" content="v1">` in
+// `<head>` and an element with `id="verdict"` somewhere in the body.
+//
+// Surface published by these helpers (per ADR-0008):
+// - DOM: `#verdict[data-verdict]` ∈ {"pending", "pass", "fail"}
+// - Globals: `__VIVARIUM_VERDICT__`, `__VIVARIUM_RESULT__`
+// - Visible text on `#verdict`, set by `setVerdict(state, text)`
+//
+// `pass` means the bug REPRODUCES (the upstream behaviour is observable in
+// the runtime this page loads). `fail` means it does NOT — either the
+// runtime ships a fixed version, or the runtime errored before producing a
+// result. `pending` means the run has not yet produced a verdict.
+
+/**
+ * @typedef {Object} VivariumResultV1Bug
+ * @property {string} project       Upstream project short name (e.g. "pandas").
+ * @property {number} issue         Upstream issue number, no `#` prefix.
+ * @property {string} upstream_url  URL to the upstream issue or PR.
+ */
+
+/**
+ * @typedef {Object} VivariumResultV1Runtime
+ * @property {string} name                       Runtime name (e.g. "pyodide").
+ * @property {string} version                    Runtime version (e.g. "0.29.3").
+ * @property {Record<string, string>} extras     Free-form extras (python, pandas versions, etc.).
+ */
+
+/**
+ * @typedef {Object} VivariumResultV1Timing
+ * @property {string} started_at   ISO-8601 timestamp.
+ * @property {string} finished_at  ISO-8601 timestamp.
+ * @property {number} duration_ms  Wall-clock duration in milliseconds.
+ */
+
+/**
+ * @typedef {Object} VivariumResultV1
+ * @property {"v1"} contract
+ * @property {VivariumResultV1Bug} bug
+ * @property {VivariumResultV1Runtime} runtime
+ * @property {Record<string, unknown>} result    Page-specific structured output.
+ * @property {VivariumResultV1Timing} timing
+ */
+
+/**
+ * Update the verdict element + the `__VIVARIUM_VERDICT__` global atomically.
+ *
+ * @param {"pending" | "pass" | "fail"} state
+ * @param {string} text Human-readable verdict. Should start with
+ *   "reproduction succeeded", "reproduction failed", or a page-specific
+ *   pending message — see ADR-0008.
+ */
+export function setVerdict(state, text) {
+  const el = document.getElementById("verdict");
+  if (!el) {
+    throw new Error(
+      'vivarium contract v1: missing element with id="verdict".',
+    );
+  }
+  el.classList.remove("pass", "fail", "pending");
+  el.classList.add(state);
+  el.dataset.verdict = state;
+  el.textContent = text;
+  globalThis.__VIVARIUM_VERDICT__ = state;
+}
+
+/**
+ * Publish the structured result envelope on `__VIVARIUM_RESULT__`.
+ *
+ * @param {VivariumResultV1} envelope
+ */
+export function setResult(envelope) {
+  if (!envelope || envelope.contract !== "v1") {
+    throw new Error(
+      `vivarium contract v1: setResult expected contract="v1", got ${
+        envelope ? JSON.stringify(envelope.contract) : "null"
+      }.`,
+    );
+  }
+  globalThis.__VIVARIUM_RESULT__ = envelope;
+}


### PR DESCRIPTION
## Summary

- Introduce [`src/layer1_wasm/_shared/`](https://github.com/aletheia-works/vivarium/tree/feat/phase1-shared-scaffolding/src/layer1_wasm/_shared) — the canonical home for the **vivarium contract v1** plumbing (`verdict.mjs`, `loader.mjs`, `style.css`) plus a smoke test under `_test/`.
- Extend [`deploy-docs.yml`](https://github.com/aletheia-works/vivarium/blob/feat/phase1-shared-scaffolding/.github/workflows/deploy-docs.yml) so underscore-prefixed subdirectories of `src/layer1_wasm/` are bundled even without an `index.html`. Reproductions can reach shared modules at `<pages-base>/poc/_shared/…`.
- The existing `pandas-56679` PoC is **untouched**. Its retrofit onto these helpers (and the `/poc/` → `/repro/` URL migration) is a follow-up Issue per the maintainer-private ADR-0008 § Migration.

Closes #62.

## What lands in `_shared/`

| File | Role |
| --- | --- |
| `verdict.mjs` | `setVerdict(state, text)` and `setResult(envelope)` helpers. `VivariumResultV1` JSDoc typedef. Publishes on DOM (`#verdict[data-verdict]`, visible text) and globals (`__VIVARIUM_VERDICT__`, `__VIVARIUM_RESULT__`). |
| `loader.mjs` | `loadVivariumPyodide({ version, packages, pendingText })`. Default version `0.29.3`. On load failure: sets verdict `fail` with the error text and re-throws. |
| `style.css` | Copy of the existing PoC stylesheet. The PoC keeps its own copy until retrofit. |
| `_test/index.html` + `_test/repro.mjs` | Smoke test that validates the contract surface without loading Pyodide. |
| `README.md` | Contents, contract-v1 reminder, smoke-test instructions, deployment-path explanation. |

## Verification

Smoke test, served locally:

```bash
python -m http.server -d src/layer1_wasm/_shared 8766
# then open http://localhost:8766/_test/
```

Observed (Preview MCP, Chromium engine):

| Surface | Expected | Got |
| --- | --- | --- |
| `<meta name=\"vivarium-contract\">` | `v1` | `v1` |
| `#verdict[data-verdict]` | `pass` | `pass` |
| `__VIVARIUM_VERDICT__` | `\"pass\"` | `\"pass\"` |
| `__VIVARIUM_RESULT__.contract` | `\"v1\"` | `\"v1\"` |
| `__VIVARIUM_RESULT__.result.smoke_test` | `\"ok\"` | `\"ok\"` |
| Console errors | none | none |

## Review focus

- [x] [`verdict.mjs`](https://github.com/aletheia-works/vivarium/blob/feat/phase1-shared-scaffolding/src/layer1_wasm/_shared/verdict.mjs) JSDoc typedef matches the envelope shape ADR-0008 specifies.
- [x] [`loader.mjs`](https://github.com/aletheia-works/vivarium/blob/feat/phase1-shared-scaffolding/src/layer1_wasm/_shared/loader.mjs) load-time error path correctly sets `fail` verdict and re-throws.
- [x] [`deploy-docs.yml` bundling step](https://github.com/aletheia-works/vivarium/blob/feat/phase1-shared-scaffolding/.github/workflows/deploy-docs.yml) handles both reproductions and underscore-prefixed scaffolding without breaking the existing `pandas-56679` deploy path.
- [x] [`README.md`](https://github.com/aletheia-works/vivarium/blob/feat/phase1-shared-scaffolding/src/layer1_wasm/_shared/README.md) reads cleanly for a future contributor who is touching the gallery for the first time.

## Process notes

- AI-authored: `ai: generated` label set on this PR.
- No build step, no bundler, no TypeScript — vanilla ES modules + JSDoc. Stays the simplest thing that satisfies the contract.
- Scope strictly limited to extraction. The pandas-56679 retrofit, the URL migration to `/repro/`, and adding the second bug are separate follow-up Issues to be filed once this lands.