### PR TITLE
docs(agents): document commitlint subject-case pitfall

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,21 @@ vivarium/
   bootstrap of vivarium`) and every squash commit thereafter.
 - Enforced by the reusable workflow at
   `aletheia-works/.github/.github/workflows/commitlint.yml`, which this repo
-  calls from `.github/workflows/commitlint.yml`.
+  calls from `.github/workflows/commitlint.yml`. The config is the unmodified
+  `@commitlint/config-conventional`.
+- **Subject case is the most common AI trip-wire.** The subject (the part
+  after `type(scope):`) must **start with a lowercase letter** —
+  `@commitlint/config-conventional` rejects sentence-case, start-case,
+  pascal-case, and upper-case via `subject-case`. So:
+  - ❌ `feat(ci): Phase 4 Stage A — rr replay PoC scaffold` (sentence-case)
+  - ✅ `feat(ci): phase 4 Stage A — rr replay PoC scaffold` (lowercase first
+    char; mixed case later in the line is fine — proper nouns and acronyms
+    only matter for the leading character)
+- Other rules worth remembering: subject must not end with `.`, header must
+  be ≤100 characters, `type` and `scope` must both be lowercase, the body
+  (if present) must be separated from the subject by a blank line, and
+  `type` must be one of the standard Conventional Commits set
+  (`feat`/`fix`/`docs`/`style`/`refactor`/`perf`/`test`/`build`/`ci`/`chore`/`revert`).
 
 ### 4.5 Early-stage commit policy
 


### PR DESCRIPTION
## Summary

`@commitlint/config-conventional` (the unmodified config the org-level reusable workflow uses) rejects **sentence-case subjects** via the `subject-case` rule. This is the trip-wire AI agents authoring commit messages most commonly miss — recent example: PR #103's `feat(ci): Phase 4 Stage A — ...` (capital "P" after the colon).

Add an explicit rule + good/bad example to [`AGENTS.md`](AGENTS.md) §4.4 so future agent sessions catch it before the commitlint workflow does. Also inline the other commonly-missed rules (no trailing `.`, ≤100 char header, lowercase type/scope, type-enum) so agents do not have to re-derive them from the `config-conventional` source each time.

The commit message of this PR itself is intentionally a clean example of compliance: lowercase subject, type+scope, no trailing period, ≤100 char header.

## Test plan

- [x] `Read` the diff and confirm the new bullets in `AGENTS.md` §4.4 read clearly.
- [x] Confirm this PR's own commit passes commitlint (it should — that is the meta-test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
