### PR TITLE
ci(project): track Opened At / Closed At date fields for issues

### DIFF
--- a/.github/workflows/project-fields-backfill.yml
+++ b/.github/workflows/project-fields-backfill.yml
@@ -1,9 +1,15 @@
 name: Project fields backfill
 
-# One-shot (re-runnable) backfill of Started At / Merged At date fields
-# on the org-level vivarium roadmap board for every PR that already
-# exists in this repo. Mirrors `.github/workflows/project-fields.yml`,
-# but iterates all historical PRs instead of reacting to a single event.
+# One-shot (re-runnable) backfill of date fields on the org-level
+# vivarium roadmap board for every PR *and* issue that already exists in
+# this repo. Mirrors `.github/workflows/project-fields.yml`, but
+# iterates the full historical list instead of reacting to single events.
+#
+# Field mapping matches the live workflow:
+#
+#   PRs    : Started At ← createdAt;  Merged At ← mergedAt (state == MERGED)
+#   Issues : Opened At  ← createdAt;  Closed At ← closedAt (state == CLOSED
+#                                     and stateReason == COMPLETED)
 #
 # Trigger: Actions tab → "Project fields backfill" → Run workflow →
 # type "yes" in the confirm input → Run workflow.
@@ -16,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: 'Type "yes" to confirm. Rewrites Started At / Merged At for every PR in the repo.'
+        description: 'Type "yes" to confirm. Rewrites date fields for every PR and issue in the repo.'
         required: true
         default: 'no'
 
@@ -26,23 +32,25 @@ env:
   GH_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
   PROJECT_OWNER: aletheia-works
   PROJECT_NUMBER: "1"
-  STARTED_FIELD_NAME: Started At
-  MERGED_FIELD_NAME: Merged At
+  PR_STARTED_FIELD_NAME: Started At
+  PR_MERGED_FIELD_NAME: Merged At
+  ISSUE_OPENED_FIELD_NAME: Opened At
+  ISSUE_CLOSED_FIELD_NAME: Closed At
 
 jobs:
   backfill:
     if: inputs.confirm == 'yes'
-    name: Backfill date fields for all PRs
+    name: Backfill date fields for all PRs and issues
     runs-on: ubuntu-latest
 
     steps:
-      - name: Resolve project + field IDs and rewrite per-PR dates
+      - name: Resolve project + field IDs and rewrite per-item dates
         env:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          # 1. Resolve project ID and the two date field IDs by name.
+          # 1. Resolve project ID and the four date field IDs by name.
           project_data=$(gh api graphql \
             -f owner="$PROJECT_OWNER" \
             -F number="$PROJECT_NUMBER" \
@@ -65,41 +73,37 @@ jobs:
               }')
 
           PROJECT_ID=$(echo "$project_data" | jq -r '.data.organization.projectV2.id')
-          STARTED_FIELD_ID=$(echo "$project_data" \
-            | jq -r --arg n "$STARTED_FIELD_NAME" \
-                '.data.organization.projectV2.fields.nodes[] | select(.name == $n and .dataType == "DATE") | .id')
-          MERGED_FIELD_ID=$(echo "$project_data" \
-            | jq -r --arg n "$MERGED_FIELD_NAME" \
-                '.data.organization.projectV2.fields.nodes[] | select(.name == $n and .dataType == "DATE") | .id')
+          resolve_field_id() {
+            echo "$project_data" \
+              | jq -r --arg n "$1" \
+                  '.data.organization.projectV2.fields.nodes[] | select(.name == $n and .dataType == "DATE") | .id'
+          }
+          PR_STARTED_FIELD_ID=$(resolve_field_id "$PR_STARTED_FIELD_NAME")
+          PR_MERGED_FIELD_ID=$(resolve_field_id "$PR_MERGED_FIELD_NAME")
+          ISSUE_OPENED_FIELD_ID=$(resolve_field_id "$ISSUE_OPENED_FIELD_NAME")
+          ISSUE_CLOSED_FIELD_ID=$(resolve_field_id "$ISSUE_CLOSED_FIELD_NAME")
 
           if [[ -z "$PROJECT_ID" || "$PROJECT_ID" == "null" ]]; then
             echo "Could not resolve $PROJECT_OWNER/projects/$PROJECT_NUMBER (token scope?)." >&2
             exit 1
           fi
