### PR TITLE
ci(spec): replace jq -e contract validators with ajv schema validation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -77,6 +77,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Install ajv-cli for verdict schema validation
+        # Validates each Layer 2 verdict.json against
+        # `docs/public/spec/verdict.schema.json` (contract v1) right
+        # after CI writes it, before the bundling step copies the
+        # directory into the Pages artefact. Catches any malformed
+        # snapshot at deploy time rather than letting it ship.
+        # `bun add --global` puts `ajv` on PATH for subsequent steps.
+        working-directory: ${{ github.workspace }}
+        run: bun add --global ajv-cli@5 ajv-formats
+
       - name: Build docs
         run: bun run build
 
@@ -232,6 +242,15 @@ jobs:
                 stdout: $stdout,
                 stderr_tail: $stderr_tail
               }' >"${slug_dir}/verdict.json"
+
+            # Validate the freshly-written verdict.json against the
+            # contract v1 schema before the bundling step picks it up.
+            # Single-sourced with repro-regression.yml.
+            ajv validate \
+              --spec=draft2020 \
+              -c ajv-formats \
+              -s "${GITHUB_WORKSPACE}/docs/public/spec/verdict.schema.json" \
+              -d "${slug_dir}/verdict.json"
 
             rm -f "$stdout_file" "$stderr_file"
             echo "Captured verdict for ${slug}: ${verdict} (exit ${exit_code})"

--- a/.github/workflows/repro-regression.yml
+++ b/.github/workflows/repro-regression.yml
@@ -71,6 +71,17 @@ jobs:
       - name: Install Layer 1 dependencies
         run: bun install --frozen-lockfile
 
+      - name: Install ajv-cli for verdict schema validation
+        # Single-source clause 4 of the contract v1 conformance check
+        # (`docs/public/spec/verdict.schema.json`) by validating every
+        # generated / tracked `verdict.json` with ajv-cli below, instead
+        # of the historical `jq -e` predicate. Both Layer 2 (CI-built,
+        # CI-snapshot) and Layer 3 (maintainer-tracked) verdict files
+        # share the same schema. `bun add --global` puts `ajv` on
+        # PATH for subsequent steps via setup-bun's PATH wiring.
+        working-directory: ${{ github.workspace }}
+        run: bun add --global ajv-cli@5 ajv-formats
+
       - name: Type-check (sources + tests)
         # Catches any TypeScript-level regression before we boot a
         # browser. Cheap (~1 s) and produces a clear diagnostic on
@@ -180,6 +191,15 @@ jobs:
                 stderr_tail: $stderr_tail
               }' >"${slug_dir}/verdict.json"
 
+            # Validate the freshly-written verdict.json against the
+            # contract v1 schema before the Playwright suite reads it.
+            # Single-sourced with deploy-docs.yml and Layer 3 below.
+            ajv validate \
+              --spec=draft2020 \
+              -c ajv-formats \
+              -s "${GITHUB_WORKSPACE}/docs/public/spec/verdict.schema.json" \
+              -d "${slug_dir}/verdict.json"
+
             rm -f "$stdout_file" "$stderr_file"
 
             # Pass-expected for now. A future `fail`-expected sentinel
@@ -219,9 +239,15 @@ jobs:
               echo "::error::Layer 3 recipe ${slug} is missing tracked verdict.json"
               exit 1
             fi
