### PR TITLE
feat(ruby): add native repro.rb for ruby#21709 to mirror the WASM page

### DIFF
--- a/src/layer1_wasm/ruby-21709/README.md
+++ b/src/layer1_wasm/ruby-21709/README.md
@@ -43,6 +43,7 @@ of different encodings. The disagreement is the bug surface.
 | `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
 | `repro.ts`   | TypeScript source. Imports `loadVivariumRuby` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
 | `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
+| `repro.rb`   | **Native CLI variant.** Same reproduction logic, runnable directly under a real Ruby interpreter. See "Native verification" below. |
 
 Shared visual presentation lives in [`../_shared/style.css`](../_shared/style.css).
 The Ruby.wasm loader lives in [`../_shared/ruby_loader.ts`](../_shared/ruby_loader.ts).
@@ -61,7 +62,7 @@ while String interpolation succeeded. A `fail` means either the
 runtime ships a fix (both forms succeed, or both raise the same
 way), or the runtime errored before producing a result.
 
-## Running locally
+## Running locally — in-browser
 
 ```bash
 cd src/layer1_wasm
@@ -70,6 +71,39 @@ bun run build
 python -m http.server -d . 8767
 # open http://localhost:8767/ruby-21709/
 ```
+
+## Native verification — same reproduction under a real Ruby
+
+The companion `repro.rb` script reproduces the bug without any
+WASM layer, so a contributor can confirm the gallery page is
+catching a *real* upstream behaviour rather than a Ruby.wasm
+quirk. The `.mise.toml` at the repo root pins Ruby to **3.3.3**
+to match the version `@ruby/3.3-wasm-wasi` bundles, so:
+
+```bash
+# One-time per machine / .mise.toml change.
+mise install
+
+# Reproduces the bug; exits 0 on `pass`.
+mise exec ruby -- ruby src/layer1_wasm/ruby-21709/repro.rb
+
+# Expected output (Ruby 3.3.3):
+# {
+#   "ruby_version": "3.3.3",
+#   "regexp_built": false,
+#   "regexp_raised": "RegexpError",
+#   "string_built": true,
+#   "string_encoding": "UTF-8",
+#   "string_raised": null,
+#   "reproduced": true
+# }
+# verdict=pass — bug reproduces on this interpreter
+```
+
+`mise install` may need a Unix-y toolchain (ruby-build, openssl
+headers, etc.) — Linux and macOS work out of the box; on Windows
+use WSL or an equivalent layer. CI installs mise on a Linux
+runner.
 
 ## Deployment
 

--- a/src/layer1_wasm/ruby-21709/repro.rb
+++ b/src/layer1_wasm/ruby-21709/repro.rb
@@ -1,0 +1,55 @@
+# Vivarium Layer 1 reproduction — ruby/ruby#21709, native variant.
+#
+# Mirrors the script that runs in `repro.ts` (under Ruby.wasm) so a
+# contributor can re-verify the bug against a real Ruby interpreter:
+#
+#   mise install                     # one-time, picks up .mise.toml
+#   mise exec ruby -- ruby src/layer1_wasm/ruby-21709/repro.rb
+#
+# Prints `pass` if the bug REPRODUCES (Regexp interpolation rejects
+# the mixed-encoding combine ∧ String interpolation accepts it),
+# `fail` otherwise. Exit code: 0 on `pass`, 1 on `fail` so CI can
+# shell-script around it without parsing stdout.
+
+require "json"
+
+result = { ruby_version: RUBY_VERSION }
+
+prefix = '\p{In_Arabic}'
+suffix = '\p{In_Arabic}'.encode("US-ASCII")
+
+begin
+  re = /#{prefix}#{suffix}/
+  result[:regexp_built] = true
+  result[:regexp_raised] = nil
+rescue => e
+  result[:regexp_built] = false
+  result[:regexp_raised] = e.class.name
+end
+
+begin
+  s = "#{prefix}#{suffix}"
+  result[:string_built] = true
+  result[:string_encoding] = s.encoding.name
+  result[:string_raised] = nil
+rescue => e
+  result[:string_built] = false
+  result[:string_encoding] = nil
+  result[:string_raised] = e.class.name
+end
+
+reproduced = !result[:regexp_built] && result[:string_built]
+result[:reproduced] = reproduced
+
+puts JSON.pretty_generate(result)
+
+if reproduced
+  warn "verdict=pass — bug reproduces on this interpreter"
+  exit 0
+elsif result[:regexp_built] && result[:string_built]
+  warn "verdict=fail — Regexp and String interpolation now agree (likely fixed upstream)"
+  exit 1
+else
+  warn "verdict=fail — unexpected outcome (regexp_built=#{result[:regexp_built]}, string_built=#{result[:string_built]})"
+  exit 1
+end


### PR DESCRIPTION
## Summary

Adds the native CLI variant for the existing [ruby-21709](https://aletheia-works.github.io/vivarium/repro/ruby-21709/) gallery page, completing the **native re-verification convention** introduced in [#84](https://github.com/aletheia-works/vivarium/pull/84) (PHP) for the Ruby reproduction that landed earlier in [#79](https://github.com/aletheia-works/vivarium/pull/79).

The reproduction logic is bit-for-bit the same as \`repro.ts\`, just expressed in pure Ruby — so a contributor can confirm the bug is a real upstream behaviour and not a Ruby.wasm-specific quirk:

\`\`\`bash
mise install                                     # picks up Ruby 3.3.3 from .mise.toml
mise exec ruby -- ruby src/layer1_wasm/ruby-21709/repro.rb
# verdict=pass — bug reproduces on this interpreter
\`\`\`

This could not be folded into #79 because that PR has already merged; #84 already added the \`.mise.toml\` pin (\`ruby = \"3.3.3\"\`) so this PR only needs to drop in the script and link it from the page README.

## Files

- New: \`src/layer1_wasm/ruby-21709/repro.rb\` — pure-Ruby variant of the reproduction. \`exit 0\` on \`pass\`, \`exit 1\` on \`fail\`, with the same JSON envelope on stdout that the WASM page publishes via \`__VIVARIUM_RESULT__.result\`.
- Edited: \`src/layer1_wasm/ruby-21709/README.md\`:
  - Adds \`repro.rb\` to the Files table.
  - Renames the \"Running locally\" section to \"Running locally — in-browser\" for symmetry with the new \"Native verification\" section.
  - Adds a \"Native verification — same reproduction under a real Ruby\" section with the \`mise exec\` invocation and expected output.

## Why split this out

#79 was already merged when the native re-verification convention was discussed offline; #84 introduced it for PHP. Folding the analogous Ruby script into a tiny follow-up PR is the smallest-diff way to bring ruby-21709 onto the same convention, while keeping the change reviewable next to the PHP precedent.

## Test plan

- [x] \`bun run typecheck\` unaffected (\`.rb\` is outside TS rootDir)
- [x] \`bun run build\` unaffected
- [x] (optional) \`mise install && mise exec ruby -- ruby src/layer1_wasm/ruby-21709/repro.rb\` on a Linux / macOS runner exits 0
- [x] CI green on this PR