-          if [[ -z "$STARTED_FIELD_ID" || -z "$MERGED_FIELD_ID" ]]; then
-            echo "Date fields '$STARTED_FIELD_NAME' / '$MERGED_FIELD_NAME' not found on project." >&2
-            exit 1
-          fi
+          for pair in \
+            "$PR_STARTED_FIELD_NAME=$PR_STARTED_FIELD_ID" \
+            "$PR_MERGED_FIELD_NAME=$PR_MERGED_FIELD_ID" \
+            "$ISSUE_OPENED_FIELD_NAME=$ISSUE_OPENED_FIELD_ID" \
+            "$ISSUE_CLOSED_FIELD_NAME=$ISSUE_CLOSED_FIELD_ID"; do
+            name="${pair%=*}"
+            id="${pair#*=}"
+            if [[ -z "$id" ]]; then
+              echo "Date field '$name' not found on project." >&2
+              exit 1
+            fi
+          done
 
-          # 2. Pull the full PR list with the metadata we need. `--state all`
-          # covers open + closed (merged or not).
-          prs=$(gh pr list --repo "$REPO" --state all --limit 2000 \
-            --json number,id,createdAt,mergedAt,state)
-
-          count=$(echo "$prs" | jq 'length')
-          echo "Backfilling $count PRs."
-
-          # 3. For each PR: ensure on board, then write Started At and
-          # (if merged) Merged At. Process substitution keeps the loop in
-          # the parent shell so `set -e` can halt on any per-PR failure.
-          while IFS= read -r pr; do
-            number=$(echo "$pr" | jq -r '.number')
-            content_id=$(echo "$pr" | jq -r '.id')
-            created_date=$(echo "$pr" | jq -r '.createdAt' | cut -d'T' -f1)
-            state=$(echo "$pr" | jq -r '.state')
-            merged_at=$(echo "$pr" | jq -r '.mergedAt')
-
-            add_result=$(gh api graphql \
+          # Helpers shared between the PR and issue loops below.
+          add_to_project() {
+            local content_id="$1"
+            gh api graphql \
               -f projectId="$PROJECT_ID" \
               -f contentId="$content_id" \
               -f query='
@@ -107,14 +111,16 @@ jobs:
                   addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
                     item { id }
                   }
-                }')
-            item_id=$(echo "$add_result" | jq -r '.data.addProjectV2ItemById.item.id')
-
+                }' \
+              | jq -r '.data.addProjectV2ItemById.item.id'
+          }
+          set_date_field() {
+            local item_id="$1" field_id="$2" date_value="$3"
             gh api graphql \
               -f projectId="$PROJECT_ID" \
               -f itemId="$item_id" \
-              -f fieldId="$STARTED_FIELD_ID" \
-              -f date="$created_date" \
+              -f fieldId="$field_id" \
+              -f date="$date_value" \
               -f query='
                 mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
                   updateProjectV2ItemFieldValue(input: {
@@ -126,29 +132,63 @@ jobs:
                     projectV2Item { id }
                   }
                 }' >/dev/null
+          }
+
+          # 2. Pull all PRs.
+          prs=$(gh pr list --repo "$REPO" --state all --limit 2000 \
+            --json number,id,createdAt,mergedAt,state)
+          pr_count=$(echo "$prs" | jq 'length')
+          echo "Backfilling $pr_count PRs."
+
+          # Process substitution keeps the loop in the parent shell so
+          # `set -e` halts the whole job on any per-item failure.
+          while IFS= read -r pr; do
+            number=$(echo "$pr" | jq -r '.number')
+            content_id=$(echo "$pr" | jq -r '.id')
+            created_date=$(echo "$pr" | jq -r '.createdAt' | cut -d'T' -f1)
+            state=$(echo "$pr" | jq -r '.state')
+            merged_at=$(echo "$pr" | jq -r '.mergedAt')
+
+            item_id=$(add_to_project "$content_id")
+            set_date_field "$item_id" "$PR_STARTED_FIELD_ID" "$created_date"
 
             if [[ "$state" == "MERGED" ]]; then
               merged_date=$(echo "$merged_at" | cut -d'T' -f1)