-            jq -e '.contract == "v1" and (.verdict == "pass" or .verdict == "fail") and (.exit_code | type == "number")' \
-              "$verdict_file" >/dev/null || {
-                echo "::error::Layer 3 recipe ${slug} has malformed verdict.json"
+            # Schema-validate the tracked verdict.json against the
+            # contract v1 schema. Replaces the historical `jq -e`
+            # predicate; ajv reports the offending field on failure.
+            ajv validate \
+              --spec=draft2020 \
+              -c ajv-formats \
+              -s "${GITHUB_WORKSPACE}/docs/public/spec/verdict.schema.json" \
+              -d "$verdict_file" || {
+                echo "::error::Layer 3 recipe ${slug} has malformed verdict.json (failed schema validation)"
                 cat "$verdict_file"
                 exit 1
               }

--- a/docs/docs/spec/contract-v1.md
+++ b/docs/docs/spec/contract-v1.md
@@ -163,7 +163,7 @@ Field summary:
 | `verdict` | `"pass"` \| `"fail"` | ✅ | snapshot verdict (no `"pending"` — the snapshot is post-run) |
 | `exit_code` | integer | ✅ | recorded program / replay exit code |
 | `image_tag` | string | ✅ | docker image tag the snapshot was captured against |
-| `image_digest` | string | ✅ | docker image digest at capture time (empty string allowed when local-build) |
+| `image_digest` | string | ✅ | docker image identifier — CI-pushed captures use the registry RepoDigest, Layer 3 local-build captures use the local image ID (`docker inspect --format='{{.Id}}'`); empty string allowed when neither is available |
 | `captured_at` | ISO-8601 string | ✅ | wall-clock timestamp of the snapshot |
 | `stdout` | string | ✅ | full stdout, or page-specific JSON-encoded output |
 | `stderr_tail` | string | ✅ | last 4 KiB of stderr, truncated front-back to fit |

--- a/docs/public/spec/verdict.schema.json
+++ b/docs/public/spec/verdict.schema.json
@@ -35,7 +35,7 @@
     },
     "image_digest": {
       "type": "string",
-      "description": "Docker image digest at capture time (typically 'sha256:…@…'). Empty string is allowed for local-build captures where no digest is available."
+      "description": "Docker image identifier at capture time. CI-pushed captures use the registry RepoDigest ('sha256:…'). Layer 3 maintainer-side local-build captures use the local image ID ('sha256:…' from `docker inspect --format='{{.Id}}'`) since RepoDigests are unavailable for never-pushed images. Empty string is allowed when neither is available."
     },
     "captured_at": {
       "type": "string",

--- a/src/layer3_thirdway/lost-update/verdict.json
+++ b/src/layer3_thirdway/lost-update/verdict.json
@@ -3,8 +3,7 @@
   "verdict": "pass",
   "exit_code": 0,
   "image_tag": "ghcr.io/aletheia-works/vivarium-lost-update:latest",
-  "image_digest": "",
-  "local_build_id": "sha256:d9a1687b4b308c6ee2dd32ac2868f450c0c260a9e07ff3c6f077775bcc669508",
+  "image_digest": "sha256:d9a1687b4b308c6ee2dd32ac2868f450c0c260a9e07ff3c6f077775bcc669508",
   "captured_at": "2026-04-27T12:17:53Z",
   "stdout": "Replaying trace at: /trace/repro-0\ncounter = 11272759, expected = 20000000, lost = 8727241\npass: lost-update race observed in recorded trace",
   "stderr_tail": ""


### PR DESCRIPTION
## Summary

PR 2 of #109 — single-source clause 4 of contract v1 conformance by replacing the ad-hoc `jq -e` predicates with `ajv-cli` schema validation pointed at `docs/public/spec/verdict.schema.json`.

- **`.github/workflows/repro-regression.yml`** — install `ajv-cli@5` + `ajv-formats` after the Bun setup; validate the freshly-written Layer 2 `verdict.json` immediately after the `jq -n` write, and replace the Layer 3 `jq -e '.contract == "v1" and …'` predicate with the same `ajv validate` call.
- **`.github/workflows/deploy-docs.yml`** — same install + Layer 2 schema validation right after `verdict.json` is composed and before the bundling step copies the directory into the Pages artefact.
- **`src/layer3_thirdway/lost-update/verdict.json`** — fold the previously-sibling `local_build_id` into `image_digest`, where it semantically belongs. The existing schema has `additionalProperties: false`, so the first `ajv validate` run against this file would otherwise fail.
- **`docs/public/spec/verdict.schema.json`** + **`docs/docs/spec/contract-v1.md`** — broaden the `image_digest` field description from "Docker image digest at capture time" to "registry RepoDigest, or local image ID for local-build captures (`docker inspect --format='{{.Id}}'`); empty string allowed when neither is available". This documents the convention the Layer 3 maintainer-side captures already follow — Layer 3 images are never pushed at capture time, so RepoDigests do not exist for them.

Verified locally with `ajv validate --spec=draft2020 -c ajv-formats -s docs/public/spec/verdict.schema.json -d src/layer3_thirdway/lost-update/verdict.json` against the post-edit file.

## Test plan

- [x] CI: `repro-regression` (Layer 2 + Layer 3 steps) passes — `ajv validate` flags any malformed `verdict.json`.
- [x] CI: `deploy-docs` Layer 2 step passes — `ajv validate` runs after each `verdict.json` write, before the bundling step.
- [x] No remaining `jq -e '.contract == "v1"'` invocations in `.github/workflows/`.
- [x] `src/layer3_thirdway/lost-update/verdict.json` validates against the schema with no warnings (the only currently-tracked `verdict.json` in the tree).
- [x] After this lands, PR 3 of #109 (cross-links from `README.md` / `docs/docs/index.md` / `src/layer{1,2,3}*/README.md`, plus the missing `docs/docs/_meta.json` + `_nav.json` entries) follows.

Refs: #109 (PR 2 of 3).

---
_Generated by [Claude Code](https://claude.ai/code/session_01G68TcnJ4TZ1XXLWqdVnJ6k)_