### PR TITLE
feat(rust): scaffold + design memo for Phase 2 Rust runtime-bootstrap

### DIFF
--- a/src/layer1_wasm/rust-spike/README.md
+++ b/src/layer1_wasm/rust-spike/README.md
@@ -1,0 +1,65 @@
+# Rust spike — runtime-bootstrap design memo
+
+> **Status:** draft scaffold, no reproduction page yet. This directory
+> exists to capture the design choices a real Rust reproduction page
+> will need before it can be authored. There is **no** `index.html`,
+> so the deploy workflow does not publish anything from this folder.
+
+## Why this is a separate scaffold (not a feature PR)
+
+A Rust reproduction in the Phase 2 spirit needs *more* than just a
+new subdirectory like `pandas-56679/` did. Two design choices block
+the first concrete reproduction:
+
+1. **How does the page load Rust?** Pyodide and Ruby.wasm both ship
+   a single CDN-hosted runtime + stdlib bundle that the browser can
+   instantiate without any per-bug compilation. Rust does not — every
+   reproduction is its own crate compiled to its own
+   `wasm32-unknown-unknown` (or `wasm32-wasi`) artefact.
+2. **Where does the compilation happen?** Either (a) commit the
+   prebuilt `.wasm` next to `repro.ts` (treating it as a generated
+   artefact tracked through Sapling), or (b) extend the
+   `deploy-docs` workflow to install a Rust toolchain and run
+   `wasm-pack build` on push.
+
+Picking one of these is a load-bearing scope decision — it changes
+the contributor experience, the CI cost, and the size of the
+deployed Pages artefact. It deserves its own ADR rather than
+landing as a side effect of the first concrete bug-reproduction PR.
+
+## Candidate Rust reproductions
+
+These are pure-Rust upstream bugs whose reproduction surface fits
+the WASM cell shape (no system calls, no native deps beyond
+`std`). They are *candidates*, not commitments:
+
+- **`regex` crate** — pathological-input pattern that triggers
+  exponential blow-up on a specific build. Pure Rust, single-line
+  call.
+- **`serde_json` crate** — deserialisation edge case for f64 ±0.0
+  / NaN. Pure Rust, deterministic.
+- **`std::num::ParseFloatError`** — historical edge case in
+  `f64::from_str` for subnormals. Stdlib only.
+
+A real PR following this scaffold should pick exactly one and link
+the upstream issue.
+
+## Path forward
+
+1. **Open an ADR** documenting the choice between (a) committed
+   prebuilt `.wasm` artefacts and (b) Rust toolchain in
+   `deploy-docs`. (This work is not in scope for the present PR.)
+2. **Pick one of the candidate bugs above**, confirm it reproduces
+   on the chosen toolchain version, and write `repro.rs` /
+   `Cargo.toml` / `index.html` / `repro.ts` against the agreed
+   loader pattern.
+3. **Replace this `rust-spike/` folder** with the chosen
+   `rust-<crate>-<issue>/` directory.
+
+## Why land this scaffold at all
+
+Until this directory exists in the tree the work is invisible — the
+project board has nothing to point a future contributor at, and the
+"Phase 2 multi-language" status is harder to reason about. Landing
+the scaffold + memo creates a single anchor point that the ADR and
+the eventual feature PR can both reference.


### PR DESCRIPTION
## Summary

Lands an empty-ish \`src/layer1_wasm/rust-spike/\` directory with a design memo (no \`index.html\`, so deploy-docs skips it). The memo captures the load-bearing scope decision a real Rust reproduction page needs to make *before* any single-bug PR can sensibly land.

## Why this is a draft + \`status: blocked\`

A Rust reproduction can't follow the Pyodide / Ruby.wasm shape directly:

- Pyodide / Ruby.wasm each ship a single CDN-hosted runtime + stdlib bundle. The browser instantiates it; the per-bug page only contains a tiny script.
- Rust ships no such bundle. Every reproduction is its own crate compiled to its own \`wasm32-unknown-unknown\` (or \`wasm32-wasi\`) \`.wasm\` artefact.

That forces a choice between:

1. **Commit prebuilt \`.wasm\` artefacts** next to \`repro.ts\` (treat them as generated artefacts in version control).
2. **Add a Rust toolchain to \`deploy-docs\`**, running \`wasm-pack build\` on push.

Both options have real cost in different places (repo size, contributor friction vs CI complexity, cold-build time, cache strategy). Picking one as a side-effect of a \"reproduce bug X\" PR is the wrong shape — it deserves its own ADR.

The scaffold + memo unblocks that ADR by giving it a single place to point at.

## Path forward (out of scope for this PR)

1. **Open an ADR** for the toolchain choice.
2. **Pick a candidate bug** (memo lists a few — \`regex\`, \`serde_json\`, \`std::num::ParseFloatError\`).
3. **Replace \`rust-spike/\` with \`rust-<crate>-<issue>/\`** following the agreed loader pattern.

## Files

- New: \`src/layer1_wasm/rust-spike/README.md\` — design memo only.

## Test plan

- [x] No \`index.html\` ⇒ \`deploy-docs\` skips the directory (verified by reading the workflow's \`for poc in src/layer1_wasm/*/; do ... if [ ! -f \"\${poc}index.html\" ]; then continue\` loop)
- [x] No TypeScript sources ⇒ \`bun run typecheck\` unaffected
- [ ] CI green (Markdown link checker may flag the upstream ADR link if a tracking Issue exists; safe to update once filed)