### PR TITLE
feat(python): add numpy-28287 reproduction and migrate gallery URLs to /repro/

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,15 +16,20 @@ name: deploy-docs
 # - `docs/` holds the rspress site (config, lockfile, markdown content).
 # - `docs/docs/` is the rspress `root` and contains the markdown.
 # - The build artefact is written to `docs/doc_build/`.
-# - `src/layer1_wasm/<slug>/` directories are static Pyodide / WASM PoCs.
-#   Sources are TypeScript; `tsc` emits side-by-side `.js` files which
-#   are then copied verbatim into `docs/doc_build/poc/<slug>/`. The
-#   `.js` outputs are gitignored — the deploy step rebuilds them from
-#   the `.ts` sources via `src/layer1_wasm/package.json`'s `build` script.
+# - `src/layer1_wasm/<slug>/` directories are static Pyodide / WASM
+#   reproductions. Sources are TypeScript; `tsc` emits side-by-side
+#   `.js` files which are then copied verbatim into
+#   `docs/doc_build/repro/<slug>/`. The `.js` outputs are gitignored —
+#   the deploy step rebuilds them from the `.ts` sources via
+#   `src/layer1_wasm/package.json`'s `build` script.
 # - Underscore-prefixed subdirectories (e.g. `src/layer1_wasm/_shared/`)
-#   hold scaffolding shared across reproductions. They are bundled under
-#   the same `poc/` prefix without requiring an `index.html`, so each
-#   reproduction can reference them via `../_shared/…`.
+#   hold scaffolding shared across reproductions. They are bundled
+#   alongside reproductions under `repro/` without requiring an
+#   `index.html`, so each reproduction can reference them via
+#   `../_shared/…`.
+# - Legacy `/poc/<slug>/` URLs (Phase 0 noun) get HTML meta-refresh
+#   redirect pages pointing at the new `/repro/<slug>/` location, so
+#   external links from before the migration continue to work.
 
 on:
   push:
@@ -84,23 +89,27 @@ jobs:
         working-directory: ${{ github.workspace }}/src/layer1_wasm
         run: bun run build
 
-      - name: Bundle Layer 1 PoCs alongside docs
+      - name: Bundle Layer 1 reproductions alongside docs
         # Each immediate subdirectory of `src/layer1_wasm/` is published at
-        # `<pages-base>/poc/<slug>/`. README files and other tracked source
-        # live next to the PoC for review; they get copied too, which is
-        # fine — the PoC pages are static.
+        # `<pages-base>/repro/<slug>/`. README files and other tracked
+        # source live next to the reproduction for review; they get copied
+        # too, which is fine — the pages are static.
         #
         # Two flavours of subdirectory:
         # 1. Reproduction pages — must contain `index.html`. Skipped if not.
+        #    Also gets an HTML meta-refresh redirect page at
+        #    `<pages-base>/poc/<slug>/` to keep legacy URLs working.
         # 2. Underscore-prefixed scaffolding (e.g. `_shared/`) — bundled
-        #    unconditionally so each reproduction can reference shared
-        #    modules via `../_shared/…` after deploy.
+        #    unconditionally under `repro/` so each reproduction can
+        #    reference shared modules via `../_shared/…` after deploy.
+        #    No `/poc/_shared/` redirect — it was never a public URL.
         working-directory: ${{ github.workspace }}
         run: |
           set -euo pipefail
-          dest="docs/doc_build/poc"
+          dest="docs/doc_build/repro"
+          legacy_dest="docs/doc_build/poc"
           if [ ! -d src/layer1_wasm ]; then
-            echo "No src/layer1_wasm/ directory; skipping PoC bundling."
+            echo "No src/layer1_wasm/ directory; skipping bundling."
             exit 0
           fi
           mkdir -p "$dest"
@@ -116,12 +125,34 @@ jobs:
                   echo "Skipping ${poc} (no index.html)"
                   continue
                 fi
-                echo "Bundling PoC: ${slug}"
+                echo "Bundling reproduction: ${slug}"
                 cp -R "$poc" "$dest/"
