### PR TITLE
feat(ruby): ruby#21709 reproduction (Regexp interpolation encoding inconsistency)

### DIFF
--- a/docs/docs/repro/index.md
+++ b/docs/docs/repro/index.md
@@ -1,9 +1,9 @@
 # Reproductions
 
 Each card below is a real bug from a real upstream project, reproduced
-in your browser via Pyodide. Click "Open" to load the page; the verdict
-appears at the top once the runtime finishes loading and the
-reproduction script has run.
+in your browser via a WebAssembly language runtime. Click "Open" to
+load the page; the verdict appears at the top once the runtime
+finishes loading and the reproduction script has run.
 
 ## Vivarium contract
 
@@ -24,7 +24,7 @@ producing a result. The semantics are counterintuitive in isolation
 but match the project's domain noun: a *reproduction* succeeds when it
 reproduces.
 
-## Layer 1 — Pyodide
+## Layer 1 — Pyodide (Python)
 
 | Project | Issue | Verdict | |
 | --- | --- | --- | --- |
@@ -37,6 +37,18 @@ Vivarium currently loads (Pyodide v0.29.3 with pandas 2.3.3 and numpy
 visit it to confirm the live verdict, since an upstream fix landing in
 a future Pyodide release will flip the verdict to `fail`.
 
+## Layer 1 — Ruby.wasm (Ruby)
+
+| Project | Issue | Verdict | |
+| --- | --- | --- | --- |
+| ruby | [#21709](https://bugs.ruby-lang.org/issues/21709) — Regexp interpolation rejects mixed encodings while String interpolation silently upgrades to UTF-8 | `pass` (bug reproduces) | [Open ↗](https://aletheia-works.github.io/vivarium/repro/ruby-21709/) |
+
+The Verdict column reflects what the page reports on
+`@ruby/3.3-wasm-wasi` (Ruby 3.3.3 over WASI) at the time of writing.
+The upstream issue is currently Open with a draft patch in flight;
+when a fix lands and is picked up by Ruby.wasm the verdict will flip
+to `fail`.
+
 ## Adding a reproduction
 
 A new reproduction page lives under
@@ -45,8 +57,9 @@ and ships:
 
 - `index.html` declaring the contract version, with a `#verdict` band
   and `<script src="./repro.js">`.
-- `repro.ts` that imports `loadVivariumPyodide`, `setVerdict`,
-  `setResult` from
+- `repro.ts` that imports the runtime loader (`loadVivariumPyodide`
+  for Python via Pyodide, `loadVivariumRuby` for Ruby via Ruby.wasm)
+  plus `setVerdict` and `setResult` from
   [`../_shared/`](https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/_shared)
   and publishes a `VivariumResultV1` envelope on completion.
 - A short `README.md` explaining the bug and the verdict criterion.

--- a/src/layer1_wasm/_shared/ruby_loader.ts
+++ b/src/layer1_wasm/_shared/ruby_loader.ts
@@ -1,0 +1,90 @@
+// Vivarium contract v1 — Ruby.wasm loader.
+//
+// Loads `@ruby/wasm-wasi` from jsDelivr, fetches the matching
+// `@ruby/<ruby-major-minor>-wasm-wasi` ruby+stdlib.wasm binary, and
+// returns an instantiated RubyVM. On any load failure, the helper sets
+// the verdict to "fail" with the error text and re-throws — mirroring
+// `loader.ts` for Pyodide.
+//
+// Pages should still wrap their reproduction code in `try/catch` and
+// call `setVerdict("fail", ...)` themselves on REPRODUCTION-time errors;
+// this helper only owns load-time errors.
+
+import { setVerdict } from "./verdict.js";
+
+/** `@ruby/wasm-wasi` package version. Bumping requires updating the
+ *  `<link rel="modulepreload">` in pages that preload this URL. */
+export const DEFAULT_RUBY_WASM_VERSION = "2.8.1";
+
+/** Ruby major.minor series shipped by the `@ruby/<X.Y>-wasm-wasi`
+ *  binary package. */
+export const DEFAULT_RUBY_VERSION = "3.3";
+
+export interface LoadOptions {
+  /** Override the `@ruby/wasm-wasi` package version. */
+  rubyWasmVersion?: string;
+  /** Override the Ruby major.minor series (e.g. "3.4"). */
+  rubyVersion?: string;
+  /** Verdict message shown while loading (default "Loading Ruby.wasm runtime…"). */
+  pendingText?: string;
+}
+
+/**
+ * Ruby VM handle. Typed as `unknown` for now because `@ruby/wasm-wasi`
+ * does not publish browser-friendly type definitions; reproductions
+ * cast or refine locally where they call `vm.eval(...)`.
+ */
+export type RubyVMInstance = unknown;
+
+export interface LoadResult {
+  vm: RubyVMInstance;
+  /** Echoes `options.rubyWasmVersion` or the default. */
+  rubyWasmVersion: string;
+  /** Echoes `options.rubyVersion` or the default. */
+  rubyVersion: string;
+}
+
+/**
+ * Load Ruby.wasm and return an instantiated VM.
+ *
+ * @throws Re-throws the underlying error after setting the verdict to "fail".
+ */
+export async function loadVivariumRuby(
+  options: LoadOptions = {},
+): Promise<LoadResult> {
+  const rubyWasmVersion = options.rubyWasmVersion ?? DEFAULT_RUBY_WASM_VERSION;
+  const rubyVersion = options.rubyVersion ?? DEFAULT_RUBY_VERSION;
+  const pendingText = options.pendingText ?? "Loading Ruby.wasm runtime…";
+
+  setVerdict("pending", pendingText);
+
+  const loaderUrl = `https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@${rubyWasmVersion}/dist/browser/+esm`;
+  const wasmUrl = `https://cdn.jsdelivr.net/npm/@ruby/${rubyVersion}-wasm-wasi@${rubyWasmVersion}/dist/ruby+stdlib.wasm`;
+
+  try {
+    const mod = (await import(/* @vite-ignore */ loaderUrl)) as {
+      DefaultRubyVM: (
+        module: WebAssembly.Module,
+      ) => Promise<{ vm: RubyVMInstance }>;
+    };
+    const response = await fetch(wasmUrl);
+    if (!response.ok) {
+      throw new Error(
+        `failed to fetch ruby+stdlib.wasm (${response.status} ${response.statusText})`,
+      );
+    }
+    const buffer = await response.arrayBuffer();
+    const wasmModule = await WebAssembly.compile(buffer);
+    const { vm } = await mod.DefaultRubyVM(wasmModule);
+    return { vm, rubyWasmVersion, rubyVersion };
+  } catch (err: unknown) {
+    const errAny = err as { stack?: string; message?: string } | null;
+    const message =
+      (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
+    setVerdict(
+      "fail",
+      `reproduction failed — runtime error during Ruby.wasm load: ${message}`,
+    );
+    throw err;
+  }
+}

--- a/src/layer1_wasm/ruby-21709/README.md
+++ b/src/layer1_wasm/ruby-21709/README.md
@@ -1,0 +1,78 @@
+# Reproduction — ruby/ruby#21709
+
+> Phase 2 reproduction page — first non-Pyodide entry in Vivarium's
+> gallery. Conforms to `vivarium-contract: v1`.
+
+## The bug
+
+[ruby/ruby#21709](https://bugs.ruby-lang.org/issues/21709) — Regexp
+interpolation rejects fragments of differing encodings, while String
+interpolation silently upgrades them to UTF-8:
+
+```ruby
+prefix = '\p{In_Arabic}'
+suffix = '\p{In_Arabic}'.encode('US-ASCII')
+
+/#{prefix}#{suffix}/   # => RegexpError: encoding mismatch in dynamic regexp
+"#{prefix}#{suffix}"   # => "\p{In_Arabic}\p{In_Arabic}" (UTF-8)
+```
+
+The two interpolation forms should agree on how to combine fragments
+of different encodings. The disagreement is the bug surface.
+
+## Why this bug
+
+- Pure Ruby standard library (Regexp, String, Encoding) — no gems,
+  no native extensions, no I/O.
+- Verdict reduces to a boolean — Regexp build raises ∧ String build
+  succeeds — so the page emits a mechanically-distinguishable `pass`
+  / `fail`.
+- Open upstream (Status: Open) at the time of writing; reported
+  against Ruby 3.4 and confirmed to affect 3.2 / 3.3 / 3.4. A draft
+  patch is in flight but has not landed.
+- Suits the WASM cell shape exactly — Ruby.wasm bundles full Onigmo
+  and Encoding support, so this reproduces without runtime gaps.
+- Demonstrates that Vivarium's Layer 1 gallery is not Pyodide-only:
+  Ruby.wasm is the second WASM runtime in the gallery and the first
+  page that uses it.
+
+## Files
+
+| File         | Role                                                              |
+| ------------ | ----------------------------------------------------------------- |
+| `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
+| `repro.ts`   | TypeScript source. Imports `loadVivariumRuby` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
+
+Shared visual presentation lives in [`../_shared/style.css`](../_shared/style.css).
+The Ruby.wasm loader lives in [`../_shared/ruby_loader.ts`](../_shared/ruby_loader.ts).
+
+## Verdict contract — `vivarium-contract: v1`
+
+The page conforms to the contract canonicalised in
+[`../_shared/verdict.ts`](../_shared/verdict.ts). The `result` field
+of the envelope reports `regexp_built`, `regexp_raised`,
+`string_built`, `string_encoding`, `string_raised`, and
+`reproduced` — enough for downstream tooling to distinguish the
+specific shape of any future change.
+
+A `pass` means **the bug reproduced** — Regexp interpolation raised
+while String interpolation succeeded. A `fail` means either the
+runtime ships a fix (both forms succeed, or both raise the same
+way), or the runtime errored before producing a result.
+
+## Running locally
+
+```bash
+cd src/layer1_wasm
+bun install
+bun run build
+python -m http.server -d . 8767
+# open http://localhost:8767/ruby-21709/
+```
+
+## Deployment
+
+Published to GitHub Pages at
+`https://aletheia-works.github.io/vivarium/repro/ruby-21709/` by the
+`deploy-docs` workflow.

--- a/src/layer1_wasm/ruby-21709/index.html
+++ b/src/layer1_wasm/ruby-21709/index.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="vivarium-contract" content="v1" />
+    <title>Vivarium · Reproducing ruby/ruby#21709</title>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <!-- Keep the version below in sync with DEFAULT_RUBY_WASM_VERSION
+         in ../_shared/ruby_loader.ts. -->
+    <link
+      rel="modulepreload"
+      href="https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.8.1/dist/browser/+esm"
+      crossorigin
+    />
+    <link rel="stylesheet" href="../_shared/style.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <p class="kicker">Vivarium · Layer 1 · Ruby.wasm</p>
+        <h1>Reproducing <a href="https://bugs.ruby-lang.org/issues/21709">ruby/ruby#21709</a></h1>
+        <p class="lede">
+          Ruby's Regexp interpolation rejects fragments of differing
+          encodings, while String interpolation silently upgrades them
+          to UTF-8. With <code>prefix = '\p{In_Arabic}'</code> and
+          <code>suffix = prefix.encode('US-ASCII')</code>,
+          <code>/#{prefix}#{suffix}/</code> raises a
+          <code>RegexpError</code> while <code>"#{prefix}#{suffix}"</code>
+          builds a UTF-8 string fine. The two interpolation forms
+          should agree on how to combine fragments of different
+          encodings — they don't.
+        </p>
+      </header>
+
+      <section>
+        <h2>Verdict</h2>
+        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          Loading Ruby.wasm runtime…
+        </div>
+        <p class="meta" id="meta"></p>
+      </section>
+
+      <section>
+        <h2>Reproduction script</h2>
+        <pre><code id="repro-code"></code></pre>
+      </section>
+
+      <section>
+        <h2>Output</h2>
+        <pre id="output">(running)</pre>
+      </section>
+
+      <footer>
+        <p class="meta">
+          Runtime:
+          <a href="https://github.com/ruby/ruby.wasm">Ruby.wasm</a>
+          loaded from
+          <a href="https://www.jsdelivr.com/package/npm/@ruby/wasm-wasi">cdn.jsdelivr.net</a>.
+          Source:
+          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/ruby-21709">vivarium/src/layer1_wasm/ruby-21709</a>.
+        </p>
+      </footer>
+    </main>
+
+    <script type="module" src="./repro.js"></script>
+  </body>
+</html>

--- a/src/layer1_wasm/ruby-21709/repro.ts
+++ b/src/layer1_wasm/ruby-21709/repro.ts
@@ -1,0 +1,159 @@
+// Vivarium Layer 1 reproduction — ruby/ruby#21709.
+//
+// Regexp interpolation rejects mixed encodings while String
+// interpolation silently upgrades to UTF-8:
+//   prefix = '\p{In_Arabic}'
+//   suffix = '\p{In_Arabic}'.encode('US-ASCII')
+//   /#{prefix}#{suffix}/  # => RegexpError ("encoding mismatch")
+//   "#{prefix}#{suffix}"  # => "\p{In_Arabic}\p{In_Arabic}"
+// The two interpolation forms should agree on how to combine
+// fragments of different encodings — they don't.
+//
+// Verdict semantics (per ADR-0008 / contract v1):
+//   - "pass" — the bug REPRODUCES (Regexp raises, String succeeds).
+//   - "fail" — the bug does NOT reproduce (the runtime ships a fix,
+//     or the runtime errored before producing a result).
+
+import { loadVivariumRuby } from "../_shared/ruby_loader.js";
+import {
+  setResult,
+  setVerdict,
+  type VivariumResultV1,
+} from "../_shared/verdict.js";
+
+const REPRO_CODE = String.raw`
+require "json"
+
+result = { ruby_version: RUBY_VERSION }
+
+prefix = '\p{In_Arabic}'
+suffix = '\p{In_Arabic}'.encode('US-ASCII')
+
+begin
+  re = /#{prefix}#{suffix}/
+  result[:regexp_built] = true
+  result[:regexp_raised] = nil
+rescue => e
+  result[:regexp_built] = false
+  result[:regexp_raised] = e.class.name
+end
+
+begin
+  s = "#{prefix}#{suffix}"
+  result[:string_built] = true
+  result[:string_encoding] = s.encoding.name
+  result[:string_raised] = nil
+rescue => e
+  result[:string_built] = false
+  result[:string_encoding] = nil
+  result[:string_raised] = e.class.name
+end
+
+JSON.dump(result)
+`.trim();
+
+interface ReproOutput {
+  ruby_version: string;
+  regexp_built: boolean;
+  regexp_raised: string | null;
+  string_built: boolean;
+  string_encoding: string | null;
+  string_raised: string | null;
+}
+
+interface RubyVM {
+  eval(code: string): { toString(): string };
+}
+
+const outputEl = document.getElementById("output");
+const metaEl = document.getElementById("meta");
+const reproCodeEl = document.getElementById("repro-code");
+
+if (!outputEl || !metaEl || !reproCodeEl) {
+  throw new Error(
+    "ruby-21709: missing required DOM elements (#output, #meta, #repro-code).",
+  );
+}
+
+reproCodeEl.textContent = REPRO_CODE;
+
+const startedAt = new Date();
+
+try {
+  const { vm, rubyWasmVersion, rubyVersion } = await loadVivariumRuby({
+    pendingText: "Loading Ruby.wasm runtime and stdlib…",
+  });
+
+  setVerdict("pending", "Running reproduction script…");
+  const rb = vm as RubyVM;
+  const jsonText = rb.eval(REPRO_CODE).toString();
+  const result = JSON.parse(jsonText) as ReproOutput;
+
+  metaEl.textContent =
+    `Ruby ${result.ruby_version} via @ruby/${rubyVersion}-wasm-wasi v${rubyWasmVersion}.`;
+  outputEl.textContent = JSON.stringify(result, null, 2);
+
+  // Bug reproduces iff Regexp interpolation raises but String
+  // interpolation succeeds — the documented inconsistency.
+  const reproduced = !result.regexp_built && result.string_built;
+
+  if (reproduced) {
+    setVerdict(
+      "pass",
+      "reproduction succeeded — Regexp interpolation rejects mixed encodings while String interpolation silently upgrades.",
+    );
+  } else if (result.regexp_built && result.string_built) {
+    setVerdict(
+      "fail",
+      "reproduction failed — Regexp and String interpolation now agree (likely fixed upstream).",
+    );
+  } else {
+    setVerdict(
+      "fail",
+      `reproduction failed — unexpected outcome (regexp_built=${result.regexp_built}, string_built=${result.string_built}).`,
+    );
+  }
+
+  const finishedAt = new Date();
+  const envelope: VivariumResultV1 = {
+    contract: "v1",
+    bug: {
+      project: "ruby",
+      issue: 21709,
+      upstream_url: "https://bugs.ruby-lang.org/issues/21709",
+    },
+    runtime: {
+      name: "ruby.wasm",
+      version: rubyWasmVersion,
+      extras: {
+        ruby: result.ruby_version,
+        ruby_wasi_package: `@ruby/${rubyVersion}-wasm-wasi`,
+      },
+    },
+    result: {
+      regexp_built: result.regexp_built,
+      regexp_raised: result.regexp_raised,
+      string_built: result.string_built,
+      string_encoding: result.string_encoding,
+      string_raised: result.string_raised,
+      reproduced,
+    },
+    timing: {
+      started_at: startedAt.toISOString(),
+      finished_at: finishedAt.toISOString(),
+      duration_ms: finishedAt.getTime() - startedAt.getTime(),
+    },
+  };
+  setResult(envelope);
+} catch (err: unknown) {
+  console.error(err);
+  const errAny = err as { stack?: string; message?: string } | null;
+  outputEl.textContent =
+    (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
+  if (globalThis.__VIVARIUM_VERDICT__ !== "fail") {
+    setVerdict(
+      "fail",
+      `reproduction failed — runtime error: ${errAny?.message ?? String(err)}`,
+    );
+  }
+}

--- a/src/layer1_wasm/tests/repro.spec.ts
+++ b/src/layer1_wasm/tests/repro.spec.ts
@@ -27,11 +27,11 @@ interface ReproCase {
   /** Envelope `bug.issue` field. */
   expectedBugIssue: number;
   /**
-   * `true` for pages that load Pyodide; the verdict can take 30+ s.
-   * `false` for the smoke test, which validates plumbing only and
-   * resolves in well under a second.
+   * Envelope `runtime.name`. `"browser"` for the smoke test (no WASM
+   * runtime loaded), `"pyodide"` / `"ruby.wasm"` for reproductions
+   * that bootstrap a language runtime over WebAssembly.
    */
-  loadsPyodide: boolean;
+  expectedRuntimeName: "browser" | "pyodide" | "ruby.wasm";
 }
 
 const cases: ReproCase[] = [
@@ -41,7 +41,7 @@ const cases: ReproCase[] = [
     expectedVerdict: "pass",
     expectedBugProject: "vivarium",
     expectedBugIssue: 0,
-    loadsPyodide: false,
+    expectedRuntimeName: "browser",
   },
   {
     name: "pandas-56679 reproduction",
@@ -49,7 +49,7 @@ const cases: ReproCase[] = [
     expectedVerdict: "pass",
     expectedBugProject: "pandas",
     expectedBugIssue: 56679,
-    loadsPyodide: true,
+    expectedRuntimeName: "pyodide",
   },
   {
     name: "numpy-28287 reproduction",
@@ -57,7 +57,15 @@ const cases: ReproCase[] = [
     expectedVerdict: "pass",
     expectedBugProject: "numpy",
     expectedBugIssue: 28287,
-    loadsPyodide: true,
+    expectedRuntimeName: "pyodide",
+  },
+  {
+    name: "ruby-21709 reproduction",
+    path: "/ruby-21709/",
+    expectedVerdict: "pass",
+    expectedBugProject: "ruby",
+    expectedBugIssue: 21709,
+    expectedRuntimeName: "ruby.wasm",
   },
 ];
 
@@ -96,7 +104,9 @@ for (const c of cases) {
 
     // Wait for the verdict to settle. Pages start at `pending` and
     // transition to `pass` or `fail` once the reproduction (or the
-    // smoke-test plumbing) completes.
+    // smoke-test plumbing) completes. The smoke test resolves under a
+    // second; WASM-runtime pages need to fetch the runtime over the
+    // network and instantiate it.
     await page.waitForFunction(
       () => {
         const v = (
@@ -105,7 +115,7 @@ for (const c of cases) {
         return v === "pass" || v === "fail";
       },
       undefined,
-      { timeout: c.loadsPyodide ? 75_000 : 10_000 },
+      { timeout: c.expectedRuntimeName === "browser" ? 10_000 : 75_000 },
     );
 
     const state = await readVivariumState(page);
@@ -133,16 +143,8 @@ for (const c of cases) {
       .getAttribute("content");
     expect.soft(contractMeta, "<meta vivarium-contract>").toBe("v1");
 
-    // Pyodide-loading pages should report a pyodide runtime; the smoke
-    // test should not (it explicitly skips the runtime).
-    if (c.loadsPyodide) {
-      expect
-        .soft(state.runtimeName, "envelope runtime.name")
-        .toBe("pyodide");
-    } else {
-      expect
-        .soft(state.runtimeName, "envelope runtime.name (smoke)")
-        .not.toBe("pyodide");
-    }
+    expect
+      .soft(state.runtimeName, "envelope runtime.name")
+      .toBe(c.expectedRuntimeName);
   });
 }


### PR DESCRIPTION
## Summary

Adds Vivarium's first **non-Pyodide** Layer 1 reproduction page, opening the Phase 2 (multi-language) branch of the Layer 1 contract: a Ruby bug reproduced in-browser via [Ruby.wasm](https://github.com/ruby/ruby.wasm). Validates that the contract-v1 surface, the verdict semantics, and the deploy / regression-test plumbing all generalise beyond Python.

The bug — [ruby/ruby#21709](https://bugs.ruby-lang.org/issues/21709) — is an Open upstream regression where Regexp interpolation rejects fragments of differing encodings while String interpolation silently upgrades them to UTF-8: \`/#{prefix}#{suffix}/\` raises a \`RegexpError\` while \`"#{prefix}#{suffix}"\` builds a UTF-8 string fine. The two interpolation forms should agree on how to combine fragments of different encodings — they don't.

## Verdict on the bundled runtime

Verified locally on \`@ruby/3.3-wasm-wasi@2.8.1\` (Ruby 3.3.3 over WASI): page reports **\`pass\`** with \`regexp_built: false\`, \`regexp_raised: \"RegexpError\"\`, \`string_built: true\`, \`string_encoding: \"UTF-8\"\`.

## Files

- New: \`src/layer1_wasm/_shared/ruby_loader.ts\` — Ruby.wasm loader, symmetric with the existing \`loader.ts\` for Pyodide.
- New: \`src/layer1_wasm/ruby-21709/{repro.ts,index.html,README.md}\`.
- Edited: \`src/layer1_wasm/tests/repro.spec.ts\` — replaces the boolean \`loadsPyodide\` field with \`expectedRuntimeName: \"browser\" | \"pyodide\" | \"ruby.wasm\"\`, so the regression suite can name each runtime explicitly instead of falling back to \"not pyodide\". Adds the ruby-21709 case under the new schema.
- Edited: \`docs/docs/repro/index.md\` — adds a new \"Layer 1 — Ruby.wasm (Ruby)\" section, retitles the existing Pyodide section to \"Layer 1 — Pyodide (Python)\", and broadens the page's lede beyond \"via Pyodide\".

## Coordination with concurrent PRs

- [aletheia-works/vivarium#78](https://github.com/aletheia-works/vivarium/pull/78) (Phase 1 cpython-137205) edits the same three files (\`tests/repro.spec.ts\`, \`docs/docs/repro/index.md\`). Whichever lands first leaves the other to rebase — the conflicts are textual additions in the same sections, mechanically resolvable.
- Two further sibling PRs (Rust spike, PHP spike) on Phase 2 may follow the same shape; expected coordination strategy is the same.

## Test plan

- [x] \`bun run typecheck\` passes locally
- [x] \`bun run build\` produces \`ruby-21709/repro.js\`
- [x] Browser load on Ruby 3.3.3 reaches \`pass\` (verdict text: \"reproduction succeeded — Regexp interpolation rejects mixed encodings while String interpolation silently upgrades.\")
- [x] CI Playwright suite green (depends on rebase order vs #78)
- [x] CI deploy-docs publishes \`/repro/ruby-21709/\`