### PR TITLE
feat(python): add native repro.py for pandas/numpy/cpython entries with PEP 723 metadata

### DIFF
--- a/docs/docs/repro/index.md
+++ b/docs/docs/repro/index.md
@@ -83,13 +83,21 @@ to the last 1.8.x line; bumping past 1.9 will flip the verdict to
 ## Native re-verification
 
 Each gallery page has a companion CLI variant — `repro.py`,
-`repro.rb`, or `repro.php` — that runs the *same* logic against a
-real native interpreter, with no WASM layer involved. The
-`.mise.toml` at the repo root pins each interpreter to the same
-major.minor.patch the WASM runtime bundles, so:
+`repro.rb`, `repro.php`, or (for Rust) the same `Cargo.toml` +
+`src/main.rs` — that runs the *same* logic against a real native
+interpreter / compiler, with no WASM layer involved. The
+`.mise.toml` at the repo root pins each runtime to the same
+major.minor.patch (or pip dependency pin) the WASM runtime
+bundles. Python pages use [PEP 723](https://peps.python.org/pep-0723/)
+inline metadata and `uv run` so each script declares its own
+package pins (`pandas==2.3.3`, `numpy==2.2.5`, …) without a
+shared `requirements.txt`.
 
 ```bash
 mise install                                                    # one-time per machine
+mise exec uv   -- uv run src/layer1_wasm/pandas-56679/repro.py
+mise exec uv   -- uv run src/layer1_wasm/numpy-28287/repro.py
+mise exec uv   -- uv run src/layer1_wasm/cpython-137205/repro.py
 mise exec ruby -- ruby src/layer1_wasm/ruby-21709/repro.rb
 mise exec php  -- php  src/layer1_wasm/php-12167/repro.php
 mise exec rust -- cargo run --release --manifest-path src/layer1_wasm/regex-779/Cargo.toml

--- a/src/layer1_wasm/cpython-137205/README.md
+++ b/src/layer1_wasm/cpython-137205/README.md
@@ -60,6 +60,7 @@ the Python API surface.
 | `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
 | `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
 | `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
+| `repro.py`   | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. The bug is in the CPython binding layer, so no third-party deps are needed (PEP 723 `dependencies = []`). See "Native verification" below. |
 
 ## Verdict contract — `vivarium-contract: v1`
 
@@ -73,7 +74,7 @@ on the PRAGMA value). A `fail` means either the runtime ships a fix
 (both connections agree), or the runtime errored before producing a
 result.
 
-## Running locally
+## Running locally — in-browser
 
 ```bash
 cd src/layer1_wasm
@@ -81,6 +82,19 @@ bun install
 bun run build
 python -m http.server -d . 8767
 # open http://localhost:8767/cpython-137205/
+```
+
+## Native verification — same reproduction under a real CPython
+
+The companion `repro.py` script reproduces the bug without any
+WASM layer. The bug lives in the CPython `sqlite3` binding layer,
+not in libsqlite3 itself, so no third-party packages are needed.
+The `.mise.toml` at the repo root pins Python to 3.13:
+
+```bash
+mise install
+mise exec uv -- uv run src/layer1_wasm/cpython-137205/repro.py
+# verdict=pass — autocommit=False silently drops PRAGMA foreign_keys
 ```
 
 ## Deployment

