### PR TITLE
feat(ci): Playwright regression suite for the Layer 1 reproduction gallery

### DIFF
--- a/.github/workflows/repro-regression.yml
+++ b/.github/workflows/repro-regression.yml
@@ -1,0 +1,102 @@
+name: repro-regression
+
+# Regression test for the Layer 1 reproduction gallery.
+#
+# Runs the Playwright suite under `src/layer1_wasm/tests/` against a
+# locally-served copy of the gallery, asserting that each reproduction
+# page reaches its documented verdict and exposes the vivarium contract
+# v1 surface (DOM `#verdict[data-verdict]`, `__VIVARIUM_VERDICT__`,
+# `__VIVARIUM_RESULT__`, `<meta name="vivarium-contract">`).
+#
+# A `pass` verdict means the upstream bug still reproduces on the
+# bundled Pyodide build; a `fail` verdict means either the upstream
+# project shipped a fix that Pyodide picked up, or the runtime
+# regressed. Either case is signal — the workflow turns it into a
+# loud red CI failure so a human can decide what to do (retire the
+# page, file an upstream-fix-detection Issue, etc.).
+#
+# Triggers:
+# - `push` to `main` touching Layer 1 sources / this workflow / the
+#   deploy workflow — fast feedback when contributors break things.
+# - `pull_request` touching the same paths — reviewers see the result
+#   on the PR.
+# - Weekly schedule — catches Pyodide-bundle drift even when the repo
+#   itself is quiet, so an upstream fix that lands a month after our
+#   last commit still surfaces within ~7 days.
+# - `workflow_dispatch` — manual trigger from the Actions tab.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/layer1_wasm/**'
+      - '.github/workflows/repro-regression.yml'
+      - '.github/workflows/deploy-docs.yml'
+  pull_request:
+    paths:
+      - 'src/layer1_wasm/**'
+      - '.github/workflows/repro-regression.yml'
+      - '.github/workflows/deploy-docs.yml'
+  schedule:
+    # Mondays at 00:00 UTC.
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repro-regression-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: src/layer1_wasm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install Layer 1 dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type-check (sources + tests)
+        # Catches any TypeScript-level regression before we boot a
+        # browser. Cheap (~1 s) and produces a clear diagnostic on
+        # failure.
+        run: bun run typecheck
+
+      - name: Build Layer 1 TypeScript sources
+        # Emits side-by-side `.js` files; the static server serves
+        # them at runtime.
+        run: bun run build
+
+      - name: Install Playwright browsers
+        # `--with-deps` brings in the system libraries Chromium needs
+        # (libnss3, libatk-bridge, etc.). The runner is fresh so the
+        # apt step is unavoidable; total step time is ~30 s.
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run Playwright regression suite
+        # `playwright.config.ts` auto-starts `python -m http.server`
+        # on the layer1 root, so the test cases can hit
+        # `/_shared/_test/`, `/pandas-56679/`, `/numpy-28287/`.
+        # Python 3 is preinstalled on `ubuntu-latest` runners.
+        run: bun run test
+        env:
+          CI: 'true'
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report-${{ github.run_id }}
+          path: src/layer1_wasm/playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -65,12 +65,18 @@ dist/
 
 # Layer 1 sources are .ts; tsc emits .js / .js.map alongside the source.
 # Only the .ts source belongs in version control.
-# (`.mjs` files such as pandas-56679/repro.mjs are NOT matched here — that
-# PoC is still pre-retrofit and remains tracked.)
 src/layer1_wasm/**/*.js
 src/layer1_wasm/**/*.js.map
 src/layer1_wasm/**/*.d.ts
 src/layer1_wasm/**/*.d.ts.map
+# `playwright.config.ts` IS tracked — `*.ts` is fine, only generated
+# `*.js` next to it would be excluded.
+
+# Playwright run artefacts (test reports, traces, screenshots).
+src/layer1_wasm/playwright-report/
+src/layer1_wasm/test-results/
+src/layer1_wasm/blob-report/
+src/layer1_wasm/.last-run.json
 
 # ─── rspress ─────────────────────────────────
 doc_build/

