### PR TITLE
feat(layer2): verdict snapshot UI for Layer 2 pages (_layer2-shared + per-page index.html)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -326,7 +326,14 @@ jobs:
             slug="$(basename "$entry")"
             case "$slug" in
               _*)
-                echo "Skipping Layer 2 underscore-prefixed dir: ${slug}"
+                # Underscore-prefixed dirs are shared scaffolding
+                # (e.g. `_layer2-shared/` with the verdict
+                # snapshot renderer). Bundle them under the same
+                # `<pages-base>/repro/` root so per-page
+                # `index.html` files can reference
+                # `../_layer2-shared/...`.
+                echo "Bundling Layer 2 shared module: ${slug}"
+                cp -R "$entry" "$dest/"
                 continue
                 ;;
             esac

--- a/src/layer2_docker/_layer2-shared/layer2.js
+++ b/src/layer2_docker/_layer2-shared/layer2.js
@@ -1,0 +1,129 @@
+// Vivarium Layer 2 — verdict snapshot renderer.
+//
+// Each Layer 2 page ships a minimal `index.html` that imports
+// this module and calls `renderVerdictSnapshot({…})` once. The
+// module fetches `./verdict.json` (CI-generated, sitting next to
+// the HTML in the deployed Pages artefact) and:
+//   - flips the DOM `#verdict[data-verdict]` element to
+//     "pass" / "fail" with human-readable text;
+//   - publishes `__VIVARIUM_VERDICT__` and `__VIVARIUM_RESULT__`
+//     globals matching the contract-v1 surface Layer 1 uses, so
+//     the same Playwright suite can later assert against
+//     Layer 2 pages without bespoke wiring;
+//   - injects the captured stdout into `#output` and the
+//     image / digest / exit-code metadata into `#meta`.
+//
+// Per ADR-0010, Layer 2 verdicts are snapshots: the page reports
+// what CI saw the last time the image was built and run. The
+// visitor's local `docker run` is the live confirmation.
+
+/**
+ * @param {Object} options
+ * @param {string} options.verdictUrl  Path to verdict.json. Defaults to "./verdict.json".
+ * @param {{project: string, issue: number | string, upstream_url: string}} options.bug
+ *   Page metadata, surfaced through `__VIVARIUM_RESULT__.bug`.
+ *   `issue` may be 0 (or a string slug) for catalogue entries
+ *   that are documented behaviours rather than numbered defects.
+ */
+export async function renderVerdictSnapshot(options) {
+  const verdictUrl = options.verdictUrl ?? "./verdict.json";
+  const bug = options.bug;
+
+  const verdictEl = document.getElementById("verdict");
+  const metaEl = document.getElementById("meta");
+  const outputEl = document.getElementById("output");
+
+  if (!verdictEl) {
+    throw new Error('layer2: missing element with id="verdict".');
+  }
+
+  function setVerdict(state, text) {
+    verdictEl.classList.remove("pass", "fail", "pending");
+    verdictEl.classList.add(state);
+    verdictEl.dataset.verdict = state;
+    verdictEl.textContent = text;
+    globalThis.__VIVARIUM_VERDICT__ = state;
+  }
+
+  setVerdict("pending", "Fetching CI verdict snapshot…");
+
+  try {
+    const response = await fetch(verdictUrl, { cache: "no-cache" });
+    if (!response.ok) {
+      throw new Error(
+        `failed to fetch ${verdictUrl}: HTTP ${response.status} ${response.statusText}`,
+      );
+    }
+    const snap = await response.json();
+
+    if (snap.contract !== "v1") {
+      throw new Error(
+        `verdict.json contract mismatch: expected "v1", got ${JSON.stringify(snap.contract)}`,
+      );
+    }
+
+    const verdict = snap.verdict;
+    if (verdict !== "pass" && verdict !== "fail") {
+      throw new Error(
+        `verdict.json verdict must be "pass" or "fail"; got ${JSON.stringify(verdict)}`,
+      );
+    }
+
+    const verb = verdict === "pass" ? "succeeded" : "failed";
+    setVerdict(
+      verdict,
+      `reproduction ${verb} (CI snapshot captured ${snap.captured_at})`,
+    );
+
+    if (metaEl) {
+      const lines = [
+        `Image: ${snap.image_tag}`,
+        snap.image_digest ? `Digest: ${snap.image_digest}` : null,
+        `Exit code: ${snap.exit_code}`,
+        `Captured at: ${snap.captured_at}`,
+      ].filter(Boolean);
+      // `<br>` between lines so the meta line-breaks render visibly.
+      // textContent collapses newlines under default `<p>` styling.
+      metaEl.replaceChildren();
+      lines.forEach((line, i) => {
+        if (i > 0) metaEl.appendChild(document.createElement("br"));
+        metaEl.appendChild(document.createTextNode(line));
+      });
+    }
+
+    if (outputEl) {
+      outputEl.textContent = snap.stdout || "(no stdout captured)";
+    }
+
+    globalThis.__VIVARIUM_RESULT__ = {
+      contract: "v1",
+      bug,
+      runtime: {
+        name: "docker-snapshot",
+        version: snap.image_digest || snap.image_tag,
+        extras: {
+          image_tag: snap.image_tag,
+          captured_at: snap.captured_at,
+        },
+      },
+      result: {
+        exit_code: snap.exit_code,
+        verdict,
+        stderr_tail: snap.stderr_tail || "",
+      },
+      timing: {
+        // Layer 2 pages don't run the reproduction in-page; the
+        // timing fields below all reference the CI snapshot's
+        // capture time.
+        started_at: snap.captured_at,
+        finished_at: snap.captured_at,
+        duration_ms: 0,
+      },
+    };
+  } catch (err) {
+    console.error(err);
+    const msg = (err && (err.message || String(err))) || "unknown error";
+    setVerdict("fail", `verdict snapshot unavailable: ${msg}`);
+    if (outputEl) outputEl.textContent = String(err.stack || err.message || err);
+  }
+}

