### PR TITLE
chore(infra): close phase 4 milestone after recipe 1 lands; recipe 2 deferred

### DIFF
--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -25,9 +25,9 @@ the "what shipped" signals are the roadmap.
 
 ---
 
-## Phase 0 — Bootstrap *(current)*
+## Phase 0 — Bootstrap
 
-**Milestone:** [Phase 0 — Bootstrap](https://github.com/aletheia-works/vivarium/milestone/3)
+**Milestone:** [Phase 0 — Bootstrap](https://github.com/aletheia-works/vivarium/milestone/3) *(closed 2026-04-26)*
 
 **What lands:**
 
@@ -137,9 +137,9 @@ the project ever has the audience to justify it.
 
 ## Phase 4 — Layer 3: record-replay & deterministic
 
-**Milestone:** [Phase 4 — Layer 3: record-replay & deterministic](https://github.com/aletheia-works/vivarium/milestone/6)
+**Milestone:** [Phase 4 — Layer 3: record-replay & deterministic](https://github.com/aletheia-works/vivarium/milestone/6) *(closed 2026-04-28 with one recipe shipped; further Layer 3 entries deferred to later phases as candidates emerge)*
 
-**What lands:**
+**What landed:**
 
 - The third layer for bugs Layers 1 and 2 cannot reach on their own:
   **record-replay** ([rr](https://rr-project.org), Pernosco-style
@@ -176,7 +176,7 @@ the visitor side or in CI** (the trace is recorded once by the
 maintainer and shipped — see ADR-0011 for the rationale, in
 particular why GitHub Actions hosted runners cannot record).
 
-## Phase 5 — Ecosystem
+## Phase 5 — Ecosystem *(current)*
 
 **Milestone:** [Phase 5 — Ecosystem](https://github.com/aletheia-works/vivarium/milestone/1)
 

--- a/infra/github/milestones.tf
+++ b/infra/github/milestones.tf
@@ -42,6 +42,8 @@ locals {
     }
     "Phase 4 — Layer 3: record-replay & deterministic" = {
       description = "rr / Pernosco-style record-replay and Antithesis-style deterministic simulation for problems Layers 1 and 2 cannot reach."
+      state       = "closed"
+      due_date    = "2026-04-28"
     }
     "Phase 5 — Ecosystem" = {
       description = "Platform integrations, third-party reproduction definitions, industry standardisation around the bug-reproduction primitive."


### PR DESCRIPTION
## Summary

* Close the **Phase 4 — Layer 3** milestone in IaC (`state="closed"`, `due_date="2026-04-28"`). Recipe 1 ([lost-update](https://github.com/aletheia-works/vivarium/pull/106)) shipped; Recipe 2 ([coreutils-sort-11015](https://github.com/aletheia-works/vivarium/issues/107)) deferred and the Issue closed.
* Mark **Phase 5 — Ecosystem** as the current scope on the public roadmap.
* Drop the obsolete `*(current)*` marker from Phase 0 (closed 2026-04-26).

## Why Recipe 2 is deferred

Build patches needed to compile coreutils 8.16 on a 2024-era libc — `FORCE_UNSAFE_CONFIGURE=1`, gnulib `gets` line-strip on `lib/stdio.in.h`, drop of `--strip-components=1` (combined with single-quote-safe inner-script comments), and finally a base-image swap to `ubuntu:18.04` (glibc 2.27, where gnulib's pre-2.28 `_IO_FILE` shims still link) — ultimately succeeded.

The actual blocker was upstream of the build: **`rr record --chaos` failed to capture the race in 200 attempts** (`LINES=2,000,000`, `PARALLEL=8`). That puts the observed race probability at < 1/200, one or two orders of magnitude below the 1/100–1/1000 the upstream report cites for native execution.

**Working hypothesis:** `rr` simulates a single physical core, time-slicing the recorded threads. The merge-completion notification race in `sort --parallel=8` is sensitive to multi-core timing windows that single-core simulation effectively widens past the failing window. This is a class incompatibility, not a parameter-tuning problem — pushing `MAX_ATTEMPTS=1000` or `LINES=10M` would not change the underlying physics.

This finding shapes future Layer 3 recipe selection: bugs whose race windows depend on multi-core timing are poor `rr` candidates even when the bug has a public reproducer. Recipe 1's `lost-update` succeeds precisely because every interleaving of two unsynced read-modify-writes loses an increment — `--chaos` always lands in the failing window. Future upstream-race candidates need to share that property.

Full reasoning trail and the alternatives considered (tune-and-retry / different upstream race / hand-crafted sibling / keep Phase 4 open indefinitely) are in **ADR-0012** (private memo, `_context/decisions/0012-phase4-close.md`).

## What stays in the catalogue

- `src/layer3_thirdway/lost-update/` (Recipe 1) — unchanged, shipped.
- `src/layer3_thirdway/README.md` — per-page contract intact; "subsequent recipes follow the convention above" still holds.
- `.github/workflows/repro-regression.yml` — Layer 3 build/contract step intact, picks up future recipes mechanically.

`_layer3-shared/` extraction stays deferred until a future Layer 3 recipe makes the shared shape obvious.

## Test plan

- [x] `terraform-plan` workflow shows the Phase 4 milestone state transition (open → closed, due_date 2026-04-28) and no other milestone changes.
- [x] On merge, `terraform-apply` lands the close.
- [x] Public roadmap renders with Phase 5 marked *(current)* and Phase 4 marked closed-with-one-recipe.
- [x] [Issue #107](https://github.com/aletheia-works/vivarium/issues/107) is already closed (deferred); no reopening.
- [x] [PR #106](https://github.com/aletheia-works/vivarium/pull/106) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)