### PR TITLE
docs(spec): cross-link contract v1 spec from README and layer READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The technology is chosen by the problem, not the other way around.
 
 **[aletheia-works.github.io/vivarium](https://aletheia-works.github.io/vivarium)** — vision, roadmap, architecture, ADRs.
 
+Public specification: **[Vivarium Contract v1](https://aletheia-works.github.io/vivarium/spec/contract-v1)** — the reproduction-verdict surface every gallery page emits, with a JSON Schema (`docs/public/spec/verdict.schema.json`) CI validates every Layer 2 / Layer 3 `verdict.json` against.
+
 The docs site is built with [rspress](https://rspress.rs) and deployed to GitHub Pages from [`docs/`](docs/) on every push to `main`. The rspress configuration and lockfile live in `docs/`; the markdown content lives in `docs/docs/`.
 
 ## Development Philosophy

--- a/docs/docs/_meta.json
+++ b/docs/docs/_meta.json
@@ -31,6 +31,11 @@
   },
   {
     "type": "dir",
+    "name": "spec",
+    "label": "Spec"
+  },
+  {
+    "type": "dir",
     "name": "repro",
     "label": "Reproductions"
   }

--- a/docs/docs/_nav.json
+++ b/docs/docs/_nav.json
@@ -15,6 +15,11 @@
     "activeMatch": "/architecture"
   },
   {
+    "text": "Spec",
+    "link": "/spec/",
+    "activeMatch": "/spec/"
+  },
+  {
     "text": "AI workflow",
     "link": "/ai-workflow",
     "activeMatch": "/ai-workflow"

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -26,4 +26,7 @@ features:
     details: Humans set direction and merge. AI agents implement, review, and iterate. Infrastructure runs continuously.
   - title: Lifelong project
     details: Measured in years, not quarters. No false urgency, no shipping-to-launch pressure, no completion deadline.
+  - title: Public spec
+    details: Vivarium Contract v1 — an open, JSON Schema-backed specification for the reproduction-verdict surface every gallery page emits. External tools and third-party reproductions can declare conformance.
+    link: /spec/
 ---

--- a/src/layer1_wasm/README.md
+++ b/src/layer1_wasm/README.md
@@ -56,3 +56,15 @@ Each new Layer 1 PoC is its own immediate subdirectory of this folder
 contain an `index.html`; the deploy workflow publishes any directory
 matching this shape under `/vivarium/poc/<slug>/`. Companion files
 (`repro.mjs`, `style.css`, `README.md`, fixtures) live alongside.
+
+## Verdict surface
+
+Every Layer 1 reproduction emits its verdict via the in-page surface
+defined by [Vivarium Contract v1](../../docs/docs/spec/contract-v1.md)
+— the `<meta name="vivarium-contract">` tag, the
+`#verdict[data-verdict]` DOM element, and the
+`__VIVARIUM_VERDICT__` / `__VIVARIUM_RESULT__` JavaScript globals.
+The helper in [`_shared/verdict.ts`](./_shared/verdict.ts) keeps the
+DOM and globals in sync; the Playwright suite at [`tests/repro.spec.ts`](./tests/repro.spec.ts)
+asserts conformance on every PR. Layer 1 does not ship a
+`verdict.json` — its verdict is live in-page.

--- a/src/layer1_wasm/tests/repro.spec.ts
+++ b/src/layer1_wasm/tests/repro.spec.ts
@@ -4,7 +4,9 @@
 // runtime it loads, and that the vivarium contract v1 surface
 // (`#verdict[data-verdict]`, `__VIVARIUM_VERDICT__`,
 // `__VIVARIUM_RESULT__`, `<meta name="vivarium-contract">`) is
-// published correctly.
+// published correctly. The contract is single-sourced at
+// https://aletheia-works.github.io/vivarium/spec/contract-v1
+// (markdown: `docs/docs/spec/contract-v1.md`).
 //
 // Layer 1 cases hit the WASM-runtime server on port 8767 (config
 // `LAYER1_PORT`). Layer 2 cases hit the Docker-recipe-snapshot server

--- a/src/layer2_docker/README.md
+++ b/src/layer2_docker/README.md
@@ -62,6 +62,12 @@ Layer 2. Visitors pull from GHCR directly.
 
 ## Verdict semantics
 
+The verdict snapshot file shape is defined by
+[Vivarium Contract v1](../../docs/docs/spec/contract-v1.md); its JSON
+Schema lives at `docs/public/spec/verdict.schema.json` and the
+`deploy-docs` / `repro-regression` workflows validate every
+`verdict.json` against it on each write.
+
 A Layer 2 page reports the **last verdict CI captured** when it
 re-built and re-ran the reproduction. The page surfaces:
 

--- a/src/layer3_thirdway/README.md
+++ b/src/layer3_thirdway/README.md
@@ -140,6 +140,12 @@ the three are in Docker's default profile.
 
 ## Verdict semantics
 
+The verdict snapshot file shape is defined by
+[Vivarium Contract v1](../../docs/docs/spec/contract-v1.md); its JSON
+Schema lives at `docs/public/spec/verdict.schema.json` and the
+`repro-regression` workflow validates the tracked `verdict.json`
+against it on every PR.
+
 A Layer 3 page reports the **maintainer-captured** verdict
 snapshot from the time the recipe was lifted (or last
 re-recorded). The page surfaces:


### PR DESCRIPTION
## Summary

PR 3 of #109 — make the contract v1 spec page that landed in #110 reachable from the surfaces a contributor or visitor actually reads.

- **`docs/docs/_meta.json`** + **`docs/docs/_nav.json`** — surface a `Spec` entry in both the rspress sidebar and the top nav. Without this, the spec page existed at `/spec/` but was unreachable from the docs site navigation.
- **`docs/docs/index.md`** — add a `Public spec` feature card linking to `/spec/`, alongside the existing Layer 1 / Layer 2 / Layer 3 / Problem-first / AI-delegated / Lifelong-project cards.
- **`README.md`** — add a one-line link to the published Contract v1 page in the Documentation section, next to the docs site link.
- **`src/layer1_wasm/README.md`** — add a `Verdict surface` section introducing the in-page surface (DOM + globals + meta tag) and pointing at the spec.
- **`src/layer2_docker/README.md`** + **`src/layer3_thirdway/README.md`** — prepend the spec reference at the top of `Verdict semantics`, so a reader hitting either layer's catalogue conventions sees the authoritative shape before the per-layer narrative.
- **`src/layer1_wasm/tests/repro.spec.ts`** — add a one-line link in the file-header comment so the contract-v1 surface assertions cite the single source of truth.

## Test plan

- [x] `bun run dev` from `docs/`: `Spec` appears in the top nav and sidebar; `/spec/` and `/spec/contract-v1` both render; the home page shows the new `Public spec` card linking to `/spec/`.
- [x] `README.md` renders cleanly on github.com with a working link to `https://aletheia-works.github.io/vivarium/spec/contract-v1`.
- [x] Layer 1 / 2 / 3 README spec references render and resolve to `docs/docs/spec/contract-v1.md` from each layer directory.
- [x] After this lands together with #111, Issue #109 is fully delivered (PR 1 → #110, PR 2 → #111, PR 3 → this).

Refs: #109 (PR 3 of 3). Stacked next to #111; no overlap, both can land independently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G68TcnJ4TZ1XXLWqdVnJ6k)_