### PR TITLE
chore(infra): close Phase 3 milestone after Layer 2 catalogue lands

### DIFF
--- a/infra/github/milestones.tf
+++ b/infra/github/milestones.tf
@@ -37,6 +37,8 @@ locals {
     }
     "Phase 3 — Layer 2: Docker" = {
       description = "Full-fidelity reproduction for arbitrary projects, complex dependencies, and network-dependent bugs via devcontainer / Firecracker."
+      state       = "closed"
+      due_date    = "2026-04-27"
     }
     "Phase 4 — Layer 3: record-replay & deterministic" = {
       description = "rr / Pernosco-style record-replay and Antithesis-style deterministic simulation for problems Layers 1 and 2 cannot reach."


### PR DESCRIPTION
## Summary

- Mark `Phase 3 — Layer 2: Docker` as `closed` with `due_date = 2026-04-27` in `infra/github/milestones.tf`, mirroring the Phase 0–2 close pattern.
- Phase 3 shipped the Layer 2 catalogue model (Dockerfile + `repro.sh` + GHCR image per recipe), the verdict snapshot UI on each gallery page, and the Playwright regression suite covering Layer 2 pages.
- Four reproductions seed the catalogue: `postgres-lost-update`, `bash-local-shadows-exit`, `flock-is-advisory`, `find-xargs-whitespace`. Further diversity-axis expansion is intentionally community-driven and not a gating criterion for closing the phase.

## Test plan

- [x] `tofu plan` in `infra/github/` shows only the Phase 3 milestone state/due_date update
- [x] After apply, the Phase 3 milestone is closed on GitHub with the matching due date

https://claude.ai/code/session_01N82iPrKkcErHoto4JaDcKm

---
_Generated by [Claude Code](https://claude.ai/code/session_01N82iPrKkcErHoto4JaDcKm)_