--- a/src/layer1_wasm/bun.lock
+++ b/src/layer1_wasm/bun.lock
@@ -5,11 +5,25 @@
     "": {
       "name": "@aletheia-works/vivarium-layer1",
       "devDependencies": {
+        "@playwright/test": "^1.49.1",
+        "@types/node": "^22.10.5",
         "typescript": "^5.7.2",
       },
     },
   },
   "packages": {
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
+
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
   }
 }

--- a/src/layer1_wasm/package.json
+++ b/src/layer1_wasm/package.json
@@ -2,14 +2,17 @@
   "name": "@aletheia-works/vivarium-layer1",
   "version": "0.0.0",
   "private": true,
-  "description": "Layer 1 (browser-native WASM) reproduction sources for Vivarium. TypeScript sources transpile 1:1 to side-by-side .js files served as ES modules.",
+  "description": "Layer 1 (browser-native WASM) reproduction sources for Vivarium. TypeScript sources transpile 1:1 to side-by-side .js files served as ES modules. Playwright tests assert each reproduction's contract-v1 verdict on every push and on a weekly schedule.",
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "watch": "tsc -p tsconfig.json --watch",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tests/tsconfig.json",
+    "test": "playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.1",
+    "@types/node": "^22.10.5",
     "typescript": "^5.7.2"
   }
 }

