### PR TITLE
feat(php): php-src#12167 reproduction (SimpleXML processing-instruction empty string-cast)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -3,3 +3,12 @@ bun = "latest"
 opentofu = "latest"
 python = "3.13"
 uv = "latest"
+# Native runtimes pinned to the same major.minor.patch the WASM gallery
+# pages run, so contributors can re-verify each Layer 1 reproduction
+# against a real interpreter (`mise exec ruby -- ruby <slug>/repro.rb`,
+# `mise exec php -- php <slug>/repro.php`). See
+# `src/layer1_wasm/<slug>/README.md` for per-page native repro
+# instructions. Building these on Windows requires WSL or an
+# equivalent Unix-y toolchain; CI installs them on Linux runners.
+php = "8.2.11"
+ruby = "3.3.3"

--- a/docs/docs/repro/index.md
+++ b/docs/docs/repro/index.md
@@ -51,6 +51,36 @@ The upstream issue is currently Open with a draft patch in flight;
 when a fix lands and is picked up by Ruby.wasm the verdict will flip
 to `fail`.
 
+## Layer 1 — php-wasm (PHP)
+
+| Project | Issue | Verdict | |
+| --- | --- | --- | --- |
+| php | [#12167](https://github.com/php/php-src/issues/12167) — `SimpleXMLElement::xpath('//processing-instruction()')` finds the PI node, but casting it to string yields an empty value | `pass` (bug reproduces) | [Open ↗](https://aletheia-works.github.io/vivarium/repro/php-12167/) |
+
+The Verdict column reflects what the page reports on `php-wasm@0.0.8`
+(PHP 8.2.11, Linux, 32-bit, Zend 4.2.11) at the time of writing. The
+bug was fixed upstream in PHP 8.2.12, so when php-wasm bumps to a
+build that ships ≥ 8.2.12 the verdict will flip to `fail` and the
+page becomes a fix-detection signal.
+
+## Native re-verification
+
+Each gallery page has a companion CLI variant — `repro.py`,
+`repro.rb`, or `repro.php` — that runs the *same* logic against a
+real native interpreter, with no WASM layer involved. The
+`.mise.toml` at the repo root pins each interpreter to the same
+major.minor.patch the WASM runtime bundles, so:
+
+```bash
+mise install                                      # one-time per machine
+mise exec ruby -- ruby src/layer1_wasm/ruby-21709/repro.rb
+mise exec php  -- php  src/layer1_wasm/php-12167/repro.php
+```
+
+`mise install` requires a Unix-y toolchain to build PHP / Ruby from
+source — Linux and macOS work directly, on Windows use WSL or an
+equivalent layer.
+
 ## Adding a reproduction
 
 A new reproduction page lives under
@@ -60,11 +90,15 @@ and ships:
 - `index.html` declaring the contract version, with a `#verdict` band
   and `<script src="./repro.js">`.
 - `repro.ts` that imports the runtime loader (`loadVivariumPyodide`
-  for Python via Pyodide, `loadVivariumRuby` for Ruby via Ruby.wasm)
-  plus `setVerdict` and `setResult` from
+  for Python via Pyodide, `loadVivariumRuby` for Ruby via Ruby.wasm,
+  `loadVivariumPhp` for PHP via php-wasm) plus `setVerdict` and
+  `setResult` from
   [`../_shared/`](https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/_shared)
   and publishes a `VivariumResultV1` envelope on completion.
 - A short `README.md` explaining the bug and the verdict criterion.
+- A native CLI variant (`repro.py` / `repro.rb` / `repro.php`) with
+  identical reproduction logic, for re-verification against a real
+  interpreter via `mise exec`.
 
 The deploy workflow handles bundling and the `.ts` → `.js` build —
 contributors only edit TypeScript sources.

