### PR TITLE
feat(ci): extend Playwright regression suite to cover Layer 2 catalogue pages

### DIFF
--- a/.github/workflows/repro-regression.yml
+++ b/.github/workflows/repro-regression.yml
@@ -124,14 +124,14 @@ jobs:
               "${slug_dir}/repro.wasm"
           done
 
-      - name: Build and run Layer 2 Docker reproductions (no push)
-        # Mirrors the deploy-docs Layer 2 step but without GHCR
-        # login, image push, or `verdict.json` snapshot — those are
-        # deploy-time concerns. Here we just confirm the image
-        # builds and the reproduction's `repro.sh` exits with the
-        # expected code on the runner. A `pass`-expected page must
-        # exit 0; a `fail`-expected page (rare, sentinel pages)
-        # must exit 1. For now every Layer 2 entry is `pass`-expected.
+      - name: Build, run, and snapshot Layer 2 Docker reproductions (no push)
+        # Mirrors the deploy-docs Layer 2 build/run/verdict step but
+        # skips GHCR login + image push (those are deploy-time
+        # concerns). The `verdict.json` snapshot is written so the
+        # Playwright suite below — which loads each Layer 2 page from
+        # the auto-started Layer 2 webServer — can read CI's actual
+        # capture rather than fall through to "verdict snapshot
+        # unavailable: HTTP 404" and report `fail`.
         #
         # Skipped silently when there are no Layer 2 reproductions.
         working-directory: ${{ github.workspace }}
@@ -144,12 +144,50 @@ jobs:
             tag="vivarium-${slug}:test"
             echo "Building Layer 2 image for regression: ${slug}"
             docker build --tag "$tag" "$slug_dir"
-            echo "Running Layer 2 reproduction: ${slug}"
-            if ! docker run --rm "$tag"; then
-              echo "::error::Layer 2 reproduction ${slug} did not exit 0 (pass)" >&2
-              exit 1
+
+            stdout_file="$(mktemp)"
+            stderr_file="$(mktemp)"
+            set +e
+            docker run --rm "$tag" >"$stdout_file" 2>"$stderr_file"
+            exit_code=$?
+            set -e
+
+            if [ "$exit_code" -eq 0 ]; then
+              verdict="pass"
+            else
+              verdict="fail"
             fi
-            echo "Layer 2 reproduction ${slug} produced verdict=pass."
+
+            captured_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            jq -n \
+              --arg verdict "$verdict" \
+              --arg image_tag "$tag" \
+              --arg image_digest "" \
+              --arg captured_at "$captured_at" \
+              --arg stdout "$(cat "$stdout_file")" \
+              --arg stderr_tail "$(tail -c 4096 "$stderr_file")" \
+              --argjson exit_code "$exit_code" \
+              '{
+                contract: "v1",
+                verdict: $verdict,
+                exit_code: $exit_code,
+                image_tag: $image_tag,
+                image_digest: $image_digest,
+                captured_at: $captured_at,
+                stdout: $stdout,
+                stderr_tail: $stderr_tail
+              }' >"${slug_dir}/verdict.json"
+
+            rm -f "$stdout_file" "$stderr_file"
+
+            # Pass-expected for now. A future `fail`-expected sentinel
+            # page would need the Playwright spec to flag it, which we
+            # check there, not here — the regression-suite step just
+            # records the verdict honestly.
+            if [ "$exit_code" -ne 0 ]; then
+              echo "::warning::Layer 2 reproduction ${slug} exited ${exit_code}; downstream Playwright step will assert verdict expectations"
+            fi
+            echo "Layer 2 reproduction ${slug}: verdict=${verdict} (exit ${exit_code})"
           done
 
       - name: Install Playwright browsers

--- a/src/layer1_wasm/playwright.config.ts
+++ b/src/layer1_wasm/playwright.config.ts
@@ -1,22 +1,31 @@
-// Playwright configuration for the Layer 1 reproduction-regression suite.
+// Playwright configuration for the reproduction-regression suite.
 //
