### PR TITLE
feat(python): cpython#137205 reproduction (sqlite3 PRAGMA foreign_keys under autocommit=False)

### DIFF
--- a/docs/docs/repro/index.md
+++ b/docs/docs/repro/index.md
@@ -30,12 +30,14 @@ reproduces.
 | --- | --- | --- | --- |
 | pandas | [#56679](https://github.com/pandas-dev/pandas/issues/56679) — empty `Series` / `DataFrame` dtype mismatch | `pass` (bug reproduces) | [Open ↗](https://aletheia-works.github.io/vivarium/repro/pandas-56679/) |
 | numpy | [#28287](https://github.com/numpy/numpy/issues/28287) — `timedelta64` ordering is non-transitive across generic units | `pass` (bug reproduces) | [Open ↗](https://aletheia-works.github.io/vivarium/repro/numpy-28287/) |
+| cpython | [#137205](https://github.com/python/cpython/issues/137205) — `sqlite3` silently drops `PRAGMA foreign_keys = ON` under `autocommit=False` | `pass` (bug reproduces) | [Open ↗](https://aletheia-works.github.io/vivarium/repro/cpython-137205/) |
 
 The Verdict column reflects what the page reports on the runtime
-Vivarium currently loads (Pyodide v0.29.3 with pandas 2.3.3 and numpy
-2.2.5 at the time of writing). The linked page is authoritative —
-visit it to confirm the live verdict, since an upstream fix landing in
-a future Pyodide release will flip the verdict to `fail`.
+Vivarium currently loads (Pyodide v0.29.3 with Python 3.13.2, pandas
+2.3.3, numpy 2.2.5, and SQLite 3.39.0 from the `sqlite3` Pyodide
+package at the time of writing). The linked page is authoritative —
+visit it to confirm the live verdict, since an upstream fix landing
+in a future Pyodide release will flip the verdict to `fail`.
 
 ## Adding a reproduction
 

--- a/src/layer1_wasm/cpython-137205/README.md
+++ b/src/layer1_wasm/cpython-137205/README.md
@@ -1,0 +1,90 @@
+# Reproduction — python/cpython#137205
+
+> Phase 1 reproduction page — third entry in Vivarium's Layer 1
+> Pyodide gallery and the first to exercise SQLite via the Python
+> `sqlite3` stdlib module. Conforms to `vivarium-contract: v1`.
+
+## The bug
+
+[python/cpython#137205](https://github.com/python/cpython/issues/137205)
+— On a `sqlite3.Connection` opened with `autocommit=False`,
+`PRAGMA foreign_keys = ON` is silently a no-op. The same PRAGMA on
+a second connection opened with `autocommit=True` takes effect, so
+two connections that should have identical FK enforcement disagree:
+
+```python
+import sqlite3
+off = sqlite3.connect(":memory:", autocommit=False)
+off.execute("PRAGMA foreign_keys = ON")
+off.commit()
+
+on = sqlite3.connect(":memory:", autocommit=True)
+on.execute("PRAGMA foreign_keys = ON")
+
+off.execute("PRAGMA foreign_keys").fetchone()[0]  # => 0  (BUG)
+on.execute("PRAGMA foreign_keys").fetchone()[0]   # => 1
+```
+
+## Why this bug
+
+- Python stdlib only — no third-party packages, no I/O beyond the
+  in-memory SQLite connection.
+- Verdict reduces to a boolean — the two connections disagree on
+  the PRAGMA value — so the page emits a mechanically-distinguishable
+  `pass` / `fail`.
+- Reported against Python 3.13. Related upstream PRs are doc-only;
+  Pyodide v0.29.3 ships Python 3.13.2 (and SQLite 3.39.0 via the
+  `sqlite3` Pyodide package), which still exhibits the behaviour.
+- Demonstrates that Vivarium handles standard-library bugs (not just
+  numerical-library bugs), and adds the **sqlite** vertical that
+  [`docs/roadmap.md`](../../docs/docs/roadmap.md) lists as a
+  Phase 1 deliverable.
+
+## A note on "SQLite-WASM"
+
+This page does **not** load
+[`sqlite-wasm`](https://sqlite.org/wasm/) — it loads Pyodide and
+exercises SQLite through the Python stdlib `sqlite3` module. In
+Pyodide, `sqlite3` is unvendored from the stdlib and ships as a
+separately-loadable package; the runtime that actually runs is the
+SQLite baked into that package (3.39.0 at the time of writing).
+A future page may load `sqlite-wasm` directly to reproduce
+SQLite-only bugs that surface beneath the Python binding; this
+entry covers the binding-layer bug, which only reproduces through
+the Python API surface.
+
+## Files
+
+| File         | Role                                                              |
+| ------------ | ----------------------------------------------------------------- |
+| `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
+| `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
+
+## Verdict contract — `vivarium-contract: v1`
+
+The page conforms to the contract canonicalised in
+[`../_shared/verdict.ts`](../_shared/verdict.ts). The `result` field
+of the envelope reports `off_autocommit_fk`, `on_autocommit_fk`, and
+`fk_disagreement`.
+
+A `pass` means **the bug reproduced** (the two connections disagree
+on the PRAGMA value). A `fail` means either the runtime ships a fix
+(both connections agree), or the runtime errored before producing a
+result.
+
+## Running locally
+
+```bash
+cd src/layer1_wasm
+bun install
+bun run build
+python -m http.server -d . 8767
+# open http://localhost:8767/cpython-137205/
+```
+
+## Deployment
+
+Published to GitHub Pages at
+`https://aletheia-works.github.io/vivarium/repro/cpython-137205/` by
+the `deploy-docs` workflow.

--- a/src/layer1_wasm/cpython-137205/index.html
+++ b/src/layer1_wasm/cpython-137205/index.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="vivarium-contract" content="v1" />
+    <title>Vivarium · Reproducing python/cpython#137205</title>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <!-- Keep the version below in sync with DEFAULT_PYODIDE_VERSION in
+         ../_shared/loader.ts. -->
+    <link
+      rel="modulepreload"
+      href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.mjs"
+      crossorigin
+    />
+    <link rel="stylesheet" href="../_shared/style.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <p class="kicker">Vivarium · Layer 1 · Pyodide · sqlite3</p>
+        <h1>Reproducing <a href="https://github.com/python/cpython/issues/137205">python/cpython#137205</a></h1>
+        <p class="lede">
+          Python's <code>sqlite3</code> stdlib silently drops
+          <code>PRAGMA foreign_keys = ON</code> when the connection
+          was opened with <code>autocommit=False</code>. The same
+          PRAGMA on a second connection opened with
+          <code>autocommit=True</code> takes effect — so two
+          connections that should have identical FK enforcement
+          disagree. The disagreement is the bug surface.
+        </p>
+      </header>
+
+      <section>
+        <h2>Verdict</h2>
+        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          Loading Pyodide runtime…
+        </div>
+        <p class="meta" id="meta"></p>
+      </section>
+
+      <section>
+        <h2>Reproduction script</h2>
+        <pre><code id="repro-code"></code></pre>
+      </section>
+
+      <section>
+        <h2>Output</h2>
+        <pre id="output">(running)</pre>
+      </section>
+
+      <footer>
+        <p class="meta">
+          Runtime:
+          <a href="https://pyodide.org/">Pyodide</a>
+          loaded from
+          <a href="https://www.jsdelivr.com/package/npm/pyodide">cdn.jsdelivr.net</a>.
+          SQLite is the version bundled into the Pyodide
+          <code>sqlite3</code> package — no separate
+          <code>sqlite-wasm</code> build is loaded for this page.
+          Source:
+          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/cpython-137205">vivarium/src/layer1_wasm/cpython-137205</a>.
+        </p>
+      </footer>
+    </main>
+
+    <script type="module" src="./repro.js"></script>
+  </body>
+</html>

--- a/src/layer1_wasm/cpython-137205/repro.ts
+++ b/src/layer1_wasm/cpython-137205/repro.ts
@@ -1,0 +1,148 @@
+// Vivarium Layer 1 reproduction — python/cpython#137205.
+//
+// `PRAGMA foreign_keys = ON` is silently a no-op when issued on a
+// `sqlite3.Connection` opened with `autocommit=False`:
+//   off = sqlite3.connect(":memory:", autocommit=False)
+//   off.execute("PRAGMA foreign_keys = ON")  # <-- silently dropped
+//   on  = sqlite3.connect(":memory:", autocommit=True)
+//   on.execute("PRAGMA foreign_keys = ON")   # <-- takes effect
+//   off.execute("PRAGMA foreign_keys").fetchone()[0]  # => 0
+//   on.execute("PRAGMA foreign_keys").fetchone()[0]   # => 1
+// The two connections should agree on whether FK enforcement is on.
+//
+// Verdict semantics (per ADR-0008 / contract v1):
+//   - "pass" — the bug REPRODUCES (the two connections disagree).
+//   - "fail" — the bug does NOT reproduce (the runtime ships a fix,
+//     or the runtime errored before producing a result).
+
+import { loadVivariumPyodide } from "../_shared/loader.js";
+import {
+  setResult,
+  setVerdict,
+  type VivariumResultV1,
+} from "../_shared/verdict.js";
+
+const REPRO_CODE = `
+import sys
+import sqlite3
+
+off = sqlite3.connect(":memory:", autocommit=False)
+off.execute("PRAGMA foreign_keys = ON")
+off.commit()
+
+on = sqlite3.connect(":memory:", autocommit=True)
+on.execute("PRAGMA foreign_keys = ON")
+
+off_value = off.execute("PRAGMA foreign_keys").fetchone()[0]
+on_value = on.execute("PRAGMA foreign_keys").fetchone()[0]
+
+{
+    "python_version": sys.version.split()[0],
+    "sqlite_version": sqlite3.sqlite_version,
+    "off_autocommit_fk": int(off_value),
+    "on_autocommit_fk": int(on_value),
+    "fk_disagreement": off_value != on_value,
+}
+`.trim();
+
+interface ReproOutput {
+  python_version: string;
+  sqlite_version: string;
+  off_autocommit_fk: number;
+  on_autocommit_fk: number;
+  fk_disagreement: boolean;
+}
+
+interface PyodideRuntime {
+  runPythonAsync(code: string): Promise<{
+    toJs(opts: { dict_converter: typeof Object.fromEntries }): ReproOutput;
+    destroy?(): void;
+  }>;
+}
+
+const outputEl = document.getElementById("output");
+const metaEl = document.getElementById("meta");
+const reproCodeEl = document.getElementById("repro-code");
+
+if (!outputEl || !metaEl || !reproCodeEl) {
+  throw new Error(
+    "cpython-137205: missing required DOM elements (#output, #meta, #repro-code).",
+  );
+}
+
+reproCodeEl.textContent = REPRO_CODE;
+
+const startedAt = new Date();
+
+try {
+  // sqlite3 is unvendored from the Python stdlib in the Pyodide
+  // distribution and ships as a separately-loadable package; preload
+  // it alongside the runtime bootstrap.
+  const { pyodide, version } = await loadVivariumPyodide({
+    packages: ["sqlite3"],
+    pendingText: "Loading Pyodide runtime and sqlite3…",
+  });
+
+  setVerdict("pending", "Running reproduction script…");
+  const runtime = pyodide as PyodideRuntime;
+  const proxy = await runtime.runPythonAsync(REPRO_CODE);
+  const result = proxy.toJs({ dict_converter: Object.fromEntries });
+  proxy.destroy?.();
+
+  metaEl.textContent =
+    `Python ${result.python_version} with stdlib sqlite3 ` +
+    `(SQLite ${result.sqlite_version}) via Pyodide v${version}.`;
+  outputEl.textContent = JSON.stringify(result, null, 2);
+
+  if (result.fk_disagreement) {
+    setVerdict(
+      "pass",
+      "reproduction succeeded — autocommit=False silently drops PRAGMA foreign_keys; the two connections disagree.",
+    );
+  } else {
+    setVerdict(
+      "fail",
+      "reproduction failed — both connections agree on PRAGMA foreign_keys (likely fixed upstream).",
+    );
+  }
+
+  const finishedAt = new Date();
+  const envelope: VivariumResultV1 = {
+    contract: "v1",
+    bug: {
+      project: "cpython",
+      issue: 137205,
+      upstream_url: "https://github.com/python/cpython/issues/137205",
+    },
+    runtime: {
+      name: "pyodide",
+      version,
+      extras: {
+        python: result.python_version,
+        sqlite: result.sqlite_version,
+      },
+    },
+    result: {
+      off_autocommit_fk: result.off_autocommit_fk,
+      on_autocommit_fk: result.on_autocommit_fk,
+      fk_disagreement: result.fk_disagreement,
+    },
+    timing: {
+      started_at: startedAt.toISOString(),
+      finished_at: finishedAt.toISOString(),
+      duration_ms: finishedAt.getTime() - startedAt.getTime(),
+    },
+  };
+  setResult(envelope);
+} catch (err: unknown) {
+  console.error(err);
+  const errAny = err as { stack?: string; message?: string } | null;
+  outputEl.textContent =
+    (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
+  if (globalThis.__VIVARIUM_VERDICT__ !== "fail") {
+    setVerdict(
+      "fail",
+      `reproduction failed — runtime error: ${errAny?.message ?? String(err)}`,
+    );
+  }
+}

--- a/src/layer1_wasm/tests/repro.spec.ts
+++ b/src/layer1_wasm/tests/repro.spec.ts
@@ -59,6 +59,14 @@ const cases: ReproCase[] = [
     expectedBugIssue: 28287,
     loadsPyodide: true,
   },
+  {
+    name: "cpython-137205 reproduction",
+    path: "/cpython-137205/",
+    expectedVerdict: "pass",
+    expectedBugProject: "cpython",
+    expectedBugIssue: 137205,
+    loadsPyodide: true,
+  },
 ];
 
 interface VivariumPageState {


### PR DESCRIPTION
## Summary

Adds Vivarium's third Layer 1 reproduction page — and the first **SQLite-shaped** vertical, closing the only outstanding deliverable of [Phase 1's roadmap entry](https://github.com/aletheia-works/vivarium/blob/main/docs/docs/roadmap.md#phase-1--layer-1-data-processing) which calls for *pandas / numpy / **sqlite** behavioural regressions*.

The bug — [python/cpython#137205](https://github.com/python/cpython/issues/137205) — is a binding-layer regression where `sqlite3.Connection(autocommit=False)` silently drops \`PRAGMA foreign_keys = ON\`, leaving two connections that should have identical FK enforcement disagreeing on the runtime PRAGMA value.

## Verdict on the bundled runtime

Verified locally on Pyodide v0.29.3 / Python 3.13.2 / SQLite 3.39.0 (loaded via the \`sqlite3\` Pyodide package): page reports **\`pass\`** with \`fk_disagreement: true\`, \`off_autocommit_fk: 0\`, \`on_autocommit_fk: 1\`.

## A note on "SQLite-WASM"

This page does NOT load \`sqlite-wasm\` — it exercises SQLite through Pyodide's \`sqlite3\` package, which is the Python stdlib module + a bundled SQLite (3.39.0). A future page may load \`sqlite-wasm\` directly to reach SQLite-only bugs that surface beneath the Python binding; this entry covers the binding-layer bug, which only reproduces through the Python API surface.

## Files

- New: \`src/layer1_wasm/cpython-137205/{repro.ts,index.html,README.md}\`
- Edited: \`src/layer1_wasm/tests/repro.spec.ts\` — adds the cpython-137205 case under the existing \`loadsPyodide\` schema
- Edited: \`docs/docs/repro/index.md\` — adds the cpython-137205 row to the Pyodide table; updates the runtime version note to mention SQLite 3.39.0

## Coordination with concurrent PRs

Three sibling PRs touch some of the same files (\`tests/repro.spec.ts\`, \`docs/docs/repro/index.md\`):
- Phase 2 Ruby spike (ruby-21709)
- Phase 2 Rust spike
- Phase 2 PHP spike

This PR is the smallest, most-additive edit of the trio. Whichever lands first is conflict-free; the others are expected to rebase on top.

## Test plan

- [x] \`bun run typecheck\` passes locally
- [x] \`bun run build\` produces \`cpython-137205/repro.js\`
- [x] Browser load on Python 3.13.2 / SQLite 3.39.0 reaches \`pass\` (verdict text: "reproduction succeeded — autocommit=False silently drops PRAGMA foreign_keys; the two connections disagree.")
- [x] CI Playwright suite green
- [x] CI deploy-docs publishes \`/repro/cpython-137205/\`