+                # Legacy `/poc/<slug>/` redirect — HTML meta-refresh is
+                # the simplest mechanism that works on GitHub Pages
+                # (which has no native server-side 301 support).
+                mkdir -p "$legacy_dest/$slug"
+                cat > "$legacy_dest/$slug/index.html" <<HTML
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8" />
+              <title>Vivarium · moved to /repro/${slug}/</title>
+              <meta http-equiv="refresh" content="0; url=../../repro/${slug}/" />
+              <link rel="canonical" href="../../repro/${slug}/" />
+              <meta name="robots" content="noindex" />
+            </head>
+            <body>
+              <p>This reproduction has moved to
+                <a href="../../repro/${slug}/">/repro/${slug}/</a>.
+                Updating in a moment…</p>
+            </body>
+          </html>
+          HTML
                 ;;
             esac
           done
           ls -la "$dest" || true
+          ls -la "$legacy_dest" || true
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/docs/docs/_meta.json
+++ b/docs/docs/_meta.json
@@ -28,5 +28,10 @@
     "type": "file",
     "name": "ai-workflow",
     "label": "AI workflow"
+  },
+  {
+    "type": "dir",
+    "name": "repro",
+    "label": "Reproductions"
   }
 ]

--- a/docs/docs/_nav.json
+++ b/docs/docs/_nav.json
@@ -18,5 +18,10 @@
     "text": "AI workflow",
     "link": "/ai-workflow",
     "activeMatch": "/ai-workflow"
+  },
+  {
+    "text": "Reproductions",
+    "link": "/repro/",
+    "activeMatch": "/repro/"
   }
 ]