--- a/src/layer1_wasm/cpython-137205/repro.py
+++ b/src/layer1_wasm/cpython-137205/repro.py
@@ -1,0 +1,66 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = []
+# ///
+"""Vivarium Layer 1 reproduction — python/cpython#137205, native variant.
+
+Mirrors the script that runs in `repro.ts` (under Pyodide) so a
+contributor can re-verify the bug against a real CPython interpreter
++ the host's bundled `sqlite3` extension:
+
+    mise install                                                       # one-time
+    mise exec uv -- uv run src/layer1_wasm/cpython-137205/repro.py
+
+`sqlite3` is part of the standard library, so PEP 723's
+`dependencies = []` is sufficient — no third-party packages needed.
+The bug is in the CPython binding layer, not in libsqlite3 itself,
+so the result depends only on the Python interpreter version and not
+on the SQLite version baked into it. The Pyodide page exercises the
+same Python 3.13 binding through the `sqlite3` Pyodide package; this
+CLI exercises the same binding through whatever CPython 3.13 build
+mise installs.
+
+Prints `pass` if the bug REPRODUCES (the two connections disagree
+on PRAGMA foreign_keys), `fail` otherwise. Exit code: 0 on `pass`,
+1 on `fail`.
+"""
+
+import json
+import sqlite3
+import sys
+
+off = sqlite3.connect(":memory:", autocommit=False)
+off.execute("PRAGMA foreign_keys = ON")
+off.commit()
+
+on = sqlite3.connect(":memory:", autocommit=True)
+on.execute("PRAGMA foreign_keys = ON")
+
+off_value = int(off.execute("PRAGMA foreign_keys").fetchone()[0])
+on_value = int(on.execute("PRAGMA foreign_keys").fetchone()[0])
+fk_disagreement = off_value != on_value
+
+result = {
+    "python_version": sys.version.split()[0],
+    "sqlite_version": sqlite3.sqlite_version,
+    "off_autocommit_fk": off_value,
+    "on_autocommit_fk": on_value,
+    "fk_disagreement": fk_disagreement,
+    "reproduced": fk_disagreement,
+}
+
+print(json.dumps(result, indent=2))
+
+if fk_disagreement:
+    print(
+        "verdict=pass — autocommit=False silently drops PRAGMA foreign_keys",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+else:
+    print(
+        "verdict=fail — both connections agree on PRAGMA foreign_keys "
+        "(likely fixed upstream)",
+        file=sys.stderr,
+    )
+    sys.exit(1)

--- a/src/layer1_wasm/numpy-28287/README.md
+++ b/src/layer1_wasm/numpy-28287/README.md
@@ -40,6 +40,7 @@ contradicts itself is a clear violation.
 | `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
 | `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
 | `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
+| `repro.py`   | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. See "Native verification" below. |
 
 Shared visual presentation lives in [`../_shared/style.css`](../_shared/style.css).
 
@@ -64,7 +65,7 @@ non-transitive ordering). A `fail` means either the bug was fixed in the
 version Pyodide currently ships, or the runtime itself errored before
 producing a result.
 
-## Running locally
+## Running locally — in-browser
 
 ```bash
 # 1. From src/layer1_wasm/, build the TypeScript sources once.
@@ -79,6 +80,19 @@ python -m http.server -d . 8767
 
 Pyodide does not require COOP/COEP headers (no `SharedArrayBuffer`, no
 threading), so a plain server is enough.
+
+## Native verification — same reproduction under a real CPython + NumPy
+
+The companion `repro.py` script reproduces the bug without any
+WASM layer. PEP 723 inline metadata pins **`numpy==2.2.5`** — the
+exact version Pyodide v0.29.3 bundles — and the `.mise.toml` at the
+repo root pins Python to 3.13:
+
+```bash
+mise install
+mise exec uv -- uv run src/layer1_wasm/numpy-28287/repro.py
+# verdict=pass — timedelta64 ordering is non-transitive
+```
 
 ## Deployment
 

--- a/src/layer1_wasm/numpy-28287/repro.py
+++ b/src/layer1_wasm/numpy-28287/repro.py
@@ -1,0 +1,64 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#   "numpy==2.2.5",
+# ]
+# ///
+"""Vivarium Layer 1 reproduction — numpy/numpy#28287, native variant.
+
+Mirrors the script that runs in `repro.ts` (under Pyodide) so a
+contributor can re-verify the bug against a real CPython interpreter
++ a real NumPy build:
+
+    mise install                                                  # one-time
+    mise exec uv -- uv run src/layer1_wasm/numpy-28287/repro.py
+
+PEP 723 inline metadata pins numpy to **2.2.5** — the exact version
+Pyodide v0.29.3 ships — so the page and this CLI exercise the same
+code path.
+
+Prints `pass` if the bug REPRODUCES (`timedelta64` ordering is
+non-transitive across the generic unit), `fail` otherwise. Exit
+code: 0 on `pass`, 1 on `fail`.
+"""
+
+import json
+import sys
+
+import numpy as np
+
+x = np.timedelta64(1, "ms")
+y = np.timedelta64(2)
+z = np.timedelta64(5, "ns")
+
+x_lt_y = bool(x < y)
+y_lt_z = bool(y < z)
+x_lt_z = bool(x < z)
+transitivity_violated = x_lt_y and y_lt_z and not x_lt_z
+
+result = {
+    "numpy_version": np.__version__,
+    "python_version": sys.version.split()[0],
+    "x_lt_y": x_lt_y,
+    "y_lt_z": y_lt_z,
+    "x_lt_z": x_lt_z,
+    "transitivity_violated": transitivity_violated,
+    "reproduced": transitivity_violated,
+}
+
+print(json.dumps(result, indent=2))
+
+if transitivity_violated:
+    print(
+        "verdict=pass — timedelta64 ordering is non-transitive "
+        "(x < y < z but x ≥ z)",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+else:
+    print(
+        "verdict=fail — timedelta64 ordering is transitive "
+        "(likely fixed upstream)",
+        file=sys.stderr,
+    )
+    sys.exit(1)

--- a/src/layer1_wasm/pandas-56679/README.md
+++ b/src/layer1_wasm/pandas-56679/README.md
@@ -33,6 +33,7 @@ Originally selected as Phase 0's "easiest to debug at a glance" PoC:
 | `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
 | `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
 | `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
+| `repro.py`   | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. See "Native verification" below. |
 
 Shared visual presentation lives in [`../_shared/style.css`](../_shared/style.css);
 this directory no longer carries its own copy.
@@ -58,7 +59,7 @@ exhibits the inconsistency). A `fail` means either the bug was fixed in
 the version Pyodide currently ships, or the runtime itself errored
 before producing a result.
 
-## Running locally
+## Running locally — in-browser
 
 ```bash
 # 1. From src/layer1_wasm/, build the TypeScript sources once.
@@ -73,6 +74,35 @@ python -m http.server -d pandas-56679 8765
 
 Pyodide does **not** require COOP/COEP headers for this page (no
 `SharedArrayBuffer`, no threading), so a plain server is enough.
+
+## Native verification — same reproduction under a real CPython + pandas
+
+The companion `repro.py` script reproduces the bug without any
+WASM layer, so a contributor can confirm the gallery page is
+catching a *real* upstream behaviour rather than a Pyodide quirk.
+PEP 723 inline metadata pins **`pandas==2.3.3`** — the exact
+version Pyodide v0.29.3 bundles — and the `.mise.toml` at the repo
+root pins Python to 3.13:
+
+```bash
+# One-time per machine / .mise.toml change.
+mise install
+
+# Reproduces the bug; exits 0 on `pass`. uv reads the inline
+# metadata, builds an ephemeral venv, and runs the script.
+mise exec uv -- uv run src/layer1_wasm/pandas-56679/repro.py
+
+# Expected output (pandas 2.3.3):
+# {
+#   "pandas_version": "2.3.3",
+#   "python_version": "3.13.x",
+#   "series_dtype": "object",
+#   "df_dtype": "float64",
+#   "mismatch": true,
+#   "reproduced": true
+# }
+# verdict=pass — Series and DataFrame disagree on empty-input dtype
+```
 
 ## Deployment
 

--- a/src/layer1_wasm/pandas-56679/repro.py
+++ b/src/layer1_wasm/pandas-56679/repro.py
@@ -1,0 +1,58 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#   "pandas==2.3.3",
+# ]
+# ///
+"""Vivarium Layer 1 reproduction — pandas-dev/pandas#56679, native variant.
+
+Mirrors the script that runs in `repro.ts` (under Pyodide) so a
+contributor can re-verify the bug against a real CPython interpreter
++ a real pandas build:
+
+    mise install                                                    # one-time
+    mise exec uv -- uv run src/layer1_wasm/pandas-56679/repro.py
+
+PEP 723 inline metadata pins pandas to **2.3.3** — the exact version
+Pyodide v0.29.3 bundles — so the page and this CLI exercise the same
+code path. `uv run` reads the metadata and creates an ephemeral venv
+on first invocation; subsequent runs hit uv's cache.
+
+Prints `pass` if the bug REPRODUCES (Series and DataFrame disagree on
+empty-input dtype), `fail` otherwise. Exit code: 0 on `pass`, 1 on
+`fail` so CI can shell-script around it without parsing stdout.
+"""
+
+import json
+import sys
+
+import pandas as pd
+
+series_dtype = str(pd.Series([]).dtype)
+df_dtype = str(pd.DataFrame({"a": []})["a"].dtype)
+mismatch = series_dtype != df_dtype
+
+result = {
+    "pandas_version": pd.__version__,
+    "python_version": sys.version.split()[0],
+    "series_dtype": series_dtype,
+    "df_dtype": df_dtype,
+    "mismatch": mismatch,
+    "reproduced": mismatch,
+}
+
+print(json.dumps(result, indent=2))
+
+if mismatch:
+    print(
+        "verdict=pass — Series and DataFrame disagree on empty-input dtype",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+else:
+    print(
+        "verdict=fail — Series and DataFrame agree on empty-input dtype "
+        "(likely fixed upstream)",
+        file=sys.stderr,
+    )
+    sys.exit(1)


### PR DESCRIPTION
## Summary

Closes the **native re-verification** convention loop for Phase 1: every Pyodide-backed gallery page now ships a companion \`repro.py\` that runs the same reproduction logic against a real CPython + a real pandas / numpy build, mirroring the Ruby ([#85](https://github.com/aletheia-works/vivarium/pull/85)) and PHP ([#84](https://github.com/aletheia-works/vivarium/pull/84)) and Rust ([#86](https://github.com/aletheia-works/vivarium/pull/86)) precedents.

After this PR every Layer 1 page satisfies the same \"WASM + native\" symmetry — a contributor can confirm any reproduction is catching a real upstream behaviour rather than a Pyodide / Ruby.wasm / php-wasm / WASI-shim quirk.

## What changes

Three new files + three README touches + one gallery doc tweak:

- New: \`src/layer1_wasm/pandas-56679/repro.py\` — pinned to \`pandas==2.3.3\` via PEP 723 inline metadata (same version Pyodide v0.29.3 bundles).
- New: \`src/layer1_wasm/numpy-28287/repro.py\` — pinned to \`numpy==2.2.5\`.
- New: \`src/layer1_wasm/cpython-137205/repro.py\` — \`dependencies = []\`; the bug is in the CPython \`sqlite3\` binding, not in libsqlite3 itself, so no third-party deps are needed.
- Edited: each page's \`README.md\` — adds \`repro.py\` to the Files table and a \"Native verification\" section with the \`mise exec uv -- uv run …\` invocation and expected output.
- Edited: \`docs/docs/repro/index.md\` — the gallery's existing \"Native re-verification\" block now lists the three new \`uv run …\` invocations next to the Ruby / PHP / Rust ones, and the prose calls out PEP 723 + \`uv run\` as the Python pinning mechanism (instead of bumping \`.mise.toml\` for every page).

## Why PEP 723 + \`uv run\`?

PEP 723 lets each script declare its own dependency pins inline — no shared \`requirements.txt\`, no per-script venv to manage. \`uv run\` reads the metadata, materialises an ephemeral cached venv, and executes the script. That keeps each gallery page self-contained: bumping pandas for a future pandas-XYZ entry doesn't touch other pages, and there's no global \"which pandas does Vivarium pin\" question to keep in sync.

\`uv\` is already pinned in \`.mise.toml\` (\`uv = \"latest\"\`), so no infra change is needed for this PR.

## Test plan

- [x] \`python -m py_compile\` clean on all three scripts (syntax check)
- [x] \`bun run typecheck\` unaffected (\`.py\` is outside TS rootDir)
- [x] (optional) \`mise install && mise exec uv -- uv run src/layer1_wasm/<slug>/repro.py\` on a Linux / macOS runner exits 0 for each of the three pages
- [x] CI \`repro-regression\` green on this PR
- [x] CI \`deploy-docs\` ships the new files under \`/repro/<slug>/repro.py\`

## Out of scope

- A CI step that actually *runs* the native scripts on every push — the gallery's contract today is the in-browser verdict captured by Playwright; the \`repro.py\` / \`repro.rb\` / \`repro.php\` files are for human re-verification, not regression. A follow-up PR could add a matrix workflow that also asserts the native scripts exit 0 on a Linux runner; deliberately deferred to keep this PR small.