### PR TITLE
fix(ci): align cpython-137205 test case with new expectedRuntimeName schema

### DIFF
--- a/src/layer1_wasm/tests/repro.spec.ts
+++ b/src/layer1_wasm/tests/repro.spec.ts
@@ -73,7 +73,7 @@ const cases: ReproCase[] = [
     expectedVerdict: "pass",
     expectedBugProject: "cpython",
     expectedBugIssue: 137205,
-    loadsPyodide: true,
+    expectedRuntimeName: "pyodide",
   },
 ];
 


### PR DESCRIPTION
## Summary

Fixes the regression-suite typecheck failure on \`main\` left behind by the **textually-clean-but-semantically-broken** merge of [#78](https://github.com/aletheia-works/vivarium/pull/78) (Phase 1 cpython-137205) followed by [#79](https://github.com/aletheia-works/vivarium/pull/79) (Phase 2 ruby-21709).

## What broke and why

- #78 added the cpython-137205 case under the **old** \`ReproCase\` schema (\`loadsPyodide: boolean\`).
- #79 swapped that schema field for \`expectedRuntimeName: \"browser\" | \"pyodide\" | \"ruby.wasm\"\` — a load-bearing change once Ruby.wasm joined the gallery.
- The two PRs touched adjacent regions of \`tests/repro.spec.ts\`. GitHub's 3-way merge produced a clean text result, but the cpython-137205 case ended up in the post-merge schema with a \`loadsPyodide\` field that no longer exists on \`ReproCase\`. \`tsc\` rejects the orphan field; the \`repro-regression\` workflow on \`main\` is currently red.

The deploy-docs workflow stayed green because \`bun run build\` excludes \`tests/**\` (per \`tsconfig.json\`), so the contradiction only surfaced in the test typecheck.

## What this PR does

Single-line fix: \`loadsPyodide: true\` → \`expectedRuntimeName: \"pyodide\"\` for the cpython-137205 case. Brings it onto the post-#79 schema; spec compiles; the regression suite can now run.

## Verification

- [x] \`bun run typecheck\` clean locally
- [x] CI \`repro-regression\` green on this PR

## Why \`fix(ci)\`?

The same prefix used in [#74](https://github.com/aletheia-works/vivarium/pull/74) for an analogous post-merge spec adjustment — it's the smallest possible scope mismatch between the prefix conventions and the actual file edited. \`fix(test)\` would be equally honest.