-              gh api graphql \
-                -f projectId="$PROJECT_ID" \
-                -f itemId="$item_id" \
-                -f fieldId="$MERGED_FIELD_ID" \
-                -f date="$merged_date" \
-                -f query='
-                  mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
-                    updateProjectV2ItemFieldValue(input: {
-                      projectId: $projectId
-                      itemId: $itemId
-                      fieldId: $fieldId
-                      value: { date: $date }
-                    }) {
-                      projectV2Item { id }
-                    }
-                  }' >/dev/null
+              set_date_field "$item_id" "$PR_MERGED_FIELD_ID" "$merged_date"
               echo "PR #$number: Started=$created_date, Merged=$merged_date"
             else
-              echo "PR #$number: Started=$created_date (open / unmerged)"
+              echo "PR #$number: Started=$created_date (state=$state)"
             fi
           done < <(echo "$prs" | jq -c '.[]')
+
+          # 3. Pull all issues. `gh issue list` already excludes PRs.
+          issues=$(gh issue list --repo "$REPO" --state all --limit 2000 \
+            --json number,id,createdAt,closedAt,state,stateReason)
+          issue_count=$(echo "$issues" | jq 'length')
+          echo "Backfilling $issue_count issues."
+
+          while IFS= read -r issue; do
+            number=$(echo "$issue" | jq -r '.number')
+            content_id=$(echo "$issue" | jq -r '.id')
+            created_date=$(echo "$issue" | jq -r '.createdAt' | cut -d'T' -f1)
+            state=$(echo "$issue" | jq -r '.state')
+            state_reason=$(echo "$issue" | jq -r '.stateReason')
+            closed_at=$(echo "$issue" | jq -r '.closedAt')
+
+            item_id=$(add_to_project "$content_id")
+            set_date_field "$item_id" "$ISSUE_OPENED_FIELD_ID" "$created_date"
+
+            # gh's GraphQL output capitalises enum values: state ∈
+            # {OPEN, CLOSED}, stateReason ∈ {COMPLETED, NOT_PLANNED,
+            # REOPENED, null}. Webhook payload uses the lowercase form
+            # (handled in project-fields.yml).
+            if [[ "$state" == "CLOSED" && "$state_reason" == "COMPLETED" ]]; then
+              closed_date=$(echo "$closed_at" | cut -d'T' -f1)
+              set_date_field "$item_id" "$ISSUE_CLOSED_FIELD_ID" "$closed_date"
+              echo "Issue #$number: Opened=$created_date, Closed=$closed_date"
+            else
+              echo "Issue #$number: Opened=$created_date (state=$state, reason=${state_reason:-null})"
+            fi
+          done < <(echo "$issues" | jq -c '.[]')
 
           echo "Backfill complete."

--- a/.github/workflows/project-fields.yml
+++ b/.github/workflows/project-fields.yml
@@ -1,26 +1,36 @@
 name: Project field updates
 
-# Updates two date fields on the org-level Projects v2 board
-# (`aletheia-works/projects/1`, "vivarium roadmap") for every PR on this
-# repo:
+# Updates per-item date fields on the org-level Projects v2 board
+# (`aletheia-works/projects/1`, "vivarium roadmap"). The board hosts both
+# pull requests and issues, with a separate field pair per content type
+# so each Roadmap view can use vocabulary that fits the lifecycle:
 #
-#   • Started At — set when the PR is opened. Marks the start of work
-#     on the implementation.
-#   • Merged At  — set when the PR is closed *and* merged. Closed-without-
-#     merge is skipped (no value written); the PR simply has no Merged At.
+#   Pull requests
+#     • Started At — set on `pull_request_target: opened`.
+#     • Merged At  — set on `pull_request_target: closed` *and* merged.
+#                    Closed-without-merge is skipped (no value written).
 #
-# The Roadmap view groups by milestone (the swimlane axis, defined in
-# `infra/github/milestones.tf`) and uses Started At / Merged At as the
-# date axis. Milestones are deliberately *not* updated per PR; phase
+#   Issues
+#     • Opened At — set on `issues: opened`.
+#     • Closed At — set on `issues: closed` *and* `state_reason ==
+#                   "completed"`. `not_planned` is skipped (no value
+#                   written), mirroring the PR closed-without-merge rule.
+#
+# The two Roadmap views (one filtered to `is:pr`, one to `is:issue`) use
+# their respective field pair as the date axis, while sharing the
+# milestone swimlanes defined in `infra/github/milestones.tf`.
+# Milestones themselves are deliberately *not* updated per item; phase
 # boundaries stay directional.
 #
