### PR TITLE
fix(ci): set working-directory override on deploy-docs Rust install step

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -96,6 +96,13 @@ jobs:
         # each `<slug>/Cargo.toml` can compile to a browser-loadable
         # artefact (the page boots it via `@bjorn3/browser_wasi_shim`).
         # Skipped silently if no Rust crate is present.
+        #
+        # Override the job-level `working-directory: docs` so the glob
+        # below resolves against the repo root — without this the
+        # `crates=(...)` array stays empty, the step exits early, and
+        # the next step then fails with `can't find crate for 'core'`
+        # because rustup never ran.
+        working-directory: ${{ github.workspace }}
         run: |
           set -euo pipefail
           shopt -s nullglob


### PR DESCRIPTION
## Summary

\`deploy-docs\` on \`main\` has been red since PR [#86](https://github.com/aletheia-works/vivarium/pull/86) merged: the Rust build step exits with \`error[E0463]: can't find crate for 'core'\`. Pages deploy never ran for the regex-779 commit.

## Root cause

\`deploy-docs.yml\` declares a job-level default:

\`\`\`yaml
defaults:
  run:
    working-directory: docs
\`\`\`

When I added the Rust install step in #86 I missed that default and never overrode it. The early-exit guard inside the step looks for crates with a path **relative to the working directory**:

\`\`\`bash
crates=(src/layer1_wasm/*/Cargo.toml)
if [ \${#crates[@]} -eq 0 ]; then
  echo \"No src/layer1_wasm/*/Cargo.toml; skipping Rust setup.\"
  exit 0
fi
\`\`\`

From \`docs/\` the glob expands to nothing, the early-exit fires, and **rustup never installs**. The next step (\"Build Layer 1 Rust artefacts\") *does* override \`working-directory\` to \`\${{ github.workspace }}\`, so it correctly enters \`src/layer1_wasm/regex-779/\` and runs \`cargo build\` — but with no toolchain and no \`wasm32-wasip1\` target, the build fails on the first transitive crate (\`memchr\`).

\`repro-regression.yml\` does not exhibit the bug because both Rust steps there share the same \`working-directory: \${{ github.workspace }}\` override; only the deploy workflow has the asymmetric defaults.

## Fix

Add \`working-directory: \${{ github.workspace }}\` to the Install Rust toolchain step, mirroring the build step that follows it. One-line change with a comment that names the failure mode so the same trip-hazard doesn't catch the next person.

## Why \`fix(ci)\`?

Same prefix used in [#83](https://github.com/aletheia-works/vivarium/pull/83) for the previous post-#79/#84 merge-interaction fix. The mismatch between deploy-docs job defaults and the new step is squarely a CI configuration issue.

## Test plan

- [x] CI \`deploy-docs\` on this PR's branch runs the new step at workspace root (visible in the log via \`Building Rust crate: regex-779\` followed by a successful build).
- [x] CI \`repro-regression\` on this PR remains green (no regression).
- [x] After merge, \`deploy-docs\` on \`main\` re-runs and successfully publishes \`/repro/regex-779/\` with \`repro.wasm\`.