--- a/docs/docs/repro/index.md
+++ b/docs/docs/repro/index.md
@@ -1,0 +1,55 @@
+# Reproductions
+
+Each card below is a real bug from a real upstream project, reproduced
+in your browser via Pyodide. Click "Open" to load the page; the verdict
+appears at the top once the runtime finishes loading and the
+reproduction script has run.
+
+## Vivarium contract
+
+Every page on this gallery satisfies **`vivarium-contract: v1`**:
+
+- `<meta name="vivarium-contract" content="v1">` declared in `<head>`.
+- A DOM element with `id="verdict"` and `data-verdict="pending" |
+  "pass" | "fail"`.
+- Globals `__VIVARIUM_VERDICT__` (mirror) and `__VIVARIUM_RESULT__`
+  (structured envelope with `bug`, `runtime`, `result`, `timing`).
+- Visible verdict text starting with `reproduction succeeded` or
+  `reproduction failed`.
+
+A `pass` verdict means **the bug reproduced** — the upstream behaviour
+is observable in the runtime this page just loaded. A `fail` verdict
+means the runtime ships a fixed version, or the runtime errored before
+producing a result. The semantics are counterintuitive in isolation
+but match the project's domain noun: a *reproduction* succeeds when it
+reproduces.
+
+## Layer 1 — Pyodide
+
+| Project | Issue | Verdict | |
+| --- | --- | --- | --- |
+| pandas | [#56679](https://github.com/pandas-dev/pandas/issues/56679) — empty `Series` / `DataFrame` dtype mismatch | `pass` (bug reproduces) | [Open ↗](https://aletheia-works.github.io/vivarium/repro/pandas-56679/) |
+| numpy | [#28287](https://github.com/numpy/numpy/issues/28287) — `timedelta64` ordering is non-transitive across generic units | `pass` (bug reproduces) | [Open ↗](https://aletheia-works.github.io/vivarium/repro/numpy-28287/) |
+
+The Verdict column reflects what the page reports on the runtime
+Vivarium currently loads (Pyodide v0.29.3 with pandas 2.3.3 and numpy
+2.2.5 at the time of writing). The linked page is authoritative —
+visit it to confirm the live verdict, since an upstream fix landing in
+a future Pyodide release will flip the verdict to `fail`.
+
+## Adding a reproduction
+
+A new reproduction page lives under
+[`src/layer1_wasm/<project>-<issue>/`](https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm)
+and ships:
+
+- `index.html` declaring the contract version, with a `#verdict` band
+  and `<script src="./repro.js">`.
+- `repro.ts` that imports `loadVivariumPyodide`, `setVerdict`,
+  `setResult` from
+  [`../_shared/`](https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/_shared)
+  and publishes a `VivariumResultV1` envelope on completion.
+- A short `README.md` explaining the bug and the verdict criterion.
+
+The deploy workflow handles bundling and the `.ts` → `.js` build —
+contributors only edit TypeScript sources.

--- a/src/layer1_wasm/numpy-28287/README.md
+++ b/src/layer1_wasm/numpy-28287/README.md
@@ -1,0 +1,89 @@
+# Reproduction — numpy/numpy#28287
+
+> Phase 1 reproduction page. The second entry in Vivarium's gallery,
+> conforming to `vivarium-contract: v1` like every other Phase 1 page.
+
+## The bug
+
+[numpy/numpy#28287](https://github.com/numpy/numpy/issues/28287) —
+NumPy's `timedelta64` ordering is non-transitive when one of the values
+uses the *generic* unit. With:
+
+```python
+x = np.timedelta64(1, "ms")
+y = np.timedelta64(2)        # generic unit, no resolution attached
+z = np.timedelta64(5, "ns")
+```
+
+NumPy reports `x < y` and `y < z` but `x > z` — strict ordering operators
+are supposed to be transitive, so a comparison chain that visibly
+contradicts itself is a clear violation.
+
+## Why this bug
+
+- Three-line reproduction (plus an import), zero non-numpy dependencies.
+- Verdict is a boolean — `(x < y) ∧ (y < z) ∧ ¬(x < z)` — so the page
+  emits a mechanically-distinguishable `pass` / `fail`.
+- Reported against numpy 2.2.2; no merged fix as of this writing.
+  Pyodide v0.29.3 ships numpy 2.2.5 as an installable package (loaded
+  via `loadPyodide({ packages: ["numpy"] })`), so the bug is expected
+  to reproduce on the build the page loads.
+- Pure NumPy, no I/O, no network, no FFI — nothing in the repro path
+  touches a browser-restricted surface.
+- Demonstrates that Vivarium's Phase 1 gallery is not pandas-only:
+  numpy is in scope as a first-class Layer 1 reproduction target.
+
+## Files
+
+| File         | Role                                                              |
+| ------------ | ----------------------------------------------------------------- |
+| `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
+| `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
+
+Shared visual presentation lives in [`../_shared/style.css`](../_shared/style.css).
+
+## Verdict contract — `vivarium-contract: v1`
+
+The page conforms to the contract canonicalised in
+[`../_shared/verdict.ts`](../_shared/verdict.ts):
+
+- `<meta name="vivarium-contract" content="v1">` declared in `<head>`.
+- `document.querySelector('#verdict').dataset.verdict` ∈
+  `{"pending", "pass", "fail"}`.
+- `globalThis.__VIVARIUM_VERDICT__` — mirror of the DOM verdict.
+- `globalThis.__VIVARIUM_RESULT__` — a `VivariumResultV1` envelope:
+  `{ contract: "v1", bug: { project: "numpy", issue: 28287, upstream_url },
+  runtime: { name: "pyodide", version, extras: { python, numpy } },
+  result: { x_lt_y, y_lt_z, x_lt_z, transitivity_violated }, timing }`.
+- Visible verdict text starts with `reproduction succeeded` or
+  `reproduction failed`.
+
+A `pass` means **the bug reproduced** (NumPy still reports the
+non-transitive ordering). A `fail` means either the bug was fixed in the
+version Pyodide currently ships, or the runtime itself errored before
+producing a result.
+
+## Running locally
+
+```bash
+# 1. From src/layer1_wasm/, build the TypeScript sources once.
+cd src/layer1_wasm
+bun install        # one-time per machine / lockfile change
+bun run build      # emits numpy-28287/repro.js next to repro.ts (gitignored)
+
+# 2. Serve the parent directory so ../_shared/ resolves at runtime.
+python -m http.server -d . 8767
+# then open http://localhost:8767/numpy-28287/
+```
+
+Pyodide does not require COOP/COEP headers (no `SharedArrayBuffer`, no
+threading), so a plain server is enough.
+
+## Deployment
+
+Published to GitHub Pages at
+`https://aletheia-works.github.io/vivarium/repro/numpy-28287/` by the
+`deploy-docs` workflow. The workflow runs `bun install` + `bun run
+build` in `src/layer1_wasm/` first so the compiled `repro.js` exists
+when the bundling step copies the directory into the Pages artefact.

--- a/src/layer1_wasm/numpy-28287/index.html
+++ b/src/layer1_wasm/numpy-28287/index.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="vivarium-contract" content="v1" />
+    <title>Vivarium · Reproducing numpy/numpy#28287</title>
+    <!-- Warm the TLS/HTTP3 handshake to jsDelivr in parallel with HTML parse. -->
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <!-- Keep the version below in sync with DEFAULT_PYODIDE_VERSION in
+         ../_shared/loader.ts. -->
+    <link
+      rel="modulepreload"
+      href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.mjs"
+      crossorigin
+    />
+    <link rel="stylesheet" href="../_shared/style.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <p class="kicker">Vivarium · Layer 1 · Pyodide</p>
+        <h1>Reproducing <a href="https://github.com/numpy/numpy/issues/28287">numpy/numpy#28287</a></h1>
+        <p class="lede">
+          NumPy's <code>timedelta64</code> ordering is non-transitive when
+          one of the values uses the <em>generic</em> unit. With
+          <code>x = 1&nbsp;ms</code>, <code>y = 2 (generic)</code>, and
+          <code>z = 5&nbsp;ns</code>, NumPy reports
+          <code>x &lt; y</code> and <code>y &lt; z</code> but
+          <code>x &gt; z</code> — a transitivity violation in a built-in
+          comparison operator.
+        </p>
+      </header>
+
+      <section>
+        <h2>Verdict</h2>
+        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          Loading Pyodide runtime…
+        </div>
+        <p class="meta" id="meta"></p>
+      </section>
+
+      <section>
+        <h2>Reproduction script</h2>
+        <pre><code id="repro-code"></code></pre>
+      </section>
+
+      <section>
+        <h2>Output</h2>
+        <pre id="output">(running)</pre>
+      </section>
+
+      <footer>
+        <p class="meta">
+          Runtime:
+          <a href="https://pyodide.org/">Pyodide</a>
+          loaded from
+          <a href="https://www.jsdelivr.com/package/npm/pyodide">cdn.jsdelivr.net</a>.
+          Source:
+          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/numpy-28287">vivarium/src/layer1_wasm/numpy-28287</a>.
+        </p>
+      </footer>
+    </main>
+
+    <script type="module" src="./repro.js"></script>
+  </body>
+</html>

--- a/src/layer1_wasm/numpy-28287/repro.ts
+++ b/src/layer1_wasm/numpy-28287/repro.ts
@@ -1,0 +1,148 @@
+// Vivarium Layer 1 reproduction — numpy/numpy#28287.
+//
+// `timedelta64` ordering is non-transitive when one of the values uses
+// the generic unit. With:
+//   x = np.timedelta64(1, "ms")
+//   y = np.timedelta64(2)         # generic unit
+//   z = np.timedelta64(5, "ns")
+// NumPy reports x < y and y < z but x > z — a transitivity violation.
+//
+// Verdict semantics (per ADR-0008 / contract v1):
+//   - "pass" — the bug REPRODUCES (numpy reports the non-transitive
+//     ordering on the build Pyodide ships).
+//   - "fail" — the bug does NOT reproduce (or the runtime errored).
+
+import { loadVivariumPyodide } from "../_shared/loader.js";
+import {
+  setResult,
+  setVerdict,
+  type VivariumResultV1,
+} from "../_shared/verdict.js";
+
+const REPRO_CODE = `
+import sys
+import numpy as np
+
+x = np.timedelta64(1, "ms")
+y = np.timedelta64(2)
+z = np.timedelta64(5, "ns")
+
+x_lt_y = bool(x < y)
+y_lt_z = bool(y < z)
+x_lt_z = bool(x < z)
+
+{
+    "numpy_version": np.__version__,
+    "python_version": sys.version.split()[0],
+    "x_lt_y": x_lt_y,
+    "y_lt_z": y_lt_z,
+    "x_lt_z": x_lt_z,
+    "transitivity_violated": x_lt_y and y_lt_z and not x_lt_z,
+}
+`.trim();
+
+interface ReproOutput {
+  numpy_version: string;
+  python_version: string;
+  x_lt_y: boolean;
+  y_lt_z: boolean;
+  x_lt_z: boolean;
+  transitivity_violated: boolean;
+}
+
+interface PyodideRuntime {
+  runPythonAsync(code: string): Promise<{
+    toJs(opts: { dict_converter: typeof Object.fromEntries }): ReproOutput;
+    destroy?(): void;
+  }>;
+}
+
+const outputEl = document.getElementById("output");
+const metaEl = document.getElementById("meta");
+const reproCodeEl = document.getElementById("repro-code");
+
+if (!outputEl || !metaEl || !reproCodeEl) {
+  throw new Error(
+    "numpy-28287: missing required DOM elements (#output, #meta, #repro-code).",
+  );
+}
+
+reproCodeEl.textContent = REPRO_CODE;
+
+const startedAt = new Date();
+
+try {
+  // numpy is shipped with the Pyodide distribution but must be installed
+  // explicitly via `loadPackage` / the `packages` option — it is not
+  // imported at runtime startup.
+  const { pyodide, version } = await loadVivariumPyodide({
+    packages: ["numpy"],
+    pendingText: "Loading Pyodide runtime and numpy…",
+  });
+
+  setVerdict("pending", "Running reproduction script…");
+  const runtime = pyodide as PyodideRuntime;
+  const proxy = await runtime.runPythonAsync(REPRO_CODE);
+  const result = proxy.toJs({ dict_converter: Object.fromEntries });
+  proxy.destroy?.();
+
+  metaEl.textContent =
+    `numpy ${result.numpy_version} on Python ${result.python_version} ` +
+    `via Pyodide v${version}.`;
+  outputEl.textContent = JSON.stringify(result, null, 2);
+
+  if (result.transitivity_violated) {
+    setVerdict(
+      "pass",
+      "reproduction succeeded — timedelta64 ordering is non-transitive (x < y < z but x ≥ z).",
+    );
+  } else {
+    setVerdict(
+      "fail",
+      "reproduction failed — timedelta64 ordering is transitive in this numpy build.",
+    );
+  }
+
+  const finishedAt = new Date();
+  const envelope: VivariumResultV1 = {
+    contract: "v1",
+    bug: {
+      project: "numpy",
+      issue: 28287,
+      upstream_url: "https://github.com/numpy/numpy/issues/28287",
+    },
+    runtime: {
+      name: "pyodide",
+      version,
+      extras: {
+        python: result.python_version,
+        numpy: result.numpy_version,
+      },
+    },
+    result: {
+      x_lt_y: result.x_lt_y,
+      y_lt_z: result.y_lt_z,
+      x_lt_z: result.x_lt_z,
+      transitivity_violated: result.transitivity_violated,
+    },
+    timing: {
+      started_at: startedAt.toISOString(),
+      finished_at: finishedAt.toISOString(),
+      duration_ms: finishedAt.getTime() - startedAt.getTime(),
+    },
+  };
+  setResult(envelope);
+} catch (err: unknown) {
+  console.error(err);
+  const errAny = err as { stack?: string; message?: string } | null;
+  outputEl.textContent =
+    (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
+  // `loadVivariumPyodide` already sets "fail" on load-time errors. Cover
+  // the case where the runtime loaded but the reproduction itself errored.
+  if (globalThis.__VIVARIUM_VERDICT__ !== "fail") {
+    setVerdict(
+      "fail",
+      `reproduction failed — runtime error: ${errAny?.message ?? String(err)}`,
+    );
+  }
+}

--- a/src/layer1_wasm/pandas-56679/README.md
+++ b/src/layer1_wasm/pandas-56679/README.md
@@ -77,14 +77,15 @@ Pyodide does **not** require COOP/COEP headers for this page (no
 ## Deployment
 
 Published to GitHub Pages at
-`https://aletheia-works.github.io/vivarium/poc/pandas-56679/` by the
-`deploy-docs` workflow. The workflow runs `bun install` + `bun run build`
-in `src/layer1_wasm/` first so the compiled `repro.js` exists when the
-bundling step copies the directory into the Pages artefact.
+`https://aletheia-works.github.io/vivarium/repro/pandas-56679/` by the
+`deploy-docs` workflow. The workflow runs `bun install` + `bun run
+build` in `src/layer1_wasm/` first so the compiled `repro.js` exists
+when the bundling step copies the directory into the Pages artefact.
 
-The URL prefix migrates from `/poc/` to `/repro/` in the same PR that
-adds the second reproduction (per ADR-0008 § Migration). Until that PR
-lands, `/poc/pandas-56679/` is the canonical URL.
+Legacy URL `https://aletheia-works.github.io/vivarium/poc/pandas-56679/`
+is preserved by an HTML meta-refresh redirect generated at deploy
+time, so external links from before the URL migration continue to
+work.
 
 ## Verification status
 


### PR DESCRIPTION
## Summary

- **New reproduction** at [`src/layer1_wasm/numpy-28287/`](https://github.com/aletheia-works/vivarium/tree/feat/numpy-28287-and-repro-migration/src/layer1_wasm/numpy-28287) — `np.timedelta64` ordering is non-transitive when one of the values uses the generic unit. Pyodide's bundled numpy 2.2.5 reproduces it.
- **Gallery URL migration** from `/poc/` → `/repro/`. The Phase 0 noun retires; the Phase 1 noun lands. Legacy `/poc/<slug>/` URLs continue to work via deploy-time meta-refresh redirect pages.
- **Gallery index** at [`docs/docs/repro/`](https://github.com/aletheia-works/vivarium/tree/feat/numpy-28287-and-repro-migration/docs/docs/repro) plus sidebar / top-nav entries.

Closes #66.

## numpy-28287 — the bug

```python
x = np.timedelta64(1, "ms")
y = np.timedelta64(2)        # generic unit
z = np.timedelta64(5, "ns")

# NumPy reports:
#   x < y  -> True
#   y < z  -> True
#   x < z  -> False   ← transitivity violated
```

Reported against numpy 2.2.2 ([upstream issue](https://github.com/numpy/numpy/issues/28287)); no merged fix as of this writing. Pyodide v0.29.3 ships numpy 2.2.5, so the bug reproduces.

Variety motivation: pandas#56679 was a pandas dtype bug. This second page is numpy-domain, datetime-domain, and the verdict shape is a transitivity violation — proves the Phase 1 gallery is not pandas-only.

## URL migration mechanism

The deploy workflow ([deploy-docs.yml](https://github.com/aletheia-works/vivarium/blob/feat/numpy-28287-and-repro-migration/.github/workflows/deploy-docs.yml)) now bundles reproductions under `docs/doc_build/repro/` instead of `docs/doc_build/poc/`. For each reproduction (not for `_shared/`), it also generates a `docs/doc_build/poc/<slug>/index.html` redirect page:

```html
<meta http-equiv="refresh" content="0; url=../../repro/<slug>/">
<link rel="canonical" href="../../repro/<slug>/">
<meta name="robots" content="noindex">
```

GitHub Pages does not support server-side 301 redirects, so this is the cheapest mechanism that keeps existing `/poc/pandas-56679/` links working with a single client-side hop.

## What changed

| File | Status |
| --- | --- |
| [`src/layer1_wasm/numpy-28287/index.html`](https://github.com/aletheia-works/vivarium/blob/feat/numpy-28287-and-repro-migration/src/layer1_wasm/numpy-28287/index.html) | new |
| [`src/layer1_wasm/numpy-28287/repro.ts`](https://github.com/aletheia-works/vivarium/blob/feat/numpy-28287-and-repro-migration/src/layer1_wasm/numpy-28287/repro.ts) | new |
| [`src/layer1_wasm/numpy-28287/README.md`](https://github.com/aletheia-works/vivarium/blob/feat/numpy-28287-and-repro-migration/src/layer1_wasm/numpy-28287/README.md) | new |
| [`docs/docs/repro/index.md`](https://github.com/aletheia-works/vivarium/blob/feat/numpy-28287-and-repro-migration/docs/docs/repro/index.md) | new |
| [`.github/workflows/deploy-docs.yml`](https://github.com/aletheia-works/vivarium/blob/feat/numpy-28287-and-repro-migration/.github/workflows/deploy-docs.yml) | edit (URL move + redirects) |
| [`docs/docs/_meta.json`](https://github.com/aletheia-works/vivarium/blob/feat/numpy-28287-and-repro-migration/docs/docs/_meta.json) | edit (sidebar entry) |
| [`docs/docs/_nav.json`](https://github.com/aletheia-works/vivarium/blob/feat/numpy-28287-and-repro-migration/docs/docs/_nav.json) | edit (top-nav entry) |
| [`src/layer1_wasm/pandas-56679/README.md`](https://github.com/aletheia-works/vivarium/blob/feat/numpy-28287-and-repro-migration/src/layer1_wasm/pandas-56679/README.md) | edit (URL update) |

## Verification (Preview MCP, Chromium)

```bash
cd src/layer1_wasm
bun run typecheck   # 0 diagnostics
bun run build       # emits numpy-28287/repro.js + pandas-56679/repro.js
python -m http.server 8767  # serve src/layer1_wasm/ so ../_shared/ resolves
```

| Page | Surface | Got |
| --- | --- | --- |
| `/numpy-28287/` | `data-verdict` | `pass` |
| `/numpy-28287/` | `__VIVARIUM_VERDICT__` | `\"pass\"` |
| `/numpy-28287/` | bug | `{ project: \"numpy\", issue: 28287, ... }` |
| `/numpy-28287/` | runtime extras | `{ python: \"3.13.2\", numpy: \"2.2.5\" }` |
| `/numpy-28287/` | result | `{ x_lt_y: true, y_lt_z: true, x_lt_z: false, transitivity_violated: true }` |
| `/numpy-28287/` | visible text | starts with `reproduction succeeded — timedelta64 ordering is non-transitive` |
| `/numpy-28287/` | wall-clock first load | ~12 s |
| `/pandas-56679/` (regression) | `data-verdict` | `pass` |
| `/pandas-56679/` (regression) | result | `{ series_dtype: \"object\", df_dtype: \"float64\", mismatch: true }` |

## Review focus

- [x] [`numpy-28287/repro.ts`](https://github.com/aletheia-works/vivarium/blob/feat/numpy-28287-and-repro-migration/src/layer1_wasm/numpy-28287/repro.ts) — `packages: [\"numpy\"]` is required (numpy is shipped with Pyodide but must be loaded explicitly; first attempt without this flag failed locally).
- [x] [`deploy-docs.yml`](https://github.com/aletheia-works/vivarium/blob/feat/numpy-28287-and-repro-migration/.github/workflows/deploy-docs.yml) bundling step — heredoc indentation is correct (YAML literal block strips 10 leading spaces; heredoc terminator and content land at column 0 after strip).
- [x] [`repro/index.md`](https://github.com/aletheia-works/vivarium/blob/feat/numpy-28287-and-repro-migration/docs/docs/repro/index.md) — gallery copy reads cleanly for a first-time visitor; links resolve to the deployed URLs.
- [x] Legacy redirect at `/poc/pandas-56679/` will produce a usable single-hop redirect to `/repro/pandas-56679/` (only verifiable post-deploy).

## Process notes

- AI-authored: `ai: generated` label set.
- Out of scope: the seven remaining cloud-research bug candidates (each becomes its own per-bug Issue once the gallery shape is stable). Automating the gallery index (deferred per ADR-0008 § 3 until ~20 entries).