### PR TITLE
fix(ci): scope `type: docs` to all-doc-files PRs only

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -64,8 +64,12 @@
           - "**/.dockerignore"
 
 "type: docs":
+  # `any-glob-to-all-files` (not `-any-file`): apply only when every
+  # changed file matches one of these doc patterns. The previous
+  # `-any-file` form over-applied `type: docs` to any mixed PR that
+  # happened to touch a single markdown file. See Issue #115.
   - changed-files:
-      - any-glob-to-any-file:
+      - any-glob-to-all-files:
           - "**/*.md"
           - "docs/docs/**"
           - "LICENSE"


### PR DESCRIPTION

Switch the `type: docs` rule in `.github/labeler.yml` from
`any-glob-to-any-file` to `any-glob-to-all-files`. The previous
form applied `type: docs` whenever any single markdown file was
touched, even when the substantive change was workflow YAML,
TypeScript, or OpenTofu. Recent merged PRs (#110, #111, #112,
#114) all carried the incorrect label as a result.

`any-glob-to-all-files` semantics: at least one of the listed
globs must match *every* changed file. So:

* PR with only `README.md`           → matches `**/*.md` → applies.
* PR with workflow + README          → no glob covers both → skip.
* PR with `docs/docs/spec/index.md`  → matches `**/*.md` → applies.
* PR with `LICENSE` only             → matches `LICENSE` → applies.

Edge case: a PR touching `LICENSE` plus a `.md` file gets no
`type: docs` (no single glob matches both). Acceptable — that
combination is rare and the maintainer can add the label
manually.

Other `scope: *` rules keep `any-glob-to-any-file`: scope labels
legitimately apply when *any* file in their domain changes,
because a PR touching CI files does have a CI scope even if it
also touches other things.

`sync-labels: true` in the labeler workflow will drop `type: docs`
from already-merged PRs the next time their labels are
recomputed; no remediation needed.

Closes #115.