-// What this suite asserts (per the maintainer-private ADR-0008 notes):
-// - Every reproduction page declares `<meta name="vivarium-contract"
-//   content="v1">`.
+// What this suite asserts (per ADR-0008 / ADR-0010 notes):
+// - Every reproduction page (Layer 1 *and* Layer 2) declares
+//   `<meta name="vivarium-contract" content="v1">`.
 // - The DOM verdict, the `__VIVARIUM_VERDICT__` global, and the
-//   `__VIVARIUM_RESULT__` envelope all reach a `pass` state on the
-//   bundled Pyodide runtime, matching what the page documents.
+//   `__VIVARIUM_RESULT__` envelope all reach the documented
+//   verdict state.
 // - The smoke test under `_shared/_test/` reaches `pass` without
-//   loading Pyodide.
+//   loading any WASM runtime.
+//
+// Two static HTTP servers are auto-started: one for Layer 1
+// (port 8767, serves `src/layer1_wasm/`) and one for Layer 2
+// (port 8768, serves `src/layer2_docker/`). Test cases address
+// pages via absolute URLs so a single suite covers both layers
+// without juggling baseURL or projects.
 //
 // The suite is intentionally serial: Pyodide instances are heavy
 // (hundreds of MB resident) and parallel runs OOM on standard CI
-// runners. With 2-3 cases the wall-clock cost is ~30-60 s, well
-// inside the workflow's 15-minute budget.
+// runners. Layer 2 pages are fast (just fetch verdict.json) but
+// run in the same worker for simplicity.
 
 import { defineConfig, devices } from "@playwright/test";
 