--- a/src/layer1_wasm/_shared/php_loader.ts
+++ b/src/layer1_wasm/_shared/php_loader.ts
@@ -1,0 +1,121 @@
+// Vivarium contract v1 — php-wasm loader.
+//
+// Loads `php-wasm` from jsDelivr, instantiates `PhpWeb`, and returns a
+// thin `runPhp` wrapper that captures stdout via the runtime's
+// `output` event and resolves to `{ exitCode, stdout }`. On any
+// load-time failure the helper sets the verdict to "fail" with the
+// error text and re-throws — mirroring `loader.ts` (Pyodide) and
+// `ruby_loader.ts` (Ruby.wasm).
+//
+// Pages should still wrap their reproduction code in `try/catch` and
+// call `setVerdict("fail", ...)` themselves on REPRODUCTION-time errors;
+// this helper only owns load-time errors.
+//
+// php-wasm@0.0.8 ships PHP 8.2.11 (Linux, 32-bit, Zend 4.2.11) with
+// 27 bundled extensions including SimpleXML, sqlite3, mbstring, json,
+// PDO, and pdo_sqlite — confirmed in-browser; do not rely on this
+// version mapping without re-checking via `PHP_VERSION` in the
+// reproduction script.
+
+import { setVerdict } from "./verdict.js";
+
+/** `php-wasm` npm package version. Bumping requires updating the
+ *  `<link rel="modulepreload">` in pages that preload this URL. */
+export const DEFAULT_PHP_WASM_VERSION = "0.0.8";
+
+export interface LoadOptions {
+  /** Override the `php-wasm` package version. */
+  phpWasmVersion?: string;
+  /** Verdict message shown while loading (default "Loading php-wasm runtime…"). */
+  pendingText?: string;
+}
+
+export interface PhpRunResult {
+  /** Exit code returned by `PhpWeb.run`. 0 indicates a clean run. */
+  exitCode: number;
+  /** Concatenated stdout across all `output` events emitted during the
+   *  run. Includes trailing newlines if the script wrote them. */
+  stdout: string;
+}
+
+export interface PhpRunner {
+  /** Execute a PHP source string (must include the `<?php` open tag)
+   *  and resolve to the exit code + captured stdout. */
+  run(code: string): Promise<PhpRunResult>;
+}
+
+export interface LoadResult {
+  php: PhpRunner;
+  /** Echoes `options.phpWasmVersion` or the default. */
+  phpWasmVersion: string;
+}
+
+interface PhpWebInstance {
+  addEventListener(
+    type: "ready" | "error" | "output",
+    listener: (event: Event & { detail?: string | undefined }) => void,
+    options?: { once?: boolean },
+  ): void;
+  removeEventListener(
+    type: "ready" | "error" | "output",
+    listener: (event: Event & { detail?: string | undefined }) => void,
+  ): void;
+  run(code: string): Promise<number>;
+}
+
+/**
+ * Load php-wasm and return a thin runner.
+ *
+ * @throws Re-throws the underlying error after setting the verdict to "fail".
+ */
+export async function loadVivariumPhp(
+  options: LoadOptions = {},
+): Promise<LoadResult> {
+  const phpWasmVersion = options.phpWasmVersion ?? DEFAULT_PHP_WASM_VERSION;
+  const pendingText = options.pendingText ?? "Loading php-wasm runtime…";
+
+  setVerdict("pending", pendingText);
+
+  const loaderUrl = `https://cdn.jsdelivr.net/npm/php-wasm@${phpWasmVersion}/PhpWeb.mjs`;
+
+  try {
+    const mod = (await import(/* @vite-ignore */ loaderUrl)) as {
+      PhpWeb: new () => PhpWebInstance;
+    };
+    const instance = new mod.PhpWeb();
+    await new Promise<void>((resolve, reject) => {
+      instance.addEventListener("ready", () => resolve(), { once: true });
+      instance.addEventListener(
+        "error",
+        (event) => reject(new Error(event.detail ?? "php-wasm error")),
+        { once: true },
+      );
+    });
+
+    const php: PhpRunner = {
+      async run(code: string): Promise<PhpRunResult> {
+        let stdout = "";
+        const onOutput = (event: Event & { detail?: string | undefined }) => {
+          stdout += event.detail ?? "";
+        };
+        instance.addEventListener("output", onOutput);
+        try {
+          const exitCode = await instance.run(code);
+          return { exitCode, stdout };
+        } finally {
+          instance.removeEventListener("output", onOutput);
+        }
+      },
+    };
+    return { php, phpWasmVersion };
+  } catch (err: unknown) {
+    const errAny = err as { stack?: string; message?: string } | null;
+    const message =
+      (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
+    setVerdict(
+      "fail",
+      `reproduction failed — runtime error during php-wasm load: ${message}`,
+    );
+    throw err;
+  }
+}

--- a/src/layer1_wasm/php-12167/README.md
+++ b/src/layer1_wasm/php-12167/README.md
@@ -1,0 +1,112 @@
+# Reproduction — php/php-src#12167
+
+> Phase 2 reproduction page — second non-Pyodide entry in Vivarium's
+> gallery (after [`ruby-21709/`](../ruby-21709/)). Conforms to
+> `vivarium-contract: v1`.
+
+## The bug
+
+[php/php-src#12167](https://github.com/php/php-src/issues/12167) —
+PHP's `SimpleXMLElement::xpath('//processing-instruction()')` finds
+the processing-instruction node correctly, but casting that node to
+a string yields an empty value instead of the PI's content:
+
+```php
+<?php
+$xml = '<?xml version="1.0"?><foo><bar><?stylesheet hello ?></bar></foo>';
+$sxe = simplexml_load_string($xml);
+$pi  = $sxe->xpath("//processing-instruction()")[0];
+
+echo (string) $pi;   // BUG: ""        (expected "hello")
+```
+
+xpath returns the node — `count($pis) === 1` — so the bug is purely
+in the SimpleXML string-cast path for processing-instruction nodes.
+Fixed upstream in PHP 8.2.12; `php-wasm@0.0.8` ships PHP 8.2.11, so
+the page reproduces.
+
+## Why this bug
+
+- PHP standard library only — SimpleXML is a core extension shipped
+  by every mainstream PHP build (and bundled into php-wasm).
+- Verdict reduces to a boolean — `count($pis) === 1` ∧ `(string)
+  $pis[0] === ""` — so the page emits a mechanically-distinguishable
+  `pass` / `fail`.
+- Closed upstream by [PR #12190](https://github.com/php/php-src/pull/12190),
+  merged into `PHP-8.2.12`. Pyodide-style "sentinel" semantics: when
+  php-wasm bumps to a build ≥ 8.2.12, the verdict flips to `fail` and
+  the page becomes a fix-detection signal.
+- Reproduces without I/O, network, or non-default extensions — fits
+  the WASM cell shape exactly.
+
+## Files
+
+| File         | Role                                                              |
+| ------------ | ----------------------------------------------------------------- |
+| `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
+| `repro.ts`   | TypeScript source. Imports `loadVivariumPhp` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
+| `repro.php`  | **Native CLI variant.** Same reproduction logic, runnable directly under a real PHP interpreter. See "Native verification" below. |
+
+Shared visual presentation lives in
+[`../_shared/style.css`](../_shared/style.css). The php-wasm loader
+lives in [`../_shared/php_loader.ts`](../_shared/php_loader.ts).
+
+## Verdict contract — `vivarium-contract: v1`
+
+The page conforms to the contract canonicalised in
+[`../_shared/verdict.ts`](../_shared/verdict.ts). The `result` field
+of the envelope reports `xpath_count`, `pi_text`, `pi_text_empty`,
+and `reproduced` — enough for downstream tooling to distinguish the
+specific shape of any future change.
+
+A `pass` means **the bug reproduced** — xpath returned the PI node
+*and* its string-cast was empty. A `fail` means either the runtime
+ships a fix (PI string-cast now non-empty), or the runtime errored
+before producing a result.
+
+## Running locally — in-browser
+
+```bash
+cd src/layer1_wasm
+bun install
+bun run build
+python -m http.server -d . 8767
+# open http://localhost:8767/php-12167/
+```
+
+## Native verification — same reproduction under a real PHP
+
+The companion `repro.php` script reproduces the bug without any
+WASM layer, so a contributor can confirm the gallery page is
+catching a *real* upstream behaviour rather than a php-wasm
+quirk. The `.mise.toml` at the repo root pins PHP to **8.2.11**
+to match the version php-wasm bundles, so:
+
+```bash
+# One-time per machine / .mise.toml change.
+mise install
+
+# Reproduces the bug; exits 0 on `pass`.
+mise exec php -- php src/layer1_wasm/php-12167/repro.php
+
+# Expected output (8.2.11):
+# {
+#     "php_version": "8.2.11",
+#     "xpath_count": 1,
+#     "pi_text": "",
+#     "pi_text_empty": true
+# }
+# verdict=pass — bug reproduces on this interpreter
+```
+
+`mise install` may need a Unix-y toolchain (autoconf, libxml2
+headers, etc.) to build PHP from source — Linux and macOS work out
+of the box; on Windows use WSL or an equivalent layer. CI installs
+mise on a Linux runner.
+
+## Deployment
+
+Published to GitHub Pages at
+`https://aletheia-works.github.io/vivarium/repro/php-12167/` by the
+`deploy-docs` workflow.

--- a/src/layer1_wasm/php-12167/index.html
+++ b/src/layer1_wasm/php-12167/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="vivarium-contract" content="v1" />
+    <title>Vivarium · Reproducing php/php-src#12167</title>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <!-- Keep the version below in sync with DEFAULT_PHP_WASM_VERSION
+         in ../_shared/php_loader.ts. -->
+    <link
+      rel="modulepreload"
+      href="https://cdn.jsdelivr.net/npm/php-wasm@0.0.8/PhpWeb.mjs"
+      crossorigin
+    />
+    <link rel="stylesheet" href="../_shared/style.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <p class="kicker">Vivarium · Layer 1 · php-wasm</p>
+        <h1>Reproducing <a href="https://github.com/php/php-src/issues/12167">php/php-src#12167</a></h1>
+        <p class="lede">
+          PHP's SimpleXML can find a processing-instruction node via
+          <code>xpath("//processing-instruction()")</code>, but casting
+          that node to string yields an empty value instead of the
+          PI's content. xpath returns the node — the count is
+          <em>one</em> — so the bug is purely in the string-cast path
+          for processing-instruction nodes.
+        </p>
+      </header>
+
+      <section>
+        <h2>Verdict</h2>
+        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          Loading php-wasm runtime…
+        </div>
+        <p class="meta" id="meta"></p>
+      </section>
+
+      <section>
+        <h2>Reproduction script</h2>
+        <pre><code id="repro-code"></code></pre>
+      </section>
+
+      <section>
+        <h2>Output</h2>
+        <pre id="output">(running)</pre>
+      </section>
+
+      <footer>
+        <p class="meta">
+          Runtime:
+          <a href="https://github.com/seanmorris/php-wasm">php-wasm</a>
+          loaded from
+          <a href="https://www.jsdelivr.com/package/npm/php-wasm">cdn.jsdelivr.net</a>.
+          Source:
+          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/php-12167">vivarium/src/layer1_wasm/php-12167</a>.
+        </p>
+      </footer>
+    </main>
+
+    <script type="module" src="./repro.js"></script>
+  </body>
+</html>

--- a/src/layer1_wasm/php-12167/repro.php
+++ b/src/layer1_wasm/php-12167/repro.php
@@ -1,0 +1,44 @@
+<?php
+// Vivarium Layer 1 reproduction — php/php-src#12167, native variant.
+//
+// Mirrors the script that runs in `repro.ts` (under php-wasm) so a
+// contributor can re-verify the bug against a real PHP interpreter:
+//
+//   mise install               # one-time, picks up .mise.toml
+//   mise exec php -- php src/layer1_wasm/php-12167/repro.php
+//
+// The script prints `pass` if the bug REPRODUCES (xpath returns the
+// processing-instruction node but casting it to string yields ""),
+// `fail` otherwise — same verdict semantics as the in-browser page.
+// Exit code: 0 on `pass`, 1 on `fail` so CI can shell-script around
+// it without parsing stdout.
+
+$xml = '<?xml version="1.0"?><foo><bar><?stylesheet hello ?></bar></foo>';
+$sxe = simplexml_load_string($xml);
+$pis = $sxe->xpath("//processing-instruction()");
+$pi_text = isset($pis[0]) ? (string) $pis[0] : null;
+
+$result = [
+    "php_version"   => PHP_VERSION,
+    "xpath_count"   => count($pis ?: []),
+    "pi_text"       => $pi_text,
+    "pi_text_empty" => $pi_text === "",
+];
+
+$reproduced = $result["xpath_count"] === 1 && $result["pi_text_empty"];
+
+echo json_encode($result, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . "\n";
+
+if ($reproduced) {
+    fwrite(STDOUT, "verdict=pass — bug reproduces on this interpreter\n");
+    exit(0);
+} elseif ($result["xpath_count"] === 1 && !$result["pi_text_empty"]) {
+    fwrite(STDOUT, "verdict=fail — SimpleXML now returns the PI content (likely fixed upstream)\n");
+    exit(1);
+} else {
+    fwrite(
+        STDOUT,
+        "verdict=fail — unexpected outcome (xpath_count={$result['xpath_count']}, pi_text=" . json_encode($result["pi_text"]) . ")\n",
+    );
+    exit(1);
+}

--- a/src/layer1_wasm/php-12167/repro.ts
+++ b/src/layer1_wasm/php-12167/repro.ts
@@ -1,0 +1,142 @@
+// Vivarium Layer 1 reproduction — php/php-src#12167.
+//
+// `SimpleXMLElement::xpath('//processing-instruction()')` returns a
+// node, but casting that node to string yields an empty value instead
+// of the PI's content:
+//   $xml = '<?xml version="1.0"?><foo><bar><?stylesheet hello ?></bar></foo>';
+//   $sxe = simplexml_load_string($xml);
+//   $pi  = $sxe->xpath("//processing-instruction()")[0];
+//   (string) $pi;   // => ""    (BUG, expected "hello")
+// xpath finds the node — `count($pis) === 1` — so the issue is purely
+// in the SimpleXML string-cast path for processing-instruction nodes.
+//
+// Verdict semantics (per ADR-0008 / contract v1):
+//   - "pass" — the bug REPRODUCES (PI string cast is empty).
+//   - "fail" — the bug does NOT reproduce (the runtime ships a fix,
+//     or the runtime errored before producing a result).
+
+import { loadVivariumPhp } from "../_shared/php_loader.js";
+import {
+  setResult,
+  setVerdict,
+  type VivariumResultV1,
+} from "../_shared/verdict.js";
+
+const REPRO_CODE = `<?php
+$xml = '<?xml version="1.0"?><foo><bar><?stylesheet hello ?></bar></foo>';
+$sxe = simplexml_load_string($xml);
+$pis = $sxe->xpath("//processing-instruction()");
+$pi_text = isset($pis[0]) ? (string) $pis[0] : null;
+
+echo json_encode([
+  "php_version" => PHP_VERSION,
+  "xpath_count" => count($pis ?: []),
+  "pi_text" => $pi_text,
+  "pi_text_empty" => $pi_text === "",
+]);
+`;
+
+interface ReproOutput {
+  php_version: string;
+  xpath_count: number;
+  pi_text: string | null;
+  pi_text_empty: boolean;
+}
+
+const outputEl = document.getElementById("output");
+const metaEl = document.getElementById("meta");
+const reproCodeEl = document.getElementById("repro-code");
+
+if (!outputEl || !metaEl || !reproCodeEl) {
+  throw new Error(
+    "php-12167: missing required DOM elements (#output, #meta, #repro-code).",
+  );
+}
+
+reproCodeEl.textContent = REPRO_CODE;
+
+const startedAt = new Date();
+
+try {
+  const { php, phpWasmVersion } = await loadVivariumPhp({
+    pendingText: "Loading php-wasm runtime and stdlib…",
+  });
+
+  setVerdict("pending", "Running reproduction script…");
+  const { exitCode, stdout } = await php.run(REPRO_CODE);
+  if (exitCode !== 0) {
+    throw new Error(
+      `php-wasm exited non-zero (code=${exitCode}); stdout=${stdout}`,
+    );
+  }
+  const result = JSON.parse(stdout) as ReproOutput;
+
+  metaEl.textContent =
+    `PHP ${result.php_version} via php-wasm v${phpWasmVersion}.`;
+  outputEl.textContent = JSON.stringify(result, null, 2);
+
+  // Bug reproduces iff xpath finds the PI node (count === 1) but
+  // string-casting it yields an empty string.
+  const reproduced = result.xpath_count === 1 && result.pi_text_empty;
+
+  if (reproduced) {
+    setVerdict(
+      "pass",
+      "reproduction succeeded — SimpleXML xpath returns the processing-instruction node, but casting it to string yields an empty value.",
+    );
+  } else if (
+    result.xpath_count === 1 &&
+    !result.pi_text_empty &&
+    result.pi_text !== null
+  ) {
+    setVerdict(
+      "fail",
+      "reproduction failed — SimpleXML now returns the PI content correctly (likely fixed upstream).",
+    );
+  } else {
+    setVerdict(
+      "fail",
+      `reproduction failed — unexpected outcome (xpath_count=${result.xpath_count}, pi_text=${JSON.stringify(result.pi_text)}).`,
+    );
+  }
+
+  const finishedAt = new Date();
+  const envelope: VivariumResultV1 = {
+    contract: "v1",
+    bug: {
+      project: "php",
+      issue: 12167,
+      upstream_url: "https://github.com/php/php-src/issues/12167",
+    },
+    runtime: {
+      name: "php-wasm",
+      version: phpWasmVersion,
+      extras: {
+        php: result.php_version,
+      },
+    },
+    result: {
+      xpath_count: result.xpath_count,
+      pi_text: result.pi_text,
+      pi_text_empty: result.pi_text_empty,
+      reproduced,
+    },
+    timing: {
+      started_at: startedAt.toISOString(),
+      finished_at: finishedAt.toISOString(),
+      duration_ms: finishedAt.getTime() - startedAt.getTime(),
+    },
+  };
+  setResult(envelope);
+} catch (err: unknown) {
+  console.error(err);
+  const errAny = err as { stack?: string; message?: string } | null;
+  outputEl.textContent =
+    (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
+  if (globalThis.__VIVARIUM_VERDICT__ !== "fail") {
+    setVerdict(
+      "fail",
+      `reproduction failed — runtime error: ${errAny?.message ?? String(err)}`,
+    );
+  }
+}

--- a/src/layer1_wasm/tests/repro.spec.ts
+++ b/src/layer1_wasm/tests/repro.spec.ts
@@ -28,10 +28,10 @@ interface ReproCase {
   expectedBugIssue: number;
   /**
    * Envelope `runtime.name`. `"browser"` for the smoke test (no WASM
-   * runtime loaded), `"pyodide"` / `"ruby.wasm"` for reproductions
-   * that bootstrap a language runtime over WebAssembly.
+   * runtime loaded); the rest are language runtimes bootstrapped over
+   * WebAssembly.
    */
-  expectedRuntimeName: "browser" | "pyodide" | "ruby.wasm";
+  expectedRuntimeName: "browser" | "pyodide" | "ruby.wasm" | "php-wasm";
 }
 
 const cases: ReproCase[] = [
@@ -74,6 +74,14 @@ const cases: ReproCase[] = [
     expectedBugProject: "cpython",
     expectedBugIssue: 137205,
     expectedRuntimeName: "pyodide",
+  },
+  {
+    name: "php-12167 reproduction",
+    path: "/php-12167/",
+    expectedVerdict: "pass",
+    expectedBugProject: "php",
+    expectedBugIssue: 12167,
+    expectedRuntimeName: "php-wasm",
   },
 ];
 


### PR DESCRIPTION
## Summary

Adds Vivarium's third Layer 1 runtime — **php-wasm** (PHP) — with a real reproduction page for [php/php-src#12167](https://github.com/php/php-src/issues/12167) (\`SimpleXMLElement::xpath('//processing-instruction()')\` returns the PI node, but casting it to string yields an empty value). Supersedes draft scaffold [#82](https://github.com/aletheia-works/vivarium/pull/82) (close on merge).

Also introduces a **native re-verification** convention so each gallery page can be checked against a real interpreter, not just its WASM build, with mise pinning every interpreter to the same major.minor.patch the WASM page bundles.

## How the bug was found

1. **Smoke spike** — loaded \`php-wasm\` from jsDelivr with no version pin to discover what PHP it actually ships. Result: PHP **8.2.11**, Linux, 32-bit, Zend 4.2.11, 27 bundled extensions including SimpleXML, sqlite3, mbstring.
2. **Pin** — the npm package's \`latest\` tag is \`0.0.8\`; pinned the loader to \`php-wasm@0.0.8\` so future jsDelivr re-tags can't silently change the runtime under us.
3. **Bug selection** — cross-referenced PHP 8.2.12's NEWS file for stdlib bugs fixed against 8.2.11. SimpleXML had four candidates (GH-12167/12169/12170/12223). Tried each against the live php-wasm; **GH-12167 (Processing instruction empty string-cast)** reproduced cleanly with a 3-line script.

## Verdict on the bundled runtime

Verified locally on \`php-wasm@0.0.8\` (PHP 8.2.11): page reports **\`pass\`** with \`xpath_count: 1\`, \`pi_text: \"\"\`, \`pi_text_empty: true\`, \`reproduced: true\`. Verdict text:
> reproduction succeeded — SimpleXML xpath returns the processing-instruction node, but casting it to string yields an empty value.

## Native re-verification (new convention)

Per offline discussion, each Phase 2 page now ships a CLI variant of its reproduction script alongside the in-browser TypeScript variant:

- \`php-12167/repro.ts\` — runs in-browser via php-wasm (existing pattern)
- \`php-12167/repro.php\` — runs under a real PHP via \`php repro.php\` (new)

\`.mise.toml\` is updated with \`php = \"8.2.11\"\` and \`ruby = \"3.3.3\"\` so contributors can mirror the WASM-bundled runtimes locally:

\`\`\`bash
mise install
mise exec php -- php src/layer1_wasm/php-12167/repro.php
# verdict=pass — bug reproduces on this interpreter
\`\`\`

The \`mise install\` step needs a Unix-y toolchain to build the interpreters; on Windows that means WSL or equivalent. No global install of PHP/Ruby is performed — everything lives under \`~/.local/share/mise/\`.

A follow-up small PR will add the analogous \`ruby-21709/repro.rb\` (already merged in #79). It could not be bundled here without rewriting #79's history.

## Files

- New: \`src/layer1_wasm/_shared/php_loader.ts\` — php-wasm loader, symmetric to \`loader.ts\` (Pyodide) and \`ruby_loader.ts\` (Ruby.wasm). Pins \`php-wasm@0.0.8\`.
- New: \`src/layer1_wasm/php-12167/{repro.ts,index.html,README.md,repro.php}\`.
- Edited: \`.mise.toml\` — adds \`php = \"8.2.11\"\` and \`ruby = \"3.3.3\"\` with a comment explaining the pinning rationale.
- Edited: \`src/layer1_wasm/tests/repro.spec.ts\` — extends \`expectedRuntimeName\` with \`\"php-wasm\"\` and adds the php-12167 case (expected \`pass\`).
- Edited: \`docs/docs/repro/index.md\` — adds a \"Layer 1 — php-wasm (PHP)\" section, mentions the native re-verification flow with \`mise exec\`.

## Verdict semantics

- \`pass\` — bug reproduces (xpath returns the PI node ∧ string-cast is empty)
- \`fail\` — runtime ships a fix (string-cast non-empty), or runtime errored before producing a result

When php-wasm bumps to a build with PHP ≥ 8.2.12, the verdict flips to \`fail\` and the page becomes a fix-detection signal — same pattern as the Pyodide / Ruby.wasm pages.

## Test plan

- [x] \`bun run typecheck\` passes locally
- [x] \`bun run build\` produces \`php-12167/repro.js\` and \`_shared/php_loader.js\`
- [x] Browser load on PHP 8.2.11 reaches \`pass\` (verified via Playwright-style globals \`__VIVARIUM_VERDICT__\` / \`__VIVARIUM_RESULT__\`)
- [x] CI \`repro-regression\` green on this PR
- [x] CI \`deploy-docs\` publishes \`/repro/php-12167/\`

## Closes

- Supersedes draft scaffold [#82](https://github.com/aletheia-works/vivarium/pull/82) — close on merge.