--- a/src/layer1_wasm/playwright.config.ts
+++ b/src/layer1_wasm/playwright.config.ts
@@ -1,0 +1,68 @@
+// Playwright configuration for the Layer 1 reproduction-regression suite.
+//
+// What this suite asserts (per the maintainer-private ADR-0008 notes):
+// - Every reproduction page declares `<meta name="vivarium-contract"
+//   content="v1">`.
+// - The DOM verdict, the `__VIVARIUM_VERDICT__` global, and the
+//   `__VIVARIUM_RESULT__` envelope all reach a `pass` state on the
+//   bundled Pyodide runtime, matching what the page documents.
+// - The smoke test under `_shared/_test/` reaches `pass` without
+//   loading Pyodide.
+//
+// The suite is intentionally serial: Pyodide instances are heavy
+// (hundreds of MB resident) and parallel runs OOM on standard CI
+// runners. With 2-3 cases the wall-clock cost is ~30-60 s, well
+// inside the workflow's 15-minute budget.
+
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 8767;
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: false,
+  workers: 1,
+
+  // Retry once in CI to absorb transient CDN flakes (jsDelivr fetch
+  // failures, Pyodide cold-start jitter). Locally retries hide bugs;
+  // run them once and fix.
+  retries: process.env["CI"] ? 1 : 0,
+
+  // Per-test timeout. Pyodide cold-load + pandas wheel can sit in the
+  // 25-30 s range on CI runners; double that for headroom.
+  timeout: 90_000,
+
+  reporter: process.env["CI"]
+    ? [["github"], ["html", { open: "never" }]]
+    : [["list"]],
+
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    actionTimeout: 60_000,
+    navigationTimeout: 60_000,
+    // Capture trace + screenshot only on failure; keeps successful runs
+    // cheap.
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+
+  // Auto-start a static HTTP server on the layer1 root so test cases
+  // can hit `/_shared/_test/`, `/pandas-56679/`, `/numpy-28287/`. The
+  // server is reused across test runs locally; CI starts a fresh one
+  // each job.
+  webServer: {
+    command: `python -m http.server ${PORT}`,
+    url: `http://localhost:${PORT}/`,
+    reuseExistingServer: !process.env["CI"],
+    timeout: 30_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/src/layer1_wasm/tests/repro.spec.ts
+++ b/src/layer1_wasm/tests/repro.spec.ts
@@ -1,0 +1,148 @@
+// Regression suite for the Layer 1 reproduction gallery.
+//
+// Each case asserts that a page in `src/layer1_wasm/` reaches its
+// expected verdict on the bundled Pyodide runtime, and that the
+// vivarium contract v1 surface (`#verdict[data-verdict]`,
+// `__VIVARIUM_VERDICT__`, `__VIVARIUM_RESULT__`,
+// `<meta name="vivarium-contract">`) is published correctly.
+//
+// When the verdict an upstream-bug page produces flips from `pass`
+// to `fail`, that is a real signal: either the upstream project
+// merged a fix and Pyodide picked it up, or the runtime regressed.
+// Either way, this suite turns that into a CI failure so a human
+// can decide whether to update / retire the page or file an
+// upstream-fix-detection Issue.
+
+import { expect, test, type Page } from "@playwright/test";
+
+interface ReproCase {
+  /** Display name used in the test title. */
+  name: string;
+  /** URL path served by Playwright's webServer (relative to baseURL). */
+  path: string;
+  /** Expected verdict — currently "pass" for every case (reproduces). */
+  expectedVerdict: "pass" | "fail";
+  /** Envelope `bug.project` field. */
+  expectedBugProject: string;
+  /** Envelope `bug.issue` field. */
+  expectedBugIssue: number;
+  /**
+   * `true` for pages that load Pyodide; the verdict can take 30+ s.
+   * `false` for the smoke test, which validates plumbing only and
+   * resolves in well under a second.
+   */
+  loadsPyodide: boolean;
+}
+
+const cases: ReproCase[] = [
+  {
+    name: "_shared/_test smoke test",
+    path: "/_shared/_test/",
+    expectedVerdict: "pass",
+    expectedBugProject: "vivarium",
+    expectedBugIssue: 0,
+    loadsPyodide: false,
+  },
+  {
+    name: "pandas-56679 reproduction",
+    path: "/pandas-56679/",
+    expectedVerdict: "pass",
+    expectedBugProject: "pandas",
+    expectedBugIssue: 56679,
+    loadsPyodide: true,
+  },
+  {
+    name: "numpy-28287 reproduction",
+    path: "/numpy-28287/",
+    expectedVerdict: "pass",
+    expectedBugProject: "numpy",
+    expectedBugIssue: 28287,
+    loadsPyodide: true,
+  },
+];
+
+interface VivariumPageState {
+  verdict: string | undefined;
+  contract: string | undefined;
+  bugProject: string | undefined;
+  bugIssue: number | undefined;
+  runtimeName: string | undefined;
+}
+
+async function readVivariumState(page: Page): Promise<VivariumPageState> {
+  return page.evaluate(() => {
+    interface VivariumGlobals {
+      __VIVARIUM_VERDICT__?: string;
+      __VIVARIUM_RESULT__?: {
+        contract?: string;
+        bug?: { project?: string; issue?: number };
+        runtime?: { name?: string };
+      };
+    }
+    const g = globalThis as unknown as VivariumGlobals;
+    return {
+      verdict: g.__VIVARIUM_VERDICT__,
+      contract: g.__VIVARIUM_RESULT__?.contract,
+      bugProject: g.__VIVARIUM_RESULT__?.bug?.project,
+      bugIssue: g.__VIVARIUM_RESULT__?.bug?.issue,
+      runtimeName: g.__VIVARIUM_RESULT__?.runtime?.name,
+    };
+  });
+}
+
+for (const c of cases) {
+  test(`${c.name} produces ${c.expectedVerdict}`, async ({ page }) => {
+    await page.goto(c.path);
+
+    // Wait for the verdict to settle. Pages start at `pending` and
+    // transition to `pass` or `fail` once the reproduction (or the
+    // smoke-test plumbing) completes.
+    await page.waitForFunction(
+      () => {
+        const v = (
+          globalThis as unknown as { __VIVARIUM_VERDICT__?: string }
+        ).__VIVARIUM_VERDICT__;
+        return v === "pass" || v === "fail";
+      },
+      undefined,
+      { timeout: c.loadsPyodide ? 75_000 : 10_000 },
+    );
+
+    const state = await readVivariumState(page);
+
+    expect.soft(state.verdict, "DOM/global verdict").toBe(c.expectedVerdict);
+    expect.soft(state.contract, "envelope contract").toBe("v1");
+    expect
+      .soft(state.bugProject, "envelope bug.project")
+      .toBe(c.expectedBugProject);
+    expect
+      .soft(state.bugIssue, "envelope bug.issue")
+      .toBe(c.expectedBugIssue);
+
+    // Cross-check the DOM `data-verdict` attribute matches the global —
+    // they are written together by `setVerdict`, and a divergence would
+    // indicate the helpers got out of sync.
+    const domVerdict = await page
+      .locator("#verdict")
+      .getAttribute("data-verdict");
+    expect.soft(domVerdict, "#verdict[data-verdict]").toBe(c.expectedVerdict);
+
+    // Sanity: the page declares the contract version via meta tag.
+    const contractMeta = await page
+      .locator('meta[name="vivarium-contract"]')
+      .getAttribute("content");
+    expect.soft(contractMeta, "<meta vivarium-contract>").toBe("v1");
+
+    // Pyodide-loading pages should report a pyodide runtime; the smoke
+    // test should not (it explicitly skips the runtime).
+    if (c.loadsPyodide) {
+      expect
+        .soft(state.runtimeName, "envelope runtime.name")
+        .toBe("pyodide");
+    } else {
+      expect
+        .soft(state.runtimeName, "envelope runtime.name (smoke)")
+        .not.toBe("pyodide");
+    }
+  });
+}

--- a/src/layer1_wasm/tests/tsconfig.json
+++ b/src/layer1_wasm/tests/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["@playwright/test", "node"],
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["**/*.ts", "../playwright.config.ts"],
+  "exclude": ["node_modules"]
+}