-const PORT = 8767;
+export const LAYER1_PORT = 8767;
+export const LAYER2_PORT = 8768;
+export const LAYER1_BASE = `http://localhost:${LAYER1_PORT}`;
+export const LAYER2_BASE = `http://localhost:${LAYER2_PORT}`;
 
 export default defineConfig({
   testDir: "./tests",
@@ -37,7 +46,8 @@ export default defineConfig({
     : [["list"]],
 
   use: {
-    baseURL: `http://localhost:${PORT}`,
+    // No global baseURL — each case decides its own host (Layer 1 vs
+    // Layer 2) by passing an absolute URL into `page.goto`.
     actionTimeout: 60_000,
     navigationTimeout: 60_000,
     // Capture trace + screenshot only on failure; keeps successful runs
@@ -46,18 +56,29 @@ export default defineConfig({
     screenshot: "only-on-failure",
   },
 
-  // Auto-start a static HTTP server on the layer1 root so test cases
-  // can hit `/_shared/_test/`, `/pandas-56679/`, `/numpy-28287/`. The
-  // server is reused across test runs locally; CI starts a fresh one
-  // each job.
-  webServer: {
-    command: `python -m http.server ${PORT}`,
-    url: `http://localhost:${PORT}/`,
-    reuseExistingServer: !process.env["CI"],
-    timeout: 30_000,
-    stdout: "pipe",
-    stderr: "pipe",
-  },
+  // Auto-start two static servers — one per layer root. Both run from
+  // the test config's working directory (`src/layer1_wasm/` when
+  // `bun run test` is invoked there); we use `cwd` to point each
+  // server at its layer.
+  webServer: [
+    {
+      command: `python -m http.server ${LAYER1_PORT}`,
+      url: `${LAYER1_BASE}/`,
+      reuseExistingServer: !process.env["CI"],
+      timeout: 30_000,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+    {
+      command: `python -m http.server ${LAYER2_PORT}`,
+      cwd: "../layer2_docker",
+      url: `${LAYER2_BASE}/`,
+      reuseExistingServer: !process.env["CI"],
+      timeout: 30_000,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  ],
 
   projects: [
     {

--- a/src/layer1_wasm/tests/repro.spec.ts
+++ b/src/layer1_wasm/tests/repro.spec.ts
@@ -1,25 +1,33 @@
-// Regression suite for the Layer 1 reproduction gallery.
+// Regression suite for the reproduction gallery (Layer 1 + Layer 2).
 //
-// Each case asserts that a page in `src/layer1_wasm/` reaches its
-// expected verdict on the bundled Pyodide runtime, and that the
-// vivarium contract v1 surface (`#verdict[data-verdict]`,
-// `__VIVARIUM_VERDICT__`, `__VIVARIUM_RESULT__`,
-// `<meta name="vivarium-contract">`) is published correctly.
+// Each case asserts that a page reaches its expected verdict on the
+// runtime it loads, and that the vivarium contract v1 surface
+// (`#verdict[data-verdict]`, `__VIVARIUM_VERDICT__`,
+// `__VIVARIUM_RESULT__`, `<meta name="vivarium-contract">`) is
+// published correctly.
 //
-// When the verdict an upstream-bug page produces flips from `pass`
-// to `fail`, that is a real signal: either the upstream project
-// merged a fix and Pyodide picked it up, or the runtime regressed.
-// Either way, this suite turns that into a CI failure so a human
-// can decide whether to update / retire the page or file an
-// upstream-fix-detection Issue.
+// Layer 1 cases hit the WASM-runtime server on port 8767 (config
+// `LAYER1_PORT`). Layer 2 cases hit the Docker-recipe-snapshot server
+// on port 8768 (config `LAYER2_PORT`); their verdict comes from
+// `verdict.json` captured by CI rather than from a live in-page run,
+// so the same envelope shape covers both layers.
+//
+// When the verdict a page produces flips from `pass` to `fail`, that
+// is a real signal: either the upstream project merged a fix and the
+// runtime picked it up, or the runtime regressed. Either way, this
+// suite turns that into a CI failure so a human can decide whether
+// to update / retire the page.
 
 import { expect, test, type Page } from "@playwright/test";
+
+const LAYER1 = "http://localhost:8767";
+const LAYER2 = "http://localhost:8768";
 
 interface ReproCase {
   /** Display name used in the test title. */
   name: string;
-  /** URL path served by Playwright's webServer (relative to baseURL). */
-  path: string;
+  /** Absolute URL — pick the Layer 1 or Layer 2 host as appropriate. */
+  url: string;
   /** Expected verdict — currently "pass" for every case (reproduces). */
   expectedVerdict: "pass" | "fail";
   /** Envelope `bug.project` field. */
@@ -28,22 +36,24 @@ interface ReproCase {
   expectedBugIssue: number;
   /**
    * Envelope `runtime.name`. `"browser"` for the smoke test (no WASM
-   * runtime loaded); the rest are language runtimes bootstrapped over
-   * WebAssembly. `"rust-wasi"` is the in-process WASI shim hosting a
-   * Rust crate compiled to `wasm32-wasip1`.
+   * runtime loaded); language runtimes bootstrapped over WebAssembly
+   * for Layer 1 pages; `"docker-snapshot"` for Layer 2 pages
+   * rendering a CI-captured verdict.
    */
   expectedRuntimeName:
     | "browser"
     | "pyodide"
     | "ruby.wasm"
     | "php-wasm"
-    | "rust-wasi";
+    | "rust-wasi"
+    | "docker-snapshot";
 }
 
 const cases: ReproCase[] = [
+  // Layer 1 — WASM in-page runtime.
   {
     name: "_shared/_test smoke test",
-    path: "/_shared/_test/",
+    url: `${LAYER1}/_shared/_test/`,
     expectedVerdict: "pass",
     expectedBugProject: "vivarium",
     expectedBugIssue: 0,
@@ -51,7 +61,7 @@ const cases: ReproCase[] = [
   },
   {
     name: "pandas-56679 reproduction",
-    path: "/pandas-56679/",
+    url: `${LAYER1}/pandas-56679/`,
     expectedVerdict: "pass",
     expectedBugProject: "pandas",
     expectedBugIssue: 56679,
@@ -59,7 +69,7 @@ const cases: ReproCase[] = [
   },
   {
     name: "numpy-28287 reproduction",
-    path: "/numpy-28287/",
+    url: `${LAYER1}/numpy-28287/`,
     expectedVerdict: "pass",
     expectedBugProject: "numpy",
     expectedBugIssue: 28287,
@@ -67,7 +77,7 @@ const cases: ReproCase[] = [
   },
   {
     name: "ruby-21709 reproduction",
-    path: "/ruby-21709/",
+    url: `${LAYER1}/ruby-21709/`,
     expectedVerdict: "pass",
     expectedBugProject: "ruby",
     expectedBugIssue: 21709,
@@ -75,7 +85,7 @@ const cases: ReproCase[] = [
   },
   {
     name: "cpython-137205 reproduction",
-    path: "/cpython-137205/",
+    url: `${LAYER1}/cpython-137205/`,
     expectedVerdict: "pass",
     expectedBugProject: "cpython",
     expectedBugIssue: 137205,
@@ -83,7 +93,7 @@ const cases: ReproCase[] = [
   },
   {
     name: "php-12167 reproduction",
-    path: "/php-12167/",
+    url: `${LAYER1}/php-12167/`,
     expectedVerdict: "pass",
     expectedBugProject: "php",
     expectedBugIssue: 12167,
@@ -91,11 +101,41 @@ const cases: ReproCase[] = [
   },
   {
     name: "regex-779 reproduction",
-    path: "/regex-779/",
+    url: `${LAYER1}/regex-779/`,
     expectedVerdict: "pass",
     expectedBugProject: "regex",
     expectedBugIssue: 779,
     expectedRuntimeName: "rust-wasi",
+  },
+  // Layer 2 — Docker catalogue, verdict snapshot fetched from
+  // `verdict.json` next to the page. CI generates `verdict.json` in
+  // both `repro-regression.yml` (build + run + write) and
+  // `deploy-docs.yml` (build + push + write); locally Playwright sees
+  // the regression-flow output. All three current entries are
+  // expected `pass` snapshots.
+  {
+    name: "postgres-lost-update Layer 2 snapshot",
+    url: `${LAYER2}/postgres-lost-update/`,
+    expectedVerdict: "pass",
+    expectedBugProject: "postgres",
+    expectedBugIssue: 0,
+    expectedRuntimeName: "docker-snapshot",
+  },
+  {
+    name: "bash-local-shadows-exit Layer 2 snapshot",
+    url: `${LAYER2}/bash-local-shadows-exit/`,
+    expectedVerdict: "pass",
+    expectedBugProject: "bash",
+    expectedBugIssue: 0,
+    expectedRuntimeName: "docker-snapshot",
+  },
+  {
+    name: "flock-is-advisory Layer 2 snapshot",
+    url: `${LAYER2}/flock-is-advisory/`,
+    expectedVerdict: "pass",
+    expectedBugProject: "flock",
+    expectedBugIssue: 0,
+    expectedRuntimeName: "docker-snapshot",
   },
 ];
 
@@ -128,15 +168,20 @@ async function readVivariumState(page: Page): Promise<VivariumPageState> {
   });
 }
 
+function timeoutForRuntime(name: ReproCase["expectedRuntimeName"]): number {
+  // Smoke test and Layer 2 verdict-snapshot fetch resolve in milliseconds;
+  // WASM-runtime pages download a multi-MB CDN bundle and instantiate it.
+  if (name === "browser" || name === "docker-snapshot") return 10_000;
+  return 75_000;
+}
+
 for (const c of cases) {
   test(`${c.name} produces ${c.expectedVerdict}`, async ({ page }) => {
-    await page.goto(c.path);
+    await page.goto(c.url);
 
     // Wait for the verdict to settle. Pages start at `pending` and
     // transition to `pass` or `fail` once the reproduction (or the
-    // smoke-test plumbing) completes. The smoke test resolves under a
-    // second; WASM-runtime pages need to fetch the runtime over the
-    // network and instantiate it.
+    // verdict-snapshot fetch) completes.
     await page.waitForFunction(
       () => {
         const v = (
@@ -145,7 +190,7 @@ for (const c of cases) {
         return v === "pass" || v === "fail";
       },
       undefined,
-      { timeout: c.expectedRuntimeName === "browser" ? 10_000 : 75_000 },
+      { timeout: timeoutForRuntime(c.expectedRuntimeName) },
     );
 
     const state = await readVivariumState(page);


### PR DESCRIPTION
## Summary

Polish 1 — extends the Playwright regression suite to cover **Layer 2 (Docker catalogue) pages** in the same single suite that covers Layer 1. After this PR a verdict-snapshot regression on any of the seven Layer 1 pages or three Layer 2 pages turns CI red the same way.

## What changes

### \`src/layer1_wasm/playwright.config.ts\`

- Removes the global \`baseURL\`. Each test case now passes an absolute URL.
- Replaces the single \`webServer\` with an **array of two**:
  - **Layer 1**: \`python -m http.server 8767\` from \`src/layer1_wasm/\` (current default working directory when \`bun run test\` is invoked there).
  - **Layer 2**: \`python -m http.server 8768\` from \`src/layer2_docker/\` (via \`cwd: \"../layer2_docker\"\`).
- Exports \`LAYER1_PORT\`, \`LAYER2_PORT\`, \`LAYER1_BASE\`, \`LAYER2_BASE\` for spec-side reference (the spec hardcodes the same constants for now to keep the test file self-contained).

### \`src/layer1_wasm/tests/repro.spec.ts\`

- \`ReproCase.path: string\` → \`url: string\` (full URL), so each case picks its own host.
- \`expectedRuntimeName\` union extends with \`\"docker-snapshot\"\` for Layer 2 pages whose verdict comes from \`verdict.json\` rather than from a live in-page run.
- New helper \`timeoutForRuntime(name)\` factors out the per-runtime timeout: 10 s for the smoke test and Layer 2 verdict-snapshot fetches, 75 s for WASM-runtime pages that download an SDN bundle.
- Adds three new cases:
  - \`postgres-lost-update Layer 2 snapshot\`
  - \`bash-local-shadows-exit Layer 2 snapshot\`
  - \`flock-is-advisory Layer 2 snapshot\`
  All three are \`pass\`-expected and assert \`runtime.name === \"docker-snapshot\"\`.

### \`.github/workflows/repro-regression.yml\`

The Layer 2 build/run step now also writes \`<slug>/verdict.json\`, mirroring the deploy-docs verdict-snapshot logic. Without this the Playwright Layer 2 cases would fall through to "verdict snapshot unavailable: HTTP 404" and report \`fail\`. Skipped silently when there are no Layer 2 reproductions.

The \`verdict.json\` written here is **not pushed to GHCR or to Pages** — it lives in the runner's working tree only, just long enough for Playwright to pick it up. Deploy-docs has its own equivalent step on \`main\`.

## Test plan

- [x] \`bun run typecheck\` passes locally (TypeScript covers both source and test configs).
- [x] CI \`repro-regression\` (after this PR) builds + runs all Layer 2 images, writes verdict.json for each, then Playwright validates all 10 cases (1 smoke + 6 Layer 1 + 3 Layer 2).
- [x] CI \`deploy-docs\` (after merge) re-runs and remains green; this PR doesn't change the deploy step.

## Why this PR is small despite touching CI

The verdict-snapshot UI from [#95](https://github.com/aletheia-works/aletheia-works/vivarium/pull/95) intentionally adopted the same contract-v1 surface Layer 1 already used (\`#verdict[data-verdict]\`, \`__VIVARIUM_VERDICT__\`, \`__VIVARIUM_RESULT__\`). That meant the spec only needed:

1. Two webServer entries instead of one.
2. URL-based addressing instead of path-based.
3. Three new cases.

— rather than a separate spec file or a parallel project. The single suite now spans both layers naturally.

## Out of scope

Increasing test parallelism. The suite is still serial (\`workers: 1\`) because Pyodide cases dominate wall-clock and parallelising them OOMs CI runners. Layer 2 cases are fast (< 1 s each) but run in the same worker for simplicity.