-# The default GITHUB_TOKEN cannot write to org-scoped Projects v2, so a
+# The default GITHUB_TOKEN cannot mutate org-scoped Projects v2, so a
 # fine-grained PAT scoped to `aletheia-works` (Organization permissions
 # → Projects: Read and write) is read from the PROJECTS_TOKEN secret.
 # See docs/ai-workflow.md for the setup walkthrough.
 
 on:
   pull_request_target:
+    types: [opened, closed]
+  issues:
     types: [opened, closed]
 
 permissions: {}
@@ -29,8 +39,10 @@ env:
   GH_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
   PROJECT_OWNER: aletheia-works
   PROJECT_NUMBER: "1"
-  STARTED_FIELD_NAME: Started At
-  MERGED_FIELD_NAME: Merged At
+  PR_STARTED_FIELD_NAME: Started At
+  PR_MERGED_FIELD_NAME: Merged At
+  ISSUE_OPENED_FIELD_NAME: Opened At
+  ISSUE_CLOSED_FIELD_NAME: Closed At
 
 jobs:
   update-fields:
@@ -38,22 +50,76 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Write Started At / Merged At
+      - name: Write date field
         env:
+          EVENT_NAME: ${{ github.event_name }}
           ACTION: ${{ github.event.action }}
           PR_NODE_ID: ${{ github.event.pull_request.node_id }}
           PR_OPENED_AT: ${{ github.event.pull_request.created_at }}
           PR_MERGED_AT: ${{ github.event.pull_request.merged_at }}
           PR_MERGED: ${{ github.event.pull_request.merged }}
+          ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+          ISSUE_OPENED_AT: ${{ github.event.issue.created_at }}
+          ISSUE_CLOSED_AT: ${{ github.event.issue.closed_at }}
+          ISSUE_STATE_REASON: ${{ github.event.issue.state_reason }}
         run: |
           set -euo pipefail
 
-          if [[ "$ACTION" == "closed" && "$PR_MERGED" != "true" ]]; then
-            echo "PR closed without merging; nothing to update."
-            exit 0
-          fi
+          # 1. Decide what to write based on the triggering event/action.
+          # CONTENT_ID, FIELD_NAME, DATE_VALUE are the three pieces the
+          # downstream GraphQL flow needs.
+          case "$EVENT_NAME" in
+            pull_request_target)
+              CONTENT_ID="$PR_NODE_ID"
+              case "$ACTION" in
+                opened)
+                  FIELD_NAME="$PR_STARTED_FIELD_NAME"
+                  DATE_VALUE="${PR_OPENED_AT%%T*}"
+                  ;;
+                closed)
+                  if [[ "$PR_MERGED" != "true" ]]; then
+                    echo "PR closed without merging; nothing to update."
+                    exit 0
+                  fi
+                  FIELD_NAME="$PR_MERGED_FIELD_NAME"
+                  DATE_VALUE="${PR_MERGED_AT%%T*}"
+                  ;;
+                *)
+                  echo "Unhandled PR action: $ACTION" >&2
+                  exit 0
+                  ;;
+              esac
+              ;;
+            issues)
+              CONTENT_ID="$ISSUE_NODE_ID"
+              case "$ACTION" in
+                opened)
+                  FIELD_NAME="$ISSUE_OPENED_FIELD_NAME"
+                  DATE_VALUE="${ISSUE_OPENED_AT%%T*}"
+                  ;;
+                closed)
+                  # `state_reason` is lowercase in the issues webhook
+                  # payload (completed | not_planned | reopened | null).
+                  if [[ "$ISSUE_STATE_REASON" != "completed" ]]; then
+                    echo "Issue closed as '${ISSUE_STATE_REASON:-null}' (not completed); nothing to update."
+                    exit 0
+                  fi
+                  FIELD_NAME="$ISSUE_CLOSED_FIELD_NAME"
+                  DATE_VALUE="${ISSUE_CLOSED_AT%%T*}"
+                  ;;
+                *)
+                  echo "Unhandled issue action: $ACTION" >&2
+                  exit 0
+                  ;;
+              esac
+              ;;
+            *)
+              echo "Unhandled event: $EVENT_NAME" >&2
+              exit 0
+              ;;
+          esac
 