--- a/src/layer1_wasm/tsconfig.json
+++ b/src/layer1_wasm/tsconfig.json
@@ -25,5 +25,11 @@
     "verbatimModuleSyntax": true
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "**/*.mjs", "**/*.js"]
+  "exclude": [
+    "node_modules",
+    "**/*.mjs",
+    "**/*.js",
+    "tests/**",
+    "playwright.config.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

- Add a Playwright regression suite under [`src/layer1_wasm/tests/`](https://github.com/aletheia-works/vivarium/tree/feat/playwright-regression/src/layer1_wasm/tests) that asserts every reproduction page reaches its expected `pass` verdict and exposes the contract-v1 surface correctly.
- New [`repro-regression.yml`](https://github.com/aletheia-works/vivarium/blob/feat/playwright-regression/.github/workflows/repro-regression.yml) workflow runs the suite on every push / PR touching Layer 1 sources, on a weekly schedule, and on manual dispatch. Failure surfaces a red CI status plus an uploaded Playwright HTML report.
- Vivarium is a test platform; this commit closes the loop where the platform itself had no tests of its own.

Closes #71.

## What gets asserted

For each of three cases — `_shared/_test/` (smoke), `pandas-56679/`, `numpy-28287/` — the suite checks:

| Surface | Assertion |
| --- | --- |
| `__VIVARIUM_VERDICT__` | matches case-specific `expected` (currently `\"pass\"` everywhere) |
| `__VIVARIUM_RESULT__.contract` | `\"v1\"` |
| `__VIVARIUM_RESULT__.bug.project` / `.bug.issue` | matches case (e.g. `\"numpy\"` / `28287`) |
| `__VIVARIUM_RESULT__.runtime.name` | `\"pyodide\"` for upstream-bug pages, anything else for the smoke test |
| `#verdict[data-verdict]` | matches the global verdict (catches helper-internal divergence) |
| `<meta name=\"vivarium-contract\">` | `\"v1\"` |

`expect.soft` is used so a single page surfaces every failed assertion in one run, not just the first one.

## What changes

| File | Status | Notes |
| --- | --- | --- |
| [`src/layer1_wasm/tests/repro.spec.ts`](https://github.com/aletheia-works/vivarium/blob/feat/playwright-regression/src/layer1_wasm/tests/repro.spec.ts) | new | 3 cases driven by a `cases[]` array — adding a 4th page is one entry. |
| [`src/layer1_wasm/tests/tsconfig.json`](https://github.com/aletheia-works/vivarium/blob/feat/playwright-regression/src/layer1_wasm/tests/tsconfig.json) | new | `noEmit: true`, Node target, `@playwright/test` + `@types/node` ambient types. |
| [`src/layer1_wasm/playwright.config.ts`](https://github.com/aletheia-works/vivarium/blob/feat/playwright-regression/src/layer1_wasm/playwright.config.ts) | new | chromium-only; `workers: 1` so parallel Pyodide instances do not OOM CI runners; auto-starts `python -m http.server 8767` so cases hit the gallery locally. |
| [`src/layer1_wasm/package.json`](https://github.com/aletheia-works/vivarium/blob/feat/playwright-regression/src/layer1_wasm/package.json) | edit | `@playwright/test` + `@types/node` devDeps; `test` script; `typecheck` now covers both tsconfigs. |
| [`src/layer1_wasm/tsconfig.json`](https://github.com/aletheia-works/vivarium/blob/feat/playwright-regression/src/layer1_wasm/tsconfig.json) | edit | `tests/` and `playwright.config.ts` excluded so build emission stays scoped to reproduction sources. |
| [`.gitignore`](https://github.com/aletheia-works/vivarium/blob/feat/playwright-regression/.gitignore) | edit | Playwright run artefacts (`playwright-report/`, `test-results/`, `blob-report/`, `.last-run.json`). |
| [`.github/workflows/repro-regression.yml`](https://github.com/aletheia-works/vivarium/blob/feat/playwright-regression/.github/workflows/repro-regression.yml) | new | Triggers: push/PR on Layer 1 paths, weekly Monday 00:00 UTC cron, `workflow_dispatch`. 15 min timeout. Pinned action commits match the existing repo conventions. |

## Verification (local — Bun 1.3.11 on Windows)

```bash
cd src/layer1_wasm
bun install                          # resolves @playwright/test 1.59.1
bun run typecheck                    # 0 diagnostics across both tsconfigs
bun run build                        # emits side-by-side .js (unchanged)
bunx playwright install chromium     # downloads 111 MiB headless shell
bun run test                         # 3 passed (38.8 s)
```

Per-case timing on a warm local machine:

- `_shared/_test smoke test produces pass` — 2.3 s
- `pandas-56679 reproduction produces pass` — 18.1 s
- `numpy-28287 reproduction produces pass` — 8.7 s

## Why these scope choices

- **No auto-Issue-on-failure (yet):** transient CDN flakes (jsDelivr) could spam the tracker. Start with red CI + retained HTML report; revisit if the noise/value ratio justifies layering it on. The same pattern Terraform-apply uses for production failures is available for reuse later.
- **No cross-browser runs:** Firefox / WebKit add real coverage but also OOM risk, browser-install time, and flake surface. Chromium-only first; cross-browser is a separate Issue if we choose to chase it.
- **Local server, not deployed URLs:** the deployed gallery is at `https://aletheia-works.github.io/vivarium/repro/...`, but pointing the suite there couples our test signal to GitHub Pages cache propagation. A freshly-built local copy gives the same verdict signal without the flake surface.

## Review focus

- [ ] [`playwright.config.ts`](https://github.com/aletheia-works/vivarium/blob/feat/playwright-regression/src/layer1_wasm/playwright.config.ts) — `webServer.command` and base URL are correct for the layer1 root path. `workers: 1` is justified by the OOM concern.
- [ ] [`repro.spec.ts`](https://github.com/aletheia-works/vivarium/blob/feat/playwright-regression/src/layer1_wasm/tests/repro.spec.ts) — the case table is exhaustive (matches every page under `src/layer1_wasm/` that has an `index.html`).
- [ ] [`repro-regression.yml`](https://github.com/aletheia-works/vivarium/blob/feat/playwright-regression/.github/workflows/repro-regression.yml) — actions are pinned to commits matching the existing allowlist; `--with-deps` on `playwright install` is necessary on `ubuntu-latest`.
- [ ] [`tsconfig.json`](https://github.com/aletheia-works/vivarium/blob/feat/playwright-regression/src/layer1_wasm/tsconfig.json) exclusion of `tests/` is correct — build emission still produces only the side-by-side `.js` for reproduction sources.

## Process notes

- AI-authored: `ai: generated` label set on this PR.
- 4th and later pages drop into the `cases[]` array — adding a reproduction does not require touching the workflow or the config.
- The first run on `main` after this lands will be the canonical record of "yes, both pages still reproduce as of today" — useful baseline for the weekly cron's diff.