--- a/src/layer2_docker/_layer2-shared/style.css
+++ b/src/layer2_docker/_layer2-shared/style.css
@@ -1,0 +1,162 @@
+:root {
+  color-scheme: light dark;
+  --fg: #1f2328;
+  --fg-muted: #57606a;
+  --bg: #ffffff;
+  --bg-muted: #f6f8fa;
+  --border: #d0d7de;
+  --pass-bg: #dafbe1;
+  --pass-fg: #116329;
+  --fail-bg: #ffebe9;
+  --fail-fg: #82071e;
+  --pending-bg: #ddf4ff;
+  --pending-fg: #0969da;
+  --link: #0969da;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --fg: #e6edf3;
+    --fg-muted: #8d96a0;
+    --bg: #0d1117;
+    --bg-muted: #161b22;
+    --border: #30363d;
+    --pass-bg: #033a16;
+    --pass-fg: #56d364;
+    --fail-bg: #5a1e1e;
+    --fail-fg: #ff7b72;
+    --pending-bg: #0c2d6b;
+    --pending-fg: #79c0ff;
+    --link: #79c0ff;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family:
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    "Helvetica Neue",
+    Arial,
+    sans-serif;
+  line-height: 1.55;
+}
+
+main {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 2.5rem 1.25rem 4rem;
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+.kicker {
+  margin: 0 0 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--fg-muted);
+}
+
+h1 {
+  margin: 0 0 0.75rem;
+  font-size: 1.6rem;
+  line-height: 1.3;
+}
+
+h2 {
+  font-size: 1.05rem;
+  margin: 1.75rem 0 0.5rem;
+  letter-spacing: 0.01em;
+}
+
+.lede {
+  margin: 0;
+  color: var(--fg-muted);
+}
+
+a {
+  color: var(--link);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+code {
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    "SF Mono",
+    Menlo,
+    Consolas,
+    monospace;
+  font-size: 0.9em;
+  background: var(--bg-muted);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+}
+
+pre {
+  background: var(--bg-muted);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.85rem 1rem;
+  overflow-x: auto;
+  margin: 0;
+}
+
+pre code {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.verdict {
+  font-weight: 600;
+  padding: 0.85rem 1rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+}
+
+.verdict.pending {
+  background: var(--pending-bg);
+  color: var(--pending-fg);
+  border-color: var(--pending-fg);
+}
+
+.verdict.pass {
+  background: var(--pass-bg);
+  color: var(--pass-fg);
+  border-color: var(--pass-fg);
+}
+
+.verdict.fail {
+  background: var(--fail-bg);
+  color: var(--fail-fg);
+  border-color: var(--fail-fg);
+}
+
+.meta {
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+  margin: 0.5rem 0 0;
+}
+
+footer {
+  margin-top: 3rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--border);
+}

--- a/src/layer2_docker/bash-local-shadows-exit/index.html
+++ b/src/layer2_docker/bash-local-shadows-exit/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="vivarium-contract" content="v1" />
+    <title>Vivarium · Reproducing bash `local` shadows command-substitution exit code</title>
+    <link rel="stylesheet" href="../_layer2-shared/style.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <p class="kicker">Vivarium · Layer 2 · Docker (catalogue)</p>
+        <h1>Bash <code>local</code> shadows command-substitution exit code</h1>
+        <p class="lede">
+          When <code>local</code> is combined with command
+          substitution, <code>local</code>'s own (always-zero) exit
+          code overrides the right-hand side. <code>set -e</code>
+          therefore silently bypasses failures on the RHS, leading
+          to silent breakage in production scripts. Documented
+          bash + POSIX behaviour, not an upstream defect — the
+          page makes the surprise reproducible in seconds.
+        </p>
+      </header>
+
+      <section>
+        <h2>CI verdict snapshot</h2>
+        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          Loading verdict snapshot…
+        </div>
+        <p class="meta" id="meta"></p>
+      </section>
+
+      <section>
+        <h2>Reproduce yourself</h2>
+        <pre><code>docker run --rm ghcr.io/aletheia-works/vivarium-bash-local-shadows-exit:latest</code></pre>
+        <p class="meta">
+          First-pull cost ~10 MB (bash:5.2 alpine). Run takes
+          under a second. See the
+          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker/bash-local-shadows-exit">
+            recipe directory</a> for the <code>Dockerfile</code> and
+          <code>repro.sh</code>.
+        </p>
+      </section>
+
+      <section>
+        <h2>CI snapshot output</h2>
+        <pre id="output">(loading…)</pre>
+      </section>
+
+      <footer>
+        <p class="meta">
+          Layer 2 pages report a CI-snapshot verdict; the visitor's
+          local <code>docker run</code> is the live confirmation.
+          See <a href="../">/repro/</a> for the gallery.
+        </p>
+      </footer>
+    </main>
+
+    <script type="module">
+      import { renderVerdictSnapshot } from "../_layer2-shared/layer2.js";
+      renderVerdictSnapshot({
+        bug: {
+          project: "bash",
+          issue: 0,
+          upstream_url: "https://mywiki.wooledge.org/BashFAQ/105",
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/src/layer2_docker/flock-is-advisory/index.html
+++ b/src/layer2_docker/flock-is-advisory/index.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="vivarium-contract" content="v1" />
+    <title>Vivarium · Reproducing flock(2) is advisory only</title>
+    <link rel="stylesheet" href="../_layer2-shared/style.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <p class="kicker">Vivarium · Layer 2 · Docker (catalogue)</p>
+        <h1>Linux <code>flock(2)</code> is advisory only</h1>
+        <p class="lede">
+          A program holding an exclusive <code>flock</code> on a
+          file does not stop <code>cat</code>, <code>cp</code>,
+          <code>grep</code>, or any other tool that doesn't
+          itself call <code>flock</code> from reading or writing
+          the file. Linux file locks are advisory: only programs
+          that opt in see the lock. Many developers
+          misunderstand this; the page lets you confirm the
+          surprise end-to-end.
+        </p>
+      </header>
+
+      <section>
+        <h2>CI verdict snapshot</h2>
+        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          Loading verdict snapshot…
+        </div>
+        <p class="meta" id="meta"></p>
+      </section>
+
+      <section>
+        <h2>Reproduce yourself</h2>
+        <pre><code>docker run --rm ghcr.io/aletheia-works/vivarium-flock-is-advisory:latest</code></pre>
+        <p class="meta">
+          First-pull cost ~10 MB (alpine:3.19 + util-linux). Run
+          takes ~2.5 s. See the
+          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker/flock-is-advisory">
+            recipe directory</a> for the <code>Dockerfile</code> and
+          <code>repro.sh</code>.
+        </p>
+      </section>
+
+      <section>
+        <h2>CI snapshot output</h2>
+        <pre id="output">(loading…)</pre>
+      </section>
+
+      <footer>
+        <p class="meta">
+          Layer 2 pages report a CI-snapshot verdict; the visitor's
+          local <code>docker run</code> is the live confirmation.
+          See <a href="../">/repro/</a> for the gallery.
+        </p>
+      </footer>
+    </main>
+
+    <script type="module">
+      import { renderVerdictSnapshot } from "../_layer2-shared/layer2.js";
+      renderVerdictSnapshot({
+        bug: {
+          project: "flock",
+          issue: 0,
+          upstream_url: "https://man7.org/linux/man-pages/man2/flock.2.html",
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/src/layer2_docker/postgres-lost-update/index.html
+++ b/src/layer2_docker/postgres-lost-update/index.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="vivarium-contract" content="v1" />
+    <title>Vivarium · Reproducing PostgreSQL lost update under READ COMMITTED</title>
+    <link rel="stylesheet" href="../_layer2-shared/style.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <p class="kicker">Vivarium · Layer 2 · Docker (catalogue)</p>
+        <h1>PostgreSQL lost update under <code>READ COMMITTED</code></h1>
+        <p class="lede">
+          Two concurrent application-side <code>read → modify →
+          write</code> transactions under PostgreSQL's default
+          <code>READ COMMITTED</code> isolation can silently lose one
+          increment. The page below shows CI's most recent
+          reproduction snapshot. Run the recipe locally to confirm
+          the same behaviour against your own Docker.
+        </p>
+      </header>
+
+      <section>
+        <h2>CI verdict snapshot</h2>
+        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          Loading verdict snapshot…
+        </div>
+        <p class="meta" id="meta"></p>
+      </section>
+
+      <section>
+        <h2>Reproduce yourself</h2>
+        <pre><code>docker run --rm ghcr.io/aletheia-works/vivarium-postgres-lost-update:latest</code></pre>
+        <p class="meta">
+          First-pull cost ~80 MB (postgres:16-alpine). Run takes
+          ~5 s. See the
+          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker/postgres-lost-update">
+            recipe directory</a> for the <code>Dockerfile</code> and
+          <code>repro.sh</code>.
+        </p>
+      </section>
+
+      <section>
+        <h2>CI snapshot output</h2>
+        <pre id="output">(loading…)</pre>
+      </section>
+
+      <footer>
+        <p class="meta">
+          Layer 2 pages report a CI-snapshot verdict; the visitor's
+          local <code>docker run</code> is the live confirmation.
+          See <a href="../">/repro/</a> for the gallery.
+        </p>
+      </footer>
+    </main>
+
+    <script type="module">
+      import { renderVerdictSnapshot } from "../_layer2-shared/layer2.js";
+      renderVerdictSnapshot({
+        bug: {
+          project: "postgres",
+          issue: 0,
+          upstream_url: "https://www.postgresql.org/docs/current/transaction-iso.html",
+        },
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Lands the **verdict snapshot UI** for Layer 2 pages — each page now renders as a real HTML document at \`/repro/<slug>/\` with the same contract-v1 surface Layer 1 pages publish (\`#verdict[data-verdict]\`, \`__VIVARIUM_VERDICT__\`, \`__VIVARIUM_RESULT__\`). The page reads \`./verdict.json\` (CI-generated) and surfaces the captured pass/fail, the image tag/digest, the run timestamp, and the captured stdout.

This closes the visible gap from the catalogue model: before this PR, \`/repro/postgres-lost-update/\` etc. served the raw recipe directory (Dockerfile, README, verdict.json) but had no rendered page; now each page is a normal browse-able URL with the verdict at the top.

## What changes

### New: \`src/layer2_docker/_layer2-shared/\`

Layer 2 shared assets, bundled to \`/repro/_layer2-shared/\` by \`deploy-docs.yml\`:

- **\`style.css\`** — verbatim copy of \`src/layer1_wasm/_shared/style.css\`. Distinct path so Layer 1 / Layer 2 stays loosely coupled — either side can evolve its visuals without touching the other.
- **\`layer2.js\`** — \`renderVerdictSnapshot({verdictUrl, bug})\`. Fetches \`./verdict.json\`, validates contract v1, sets \`__VIVARIUM_VERDICT__\` and \`__VIVARIUM_RESULT__\` (with \`runtime.name = \"docker-snapshot\"\`), populates \`#verdict\`, \`#meta\` (image / digest / exit code / captured-at), and \`#output\` (captured stdout). Graceful fallback: if \`verdict.json\` is missing the page reports \`fail\` with \"verdict snapshot unavailable\".

### New: per-page \`index.html\` (3 files)

Static HTML for each Layer 2 entry, all following the same shape:

- \`src/layer2_docker/postgres-lost-update/index.html\`
- \`src/layer2_docker/bash-local-shadows-exit/index.html\`
- \`src/layer2_docker/flock-is-advisory/index.html\`

Each page declares \`<meta name=\"vivarium-contract\" content=\"v1\">\`, surfaces the bug description in plain markdown-ish prose, exposes the canonical \`docker run …\` command, and imports \`renderVerdictSnapshot\` from the shared module.

### Edited: \`.github/workflows/deploy-docs.yml\`

The Layer 2 bundle step now copies underscore-prefixed shared dirs (matching Layer 1's behaviour). Without this fix \`_layer2-shared/\` would be skipped by the existing \`case _*) … skip\` branch, and the per-page \`<link href=\"../_layer2-shared/style.css\">\` would 404 on Pages.

### .gitignore (no change)

\`verdict.json\` was already ignored by [#92](https://github.com/aletheia-works/vivarium/pull/92); this PR doesn't touch the rule.

## Verified locally

Local preview server (\`python -m http.server -d src/layer2_docker 8768\`) running against a manually-generated \`verdict.json\` for \`flock-is-advisory\` (built and run on Docker Desktop, exit 0):

- Page renders the \"reproduction succeeded\" green badge, captured timestamp, image tag, exit code = 0, the captured stdout JSON envelope.
- \`globalThis.__VIVARIUM_VERDICT__ === \"pass\"\`.
- \`globalThis.__VIVARIUM_RESULT__.runtime.name === \"docker-snapshot\"\`.
- \`bug.project === \"flock\"\`, \`bug.upstream_url\` set to the flock(2) man page URL.

Negative path also verified: \`postgres-lost-update\` (no local \`verdict.json\`) renders \`verdict snapshot unavailable: failed to fetch ./verdict.json: HTTP 404\` with \`__VIVARIUM_VERDICT__ === \"fail\"\`. CI deploys ship a real \`verdict.json\`, so the \"unavailable\" path only appears on dev environments.

## Why distinct \`_layer2-shared/\` (not reuse Layer 1's \`_shared/\`)

\`src/layer1_wasm/_shared/\` deploys to \`/repro/_shared/\`. Sharing that path with Layer 2 would force the two layers' loose coupling into a single shared directory whose contents serve different contracts (Layer 1's \`verdict.ts\` is a runtime helper for in-page WASM execution; Layer 2 needs a snapshot fetcher). Distinct paths keep each layer's \`_shared\` evolving independently.

CSS is duplicated verbatim today; if it diverges later the separation makes that easy. If it converges, a follow-up can hoist a single shared stylesheet to a layer-agnostic path.

## Test plan

- [x] Local preview verifies the pass-path verdict UI for \`flock-is-advisory\` (real Docker run output, contract v1 surface populated).
- [x] Local preview verifies the fail-path UI when \`verdict.json\` is absent.
- [x] CI \`repro-regression\` builds and runs all three Layer 2 images.
- [x] CI \`deploy-docs\` (post-merge) bundles \`_layer2-shared/\` under \`/repro/\` and the per-page \`index.html\` resolves \`../_layer2-shared/style.css\` + \`layer2.js\` correctly.
- [x] After merge, visiting \`https://aletheia-works.github.io/vivarium/repro/flock-is-advisory/\` shows the verdict snapshot UI with CI's actual capture.

## Out of scope

- **Playwright assertions for Layer 2 pages.** Adding Layer 2 entries to \`tests/repro.spec.ts\` would need either (a) a separate webserver pointing at \`src/layer2_docker/\` or (b) extending the regression suite to cover both layers via separate \`projects:\` in \`playwright.config.ts\`. Either is straightforward; deferred to a follow-up PR so this one keeps the diff compact.
- **wterm-based stdout renderer.** Vivarium [evaluated wterm](https://github.com/vercel-labs/wterm) (a 12 KB Zig→WASM terminal emulator) for the \`#output\` block. Decided not to depend on a v0.2.0 third-party for this PR; current \`<pre>\` rendering is enough since the captured stdout is mostly plain JSON with very few ANSI escapes. Reconsider when wterm hits a stable 1.x.