-          # 1. Resolve project ID and the two date field IDs by name.
+          # 2. Resolve project ID and the target field ID.
           project_data=$(gh api graphql \
             -f owner="$PROJECT_OWNER" \
             -F number="$PROJECT_NUMBER" \
@@ -76,28 +142,25 @@ jobs:
               }')
 
           PROJECT_ID=$(echo "$project_data" | jq -r '.data.organization.projectV2.id')
-          STARTED_FIELD_ID=$(echo "$project_data" \
-            | jq -r --arg n "$STARTED_FIELD_NAME" \
-                '.data.organization.projectV2.fields.nodes[] | select(.name == $n and .dataType == "DATE") | .id')
-          MERGED_FIELD_ID=$(echo "$project_data" \
-            | jq -r --arg n "$MERGED_FIELD_NAME" \
+          FIELD_ID=$(echo "$project_data" \
+            | jq -r --arg n "$FIELD_NAME" \
                 '.data.organization.projectV2.fields.nodes[] | select(.name == $n and .dataType == "DATE") | .id')
 
           if [[ -z "$PROJECT_ID" || "$PROJECT_ID" == "null" ]]; then
             echo "Could not resolve $PROJECT_OWNER/projects/$PROJECT_NUMBER (token scope?)." >&2
             exit 1
           fi
-          if [[ -z "$STARTED_FIELD_ID" || -z "$MERGED_FIELD_ID" ]]; then
-            echo "Date fields '$STARTED_FIELD_NAME' / '$MERGED_FIELD_NAME' not found on project." >&2
+          if [[ -z "$FIELD_ID" ]]; then
+            echo "Date field '$FIELD_NAME' not found on project." >&2
             exit 1
           fi
 
-          # 2. Add the PR to the board. addProjectV2ItemById is idempotent
-          # and returns the existing item if Auto-add already inserted it,
-          # so this race is harmless.
+          # 3. Add the item to the board. addProjectV2ItemById is
+          # idempotent and returns the existing item if Auto-add already
+          # inserted it, so this race is harmless.
           add_result=$(gh api graphql \
             -f projectId="$PROJECT_ID" \
-            -f contentId="$PR_NODE_ID" \
+            -f contentId="$CONTENT_ID" \
             -f query='
               mutation($projectId: ID!, $contentId: ID!) {
                 addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
@@ -105,22 +168,6 @@ jobs:
                 }
               }')
           ITEM_ID=$(echo "$add_result" | jq -r '.data.addProjectV2ItemById.item.id')
-
-          # 3. Pick the field + date based on the triggering action.
-          case "$ACTION" in
-            opened)
-              FIELD_ID="$STARTED_FIELD_ID"
-              DATE_VALUE="${PR_OPENED_AT%%T*}"
-              ;;
-            closed)
-              FIELD_ID="$MERGED_FIELD_ID"
-              DATE_VALUE="${PR_MERGED_AT%%T*}"
-              ;;
-            *)
-              echo "Unhandled action: $ACTION" >&2
-              exit 0
-              ;;
-          esac
 
           # 4. Write the field value.
           gh api graphql \
@@ -140,4 +187,4 @@ jobs:
                 }
               }' >/dev/null
 
-          echo "Set '$ACTION' field on item $ITEM_ID to $DATE_VALUE."
+          echo "Set '$FIELD_NAME' on item $ITEM_ID to $DATE_VALUE."

--- a/docs/docs/ai-workflow.md
+++ b/docs/docs/ai-workflow.md
@@ -41,18 +41,25 @@ workflow. The board — not this document — is the operational surface for
 "what is in flight right now." This document only describes the shape of
 the cycle.
 
-The roadmap view is grouped by **milestone** (the Phase 0–5 swimlanes
-defined in `infra/github/milestones.tf`) and uses two PR-level **Date**
-fields as the timeline axis:
+The board hosts both PRs and issues, with **two parallel Roadmap views**
+filtered to `is:pr` and `is:issue` respectively. Both views share the
+**milestone** swimlanes (Phase 0–5, defined in
+`infra/github/milestones.tf`) but use their own pair of **Date** fields
+on the timeline axis, so each lifecycle keeps its native vocabulary:
 
-- **Started At** — set when the PR is opened.
-- **Merged At** — set when the PR is closed *and* merged. Closed-without-
-  merge PRs leave this empty.
+- **PRs** — `Started At` (set on `opened`) and `Merged At` (set on
+  `closed && merged`). Closed-without-merge PRs leave `Merged At` empty.
+- **Issues** — `Opened At` (set on `opened`) and `Closed At` (set on
+  `closed && state_reason == "completed"`). Issues closed as
+  `not_planned` leave `Closed At` empty, mirroring the PR rule.
 
-Both fields are written by `.github/workflows/project-fields.yml`. The
-default `GITHUB_TOKEN` cannot mutate org-scoped Projects v2, so the
-workflow reads a **fine-grained PAT** from the `PROJECTS_TOKEN` repo
-secret. To rotate or reissue:
+All four fields are written by `.github/workflows/project-fields.yml` on
+the corresponding `pull_request_target` / `issues` events, and can be
+backfilled across the full history via the manually triggered
+`.github/workflows/project-fields-backfill.yml`. The default
+`GITHUB_TOKEN` cannot mutate org-scoped Projects v2, so both workflows
+read a **fine-grained PAT** from the `PROJECTS_TOKEN` repo secret. To
+rotate or reissue:
 
 1. Create a fine-grained PAT at
    <https://github.com/settings/personal-access-tokens/new> with


### PR DESCRIPTION
## Summary

Extends the project-fields automation to cover **issues** alongside PRs, adopting the "single Project + multiple Views + per-content-type field pair" pattern (Plan 2 from the design discussion).

Field model now on the org-level [vivarium roadmap board](https://github.com/orgs/aletheia-works/projects/1):

| Content type | Start field | End field | End-field rule |
|---|---|---|---|
| Pull request | `Started At` | `Merged At` | `closed && merged` (closed-without-merge skipped) |
| Issue        | `Opened At`  | `Closed At` | `closed && state_reason == "completed"` (`not_planned` skipped) |

Both content types live on the same Project so cross-references stay intact; the visual split is done via two Roadmap views filtered to `is:pr` and `is:issue`. PRs keep their existing `Started At` / `Merged At` field names — no rename, no churn for the data already populated by #70 / #72 / #74.

## Changes

- **`project-fields.yml`** — adds `issues: [opened, closed]` trigger; the script now branches on `github.event_name` and writes to the correct field pair. Issue `state_reason` matched against the lowercase webhook value (`"completed"`).
- **`project-fields-backfill.yml`** — adds a second loop over `gh issue list --state all`, matching `state == CLOSED && stateReason == COMPLETED` (uppercase, since gh's GraphQL output capitalises enum values). Refactors duplicated GraphQL boilerplate into `add_to_project` / `set_date_field` shell helpers.
- **`docs/docs/ai-workflow.md`** — documents the two-view model and the issue-side rule.

## Pre-merge prerequisites (human-side)

- [x] On the project, add two **Date** custom fields named exactly `Opened At` and `Closed At`. (`Started At` / `Merged At` are already present.)
- [x] Add (or repurpose) a Roadmap view filtered to `is:issue` with **Dates: Opened At → Closed At**. The existing PR Roadmap view should have its filter set to `is:pr` to avoid double-counting.

If the two Issue fields don't exist yet when the workflow runs, both `project-fields.yml` and `project-fields-backfill.yml` will fail loudly with `Date field 'Opened At' / 'Closed At' not found on project.` — non-destructive and easy to recover from.

## Test plan

- [x] Merge this PR — exercises the **PR** path of the updated live workflow (`Started At` on open, `Merged At` on merge). Should match the prior behaviour from #70.
- [x] After merge, open a throwaway issue → confirm `Opened At` is set on the board.
- [x] Close the issue **as completed** → confirm `Closed At` is set.
- [x] Open another throwaway issue → close it **as not planned** → confirm `Closed At` remains empty and the job logs `Issue closed as 'not_planned' (not completed); nothing to update.`
- [x] Trigger **Project fields backfill** from the Actions UI with `confirm: yes` → confirm both PR and Issue lines appear in the log and historical issues now have populated `Opened At` / `Closed At`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014C3W2VywioaNbgJMNMERB3)_