### PR TITLE
feat(spec): phase 5 sub-stream C — third-party manifest v1 format

### DIFF
--- a/.github/workflows/repro-regression.yml
+++ b/.github/workflows/repro-regression.yml
@@ -25,6 +25,14 @@ name: repro-regression
 #   last commit still surfaces within ~7 days.
 # - `workflow_dispatch` — manual trigger from the Actions tab.
 #
+# External manifest validation (every trigger):
+#
+# `src/external_examples/*/.vivarium/manifest.toml` are validated
+# against `docs/public/spec/manifest.schema.json` (Vivarium Manifest
+# v1; locked by ADR-0015). The workflow converts each TOML manifest
+# to JSON via Python's stdlib `tomllib` and runs ajv against the
+# JSON Schema. Phase 5 sub-stream C deliverable.
+#
 # Layer 2 verdict drift (schedule + workflow_dispatch only):
 #
 # A separate step at the end of the Layer 2 lane contrasts the
@@ -50,6 +58,8 @@ on:
       - 'src/layer1_wasm/**'
       - 'src/layer2_docker/**'
       - 'src/layer3_thirdway/**'
+      - 'src/external_examples/**'
+      - 'docs/public/spec/**.schema.json'
       - '.github/workflows/repro-regression.yml'
       - '.github/workflows/deploy-docs.yml'
   pull_request:
@@ -57,6 +67,8 @@ on:
       - 'src/layer1_wasm/**'
       - 'src/layer2_docker/**'
       - 'src/layer3_thirdway/**'
+      - 'src/external_examples/**'
+      - 'docs/public/spec/**.schema.json'
       - '.github/workflows/repro-regression.yml'
       - '.github/workflows/deploy-docs.yml'
   schedule:
@@ -97,8 +109,60 @@ jobs:
         # CI-snapshot) and Layer 3 (maintainer-tracked) verdict files
         # share the same schema. `bun add --global` puts `ajv` on
         # PATH for subsequent steps via setup-bun's PATH wiring.
+        #
+        # The same ajv install is also reused below for the Phase 5
+        # sub-stream C manifest schema validation (manifest.schema.json
+        # against `src/external_examples/*/.vivarium/manifest.toml` after
+        # a TOML→JSON conversion via Python's stdlib `tomllib`).
         working-directory: ${{ github.workspace }}
         run: bun add --global ajv-cli@5 ajv-formats
+
+      - name: Validate external manifest examples (manifest v1)
+        # Phase 5 sub-stream C (ADR-0015, private memo). Each
+        # `src/external_examples/*/.vivarium/manifest.toml` is converted
+        # to JSON via Python stdlib `tomllib` (Python 3.11+; preinstalled
+        # on `ubuntu-latest`) and validated against
+        # `docs/public/spec/manifest.schema.json`. Schema mismatch fails
+        # the workflow loudly so the spec page and the reference
+        # examples stay in lockstep.
+        #
+        # Skipped silently when the directory is absent (early-bootstrap
+        # state) or empty.
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          manifests=(src/external_examples/*/.vivarium/manifest.toml)
+          if [ ${#manifests[@]} -eq 0 ]; then
+            echo "No src/external_examples/*/.vivarium/manifest.toml; skipping."
+            exit 0
+          fi
+          schema="docs/public/spec/manifest.schema.json"
+          if [ ! -f "$schema" ]; then
+            echo "::error::Manifest schema missing at ${schema}"
+            exit 1
+          fi
+          fail=0
+          tmp_json="$(mktemp --suffix=.json)"
+          trap 'rm -f "$tmp_json"' EXIT
+          for manifest in "${manifests[@]}"; do
+            example="$(basename "$(dirname "$(dirname "$manifest")")")"
+            echo "Validating ${example}: ${manifest}"
+            python3 -c "import json, sys, tomllib; sys.stdout.write(json.dumps(tomllib.load(open(sys.argv[1], 'rb'))))" "$manifest" > "$tmp_json"
+            if ! ajv validate \
+              --spec=draft2020 \
+              -c ajv-formats \
+              -s "$schema" \
+              -d "$tmp_json"; then
+              echo "::error::Manifest validation failed for ${example} (${manifest})"
+              fail=$((fail + 1))
+            fi
+          done
+          if [ "$fail" -gt 0 ]; then
+            echo "::error::${fail} external manifest example(s) failed schema validation."
+            exit 1
+          fi
+          echo "All ${#manifests[@]} external manifest example(s) validated against manifest v1 schema."
 
       - name: Type-check (sources + tests)
         # Catches any TypeScript-level regression before we boot a

--- a/docs/docs/spec/index.md
+++ b/docs/docs/spec/index.md
@@ -8,13 +8,26 @@ cannot run live in-page.
 
 ## Versions
 
+### Verdict surface (runtime)
+
 - [Contract v1](./contract-v1.md) — current; stable since Phase 1.
 - [`verdict.schema.json`](https://aletheia-works.github.io/vivarium/spec/verdict.schema.json) — JSON Schema
   (draft 2020-12) for the Layer 2 / Layer 3 verdict snapshot file
   defined by Contract v1.
 
-There is no v2 today. Future bumps will land as siblings on this
-page; v1 will remain readable for backward-compatible consumers.
+### Manifest surface (publication)
+
+- [Manifest v1](./manifest-v1.md) — current; stable since
+  Phase 5. The TOML manifest an external repo ships at
+  `.vivarium/manifest.toml` to declare a Vivarium-runnable
+  reproduction.
+- [`manifest.schema.json`](https://aletheia-works.github.io/vivarium/spec/manifest.schema.json) —
+  JSON Schema (draft 2020-12) for the manifest after TOML → JSON
+  conversion.
+
+There is no v2 of either surface today. Future bumps will land as
+siblings on this page; v1 will remain readable for
+backward-compatible consumers.
 
 ## Tooling
 

--- a/docs/docs/spec/manifest-v1.md
+++ b/docs/docs/spec/manifest-v1.md
@@ -1,0 +1,206 @@
+# Vivarium Manifest v1
+
+> A static manifest an external repository ships at
+> `.vivarium/manifest.toml` to declare a Vivarium-runnable
+> reproduction. Locked at v1 by
+> [ADR-0015](https://github.com/aletheia-works/vivarium/blob/main/_context/decisions/0015-third-party-manifest-format.md)
+> (private memo).
+
+This is the *upstream* surface — how an external project tells
+Vivarium "we host a reproduction; here is where to find it." The
+*runtime* surface (DOM verdict, `verdict.json`) is defined
+separately in [Contract v1](./contract-v1.md). The two specs
+together let a third party publish a reproduction without
+touching the `aletheia-works/vivarium` source tree.
+
+## At a glance
+
+A repo declares a Vivarium-compatible reproduction by shipping a
+single TOML file at:
+
+```
+<repo-root>/.vivarium/manifest.toml
+```
+
+```toml
+manifest = "v1"
+slug = "bash-local-shadows-exit"
+title = "bash: `local` builtin shadows command exit code"
+layer = 2
+
+[bug]
+project = "bash"
+issue = 0
+upstream_url = "https://lists.gnu.org/archive/html/bug-bash/"
+
+[layer2]
+image = "ghcr.io/example-org/example-bash-local-shadows-exit:latest"
+dockerfile = "./Dockerfile"
+expected_verdict = "pass"
+```
+
+A consumer that wants to run the reproduction reads the manifest,
+dispatches on `layer`, and follows the per-layer convention
+defined below.
+
+## Why TOML
+
+TOML 1.0 (not YAML, not JSON). The format choice is locked by
+[ADR-0015](https://github.com/aletheia-works/vivarium/blob/main/_context/decisions/0015-third-party-manifest-format.md).
+Short version: manifests are handwritten by a human one time per
+recipe; TOML's flat surface (no significant whitespace, no
+anchors, no implicit type coercion) minimises handwriting risk
+better than YAML, while permitting comments and trailing commas
+where JSON does not.
+
+## Required top-level keys
+
+| Key | Type | Notes |
+|---|---|---|
+| `manifest` | string | Must equal `"v1"`. Version literal. |
+| `slug` | string | Kebab-case `^[a-z0-9]+(-[a-z0-9]+)*$`. Identifier for the recipe; matches the `aletheia-works/vivarium` directory-name convention. |
+| `layer` | integer | One of `1`, `2`, `3`. Selects which layer-specific table is required (see below). |
+| `[bug]` | table | Required. Describes the upstream bug. |
+| `[bug] project` | string | Upstream project name (e.g. `"bash"`). |
+| `[bug] issue` | integer | Issue number. Use `0` if no upstream issue tracker entry exists. |
+| `[bug] upstream_url` | string (URI) | Canonical link to the issue / mailing-list thread / PR / docs page. |
+
+## Optional top-level keys
+
+| Key | Type | Notes |
+|---|---|---|
+| `title` | string | Short human-readable title. |
+| `description` | string | Long-form description; markdown allowed but not interpreted. |
+
+## Layer-specific tables
+
+Exactly one of `[layer1]`, `[layer2]`, `[layer3]` is required —
+must match the top-level `layer` integer.
+
+### `[layer1]` — WASM in-browser
+
+```toml
+layer = 1
+
+[layer1]
+page_url = "https://example.org/repro/some-bug/"
+expected_verdict = "pass"  # default; optional
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `page_url` | ✅ | URL of the static reproduction page. The page must conform to [Contract v1](./contract-v1.md) — `<meta name="vivarium-contract" content="v1">` in `<head>`, `__VIVARIUM_VERDICT__` / `__VIVARIUM_RESULT__` globals, and `#verdict[data-verdict]` element. |
+| `expected_verdict` | ⏳ | `"pass"` (default) or `"fail"`. |
+
+### `[layer2]` — Docker catalogue
+
+```toml
+layer = 2
+
+[layer2]
+image = "ghcr.io/example-org/example-bash-local-shadows-exit:latest"
+dockerfile = "./Dockerfile"  # optional, informational
+expected_verdict = "pass"
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `image` | ✅ | Container image reference. Visitors run `docker run <image>`. The default CMD is the recipe's reproduction script; exit code 0 = bug reproduces (`pass`). |
+| `dockerfile` | ⏳ | Repo-relative path to the source Dockerfile. Informational — Vivarium does not build from it. |
+| `expected_verdict` | ⏳ | Default `"pass"`. |
+
+### `[layer3]` — Record-replay catalogue
+
+```toml
+layer = 3
+
+[layer3]
+image = "ghcr.io/example-org/example-recipe-with-trace:latest"
+dockerfile = "./Dockerfile"
+expected_verdict = "pass"
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `image` | ✅ | Container image reference. Image is expected to **ship with the recorded `rr` trace baked in**; entrypoint runs `rr replay` against the pinned trace. |
+| `dockerfile` | ⏳ | Informational. |
+| `expected_verdict` | ⏳ | Default `"pass"`. |
+
+> ⚠️ Layer 3 replay needs a host with **CPUID-faulting support**
+> when the visitor's CPU differs from the recording CPU. GitHub
+> Actions hosted Ubuntu runners do **not** expose this
+> capability — see
+> [ADR-0011](https://github.com/aletheia-works/vivarium/blob/main/_context/decisions/0011-phase4-first-vertical-rr.md)
+> (private memo). Layer 3 manifests are therefore best consumed
+> from self-hosted runners or visitor desktops with modern Intel
+> (Ivy Bridge+) / recent AMD silicon.
+
+## Verdict semantics
+
+The `expected_verdict` value follows the same inverse-of-typical-CI
+framing locked in [Contract v1](./contract-v1.md#verdict-semantics):
+
+- `"pass"` ⇒ the upstream bug **reproduces**.
+- `"fail"` ⇒ the upstream bug **does not reproduce**.
+
+A page declaring `expected_verdict = "pass"` is the common case —
+the recipe demonstrates the failure the upstream report
+describes. A page declaring `expected_verdict = "fail"` is a
+sentinel that intentionally tracks an upstream fix; it goes red
+the moment the bug regresses back.
+
+## Versioning
+
+The version is carried in one place:
+
+- `manifest = "v1"` at the top of the document.
+
+Adding fields, removing fields, or changing semantics requires a
+v2 manifest spec page, a v2 JSON Schema sibling, and a separate
+ADR. Consumers should be free to support v1 and v2 simultaneously
+by dispatching on the `manifest` literal.
+
+There is no current v2.
+
+## Conformance
+
+A manifest conforms to Vivarium Manifest v1 when:
+
+1. It is a valid TOML 1.0 document at `.vivarium/manifest.toml`
+   in the consuming repo.
+2. It validates against
+   [`manifest.schema.json`](https://aletheia-works.github.io/vivarium/spec/manifest.schema.json)
+   after a TOML→JSON conversion.
+3. Exactly one of `[layer1]` / `[layer2]` / `[layer3]` is
+   present, matching the top-level `layer` integer.
+4. The pointed-at artefact (page or image) actually exists and
+   produces a Contract-v1-conformant verdict at run time.
+
+Clauses 1–3 are mechanically enforceable via schema validation;
+clause 4 is per-recipe.
+
+## Reference implementations
+
+The `aletheia-works/vivarium` repo ships three example manifests
+under
+[`src/external_examples/`](https://github.com/aletheia-works/vivarium/tree/main/src/external_examples)
+— one per layer — all pointing at vivarium's own publicly-deployed
+pages and GHCR images, so they are runnable as written rather
+than just shape-valid.
+
+CI in `repro-regression.yml` validates every
+`src/external_examples/*/.vivarium/manifest.toml` against this
+schema on every push and pull request.
+
+## See also
+
+- [Contract v1](./contract-v1.md) — the runtime verdict surface
+  this manifest's pointed-at artefact must publish.
+- [`manifest.schema.json`](https://aletheia-works.github.io/vivarium/spec/manifest.schema.json)
+  — JSON Schema (draft 2020-12) for the manifest after TOML→JSON
+  conversion.
+- [Consumer workflow](./consumer-workflow.md) — the reusable
+  GitHub Actions workflow consumers use to verify a manifest's
+  declared image in their own CI.
+- ADR-0014 — Contract v1 publication precedent (private memo).
+- ADR-0015 — this manifest's stabilising decision (private memo).

--- a/docs/public/spec/manifest.schema.json
+++ b/docs/public/spec/manifest.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia-works.github.io/vivarium/spec/manifest.schema.json",
+  "title": "Vivarium third-party reproduction manifest (v1)",
+  "description": "Static manifest an external repository ships at `.vivarium/manifest.toml` to declare a Vivarium-runnable reproduction. Validated as JSON after a TOML→JSON conversion (the manifest itself is TOML; this schema validates the equivalent JSON object). See https://aletheia-works.github.io/vivarium/spec/manifest-v1 for the prose spec and ADR-0015 for the design rationale.",
+  "type": "object",
+  "required": ["manifest", "slug", "layer", "bug"],
+  "additionalProperties": false,
+  "properties": {
+    "manifest": {
+      "const": "v1",
+      "description": "Manifest format version literal. Always 'v1' for files validating against this schema; future versions will be siblings (manifest-v2.schema.json) with their own const."
+    },
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "description": "Kebab-case identifier for the recipe (e.g. 'bash-local-shadows-exit'). Lowercase ASCII letters, digits, and single-hyphen separators only — must match the directory name convention used by aletheia-works/vivarium's own catalogue."
+    },
+    "layer": {
+      "type": "integer",
+      "enum": [1, 2, 3],
+      "description": "The reproduction's runtime layer. 1 = WASM in-browser. 2 = Docker (visitor runs `docker run`). 3 = record-replay (image ships with the recorded trace baked in)."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Optional short human-readable title (e.g. 'bash: local shadows builtin's exit')."
+    },
+    "description": {
+      "type": "string",
+      "description": "Optional long-form description of the bug. Markdown content is allowed but not interpreted by Vivarium — consumers may render it or display verbatim."
+    },
+    "bug": {
+      "type": "object",
+      "required": ["project", "issue", "upstream_url"],
+      "additionalProperties": false,
+      "properties": {
+        "project": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Upstream project name (e.g. 'bash', 'pandas', 'numpy')."
+        },
+        "issue": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Upstream issue number. Use 0 if no upstream issue tracker entry exists (e.g., behaviour documented but never filed)."
+        },
+        "upstream_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Canonical URL pointing at the upstream issue, mailing list thread, PR, or documentation page describing the bug."
+        }
+      }
+    },
+    "layer1": {
+      "type": "object",
+      "required": ["page_url"],
+      "additionalProperties": false,
+      "properties": {
+        "page_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the static reproduction page. The page must conform to Vivarium Contract v1 — i.e., publish `<meta name=\"vivarium-contract\" content=\"v1\">`, expose `__VIVARIUM_VERDICT__` / `__VIVARIUM_RESULT__`, and update `#verdict[data-verdict]`. See https://aletheia-works.github.io/vivarium/spec/contract-v1 for the in-page surface."
+        },
+        "expected_verdict": {
+          "enum": ["pass", "fail"],
+          "default": "pass",
+          "description": "Expected verdict at this manifest's last review. 'pass' = bug reproduces; 'fail' = bug does not reproduce (sentinel page tracking an upstream fix). Most pages declare 'pass'."
+        }
+      }
+    },
+    "layer2": {
+      "type": "object",
+      "required": ["image"],
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Container image reference (e.g. 'ghcr.io/example-org/example-recipe' or 'ghcr.io/example-org/example-recipe:1.2.3'). Visitors run `docker run <image>` to reproduce. The image's default CMD is the recipe's reproduction script; exit code 0 = bug reproduces ('pass') per the per-layer convention."
+        },
+        "dockerfile": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional repo-relative path to the Dockerfile that produces the image. Informational only — Vivarium does not build from this. Useful for visitors who want to inspect the recipe before pulling the image."
+        },
+        "expected_verdict": {
+          "enum": ["pass", "fail"],
+          "default": "pass",
+          "description": "Expected verdict at this manifest's last review. 'pass' = bug reproduces; 'fail' = bug does not reproduce (sentinel)."
+        }
+      }
+    },
+    "layer3": {
+      "type": "object",
+      "required": ["image"],
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Container image reference for an `rr replay` -based reproduction. The image is expected to ship with the recorded trace baked in; visitors run `docker run <image>` and the entrypoint replays the trace. Visitor's host needs CPUID-faulting support for cross-CPU replay — see ADR-0011."
+        },
+        "dockerfile": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional repo-relative path to the Dockerfile that produces the image. Informational only."
+        },
+        "expected_verdict": {
+          "enum": ["pass", "fail"],
+          "default": "pass",
+          "description": "Expected verdict at this manifest's last review."
+        }
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "properties": { "layer": { "const": 1 } },
+      "required": ["layer1"],
+      "not": { "anyOf": [{ "required": ["layer2"] }, { "required": ["layer3"] }] }
+    },
+    {
+      "properties": { "layer": { "const": 2 } },
+      "required": ["layer2"],
+      "not": { "anyOf": [{ "required": ["layer1"] }, { "required": ["layer3"] }] }
+    },
+    {
+      "properties": { "layer": { "const": 3 } },
+      "required": ["layer3"],
+      "not": { "anyOf": [{ "required": ["layer1"] }, { "required": ["layer2"] }] }
+    }
+  ],
+  "examples": [
+    {
+      "manifest": "v1",
+      "slug": "bash-local-shadows-exit",
+      "title": "bash: `local` builtin shadows command exit code",
+      "layer": 2,
+      "bug": {
+        "project": "bash",
+        "issue": 0,
+        "upstream_url": "https://lists.gnu.org/archive/html/bug-bash/"
+      },
+      "layer2": {
+        "image": "ghcr.io/aletheia-works/vivarium-bash-local-shadows-exit:latest",
+        "dockerfile": "./Dockerfile",
+        "expected_verdict": "pass"
+      }
+    }
+  ]
+}

--- a/src/external_examples/README.md
+++ b/src/external_examples/README.md
@@ -1,0 +1,70 @@
+# External examples (manifest v1 reference)
+
+> **Purpose:** demonstrate how a repository *outside*
+> `aletheia-works/vivarium` would declare a Vivarium-runnable
+> reproduction via the
+> [Manifest v1 spec](../../docs/docs/spec/manifest-v1.md).
+>
+> Each subdirectory here is treated as if it were a separate
+> external repo's root. The `.vivarium/manifest.toml` inside
+> shows what that repo would commit; the rest of the repo
+> (Dockerfile, source, etc.) is **not** duplicated — these
+> manifests point at vivarium's own publicly-deployed pages and
+> GHCR images so they are runnable as written rather than just
+> shape-valid.
+
+---
+
+## What this directory is
+
+A reference / smoke-test for the manifest spec. Three example
+manifests, one per layer:
+
+| Subdirectory | Layer | Points at |
+|---|---|---|
+| [`layer1-pandas-56679/`](./layer1-pandas-56679/.vivarium/manifest.toml) | 1 (WASM) | `https://aletheia-works.github.io/vivarium/repro/pandas-56679/` |
+| [`layer2-bash-local-shadows-exit/`](./layer2-bash-local-shadows-exit/.vivarium/manifest.toml) | 2 (Docker) | `ghcr.io/aletheia-works/vivarium-bash-local-shadows-exit:latest` |
+| [`layer3-lost-update/`](./layer3-lost-update/.vivarium/manifest.toml) | 3 (record-replay) | `ghcr.io/aletheia-works/vivarium-lost-update:latest` |
+
+CI (`repro-regression.yml`) validates every
+`src/external_examples/*/.vivarium/manifest.toml` against
+[`docs/public/spec/manifest.schema.json`](../../docs/public/spec/manifest.schema.json)
+on every push and pull request. A schema mismatch fails the
+workflow loudly.
+
+## What this directory is **not**
+
+- **Not a reproduction catalogue.** Layer 1 / 2 / 3 reproductions
+  authored by `aletheia-works/vivarium` itself live under
+  [`src/layer1_wasm/`](../layer1_wasm/),
+  [`src/layer2_docker/`](../layer2_docker/), and
+  [`src/layer3_thirdway/`](../layer3_thirdway/). The examples here
+  *describe* those same recipes from a hypothetical external
+  repo's perspective; they do not duplicate the recipe sources.
+- **Not a substitute for `aletheia-works/vivarium`'s catalogue.**
+  Vivarium consumes its own per-layer catalogues directly. The
+  manifest format exists so an *external* project — one that is
+  not this repo — can advertise a Vivarium-compatible reproduction
+  without requiring Vivarium to know about it ahead of time.
+
+## Adding a new example
+
+1. Create `src/external_examples/<your-example-slug>/.vivarium/manifest.toml`.
+2. Set `manifest = "v1"`, fill in `slug`, `title`, `layer`,
+   `[bug]`, and the layer-specific table per the
+   [spec](../../docs/docs/spec/manifest-v1.md).
+3. Open a PR. CI validates the new manifest against the schema.
+
+The `<your-example-slug>` directory name does not need to match
+the manifest's `slug` field — they are conceptually separate
+(directory name = "this example", manifest slug = "the
+reproduction the example describes"). In practice keeping them
+similar is helpful.
+
+## Phase context
+
+Phase 5 sub-stream C per
+[ADR-0013](../../_context/decisions/0013-phase5-opener.md)
+(private memo). Manifest format locked at v1 by
+[ADR-0015](../../_context/decisions/0015-third-party-manifest-format.md)
+(private memo).

--- a/src/external_examples/layer1-pandas-56679/.vivarium/manifest.toml
+++ b/src/external_examples/layer1-pandas-56679/.vivarium/manifest.toml
@@ -1,0 +1,22 @@
+# Reference Vivarium manifest — Layer 1 (WASM in-browser).
+#
+# Demonstrates how an external repository would declare a Layer 1
+# reproduction (a static page running Pyodide / pandas in the
+# browser, conforming to Vivarium Contract v1's in-page surface).
+#
+# See https://aletheia-works.github.io/vivarium/spec/manifest-v1
+# for the full spec.
+
+manifest = "v1"
+slug = "pandas-56679"
+title = "pandas-56679: read_csv silently coerces int → float on `na_values`"
+layer = 1
+
+[bug]
+project = "pandas"
+issue = 56679
+upstream_url = "https://github.com/pandas-dev/pandas/issues/56679"
+
+[layer1]
+page_url = "https://aletheia-works.github.io/vivarium/repro/pandas-56679/"
+expected_verdict = "pass"

--- a/src/external_examples/layer2-bash-local-shadows-exit/.vivarium/manifest.toml
+++ b/src/external_examples/layer2-bash-local-shadows-exit/.vivarium/manifest.toml
@@ -1,0 +1,24 @@
+# Reference Vivarium manifest — Layer 2 (Docker catalogue).
+#
+# Demonstrates how an external repository would declare a Layer 2
+# reproduction (a Docker image whose default CMD is the
+# reproduction script). Visitors run `docker run <image>` to
+# reproduce; exit code 0 = bug reproduces (`pass`).
+#
+# See https://aletheia-works.github.io/vivarium/spec/manifest-v1
+# for the full spec.
+
+manifest = "v1"
+slug = "bash-local-shadows-exit"
+title = "bash: `local` builtin shadows command exit code"
+layer = 2
+
+[bug]
+project = "bash"
+issue = 0
+upstream_url = "https://lists.gnu.org/archive/html/bug-bash/"
+
+[layer2]
+image = "ghcr.io/aletheia-works/vivarium-bash-local-shadows-exit:latest"
+dockerfile = "./Dockerfile"
+expected_verdict = "pass"

--- a/src/external_examples/layer3-lost-update/.vivarium/manifest.toml
+++ b/src/external_examples/layer3-lost-update/.vivarium/manifest.toml
@@ -1,0 +1,27 @@
+# Reference Vivarium manifest — Layer 3 (record-replay catalogue).
+#
+# Demonstrates how an external repository would declare a Layer 3
+# reproduction (a Docker image with the recorded `rr` trace baked
+# in). Visitors run `docker run <image>` and the entrypoint
+# replays the pinned trace — deterministic by construction. Host
+# needs CPUID-faulting support when the visitor's CPU differs
+# from the recording CPU; ADR-0011 (private memo) covers the
+# constraint.
+#
+# See https://aletheia-works.github.io/vivarium/spec/manifest-v1
+# for the full spec.
+
+manifest = "v1"
+slug = "lost-update"
+title = "pthread lost-update data race (canonical)"
+layer = 3
+
+[bug]
+project = "pthread"
+issue = 0
+upstream_url = "https://github.com/aletheia-works/vivarium/blob/main/src/layer3_thirdway/lost-update/README.md"
+
+[layer3]
+image = "ghcr.io/aletheia-works/vivarium-lost-update:latest"
+dockerfile = "./Dockerfile"
+expected_verdict = "pass"


### PR DESCRIPTION

Adds Vivarium Manifest v1 — the upstream-side spec that lets a
repository outside aletheia-works/vivarium declare a
Vivarium-runnable reproduction by shipping a single TOML file at
`.vivarium/manifest.toml`. Companion to Contract v1
(#110-#112, the runtime verdict surface).

What lands:

* `docs/docs/spec/manifest-v1.md` — the public spec. Required
  fields (`manifest`, `slug`, `layer`, `[bug]`), layer-specific
  tables (`[layer1]`/`[layer2]`/`[layer3]`), TOML rationale,
  versioning rule (v1 lock), conformance clauses.
* `docs/public/spec/manifest.schema.json` — JSON Schema
  (draft 2020-12). Validates the manifest after TOML → JSON
  conversion. `oneOf` discriminator on `layer` enforces that
  exactly one layer-specific table is present. Locked at v1
  per the ADR-0014 precedent.
* Three reference manifests under `src/external_examples/`,
  one per layer (pandas-56679 / bash-local-shadows-exit /
  lost-update), pointing at vivarium's own publicly-deployed
  pages and GHCR images so they are runnable as written.
* `src/external_examples/README.md` — explains the
  external-examples directory's purpose and how to add new
  examples.
* `.github/workflows/repro-regression.yml` — new step
  "Validate external manifest examples (manifest v1)" that
  globs each `.vivarium/manifest.toml`, converts to JSON via
  Python stdlib `tomllib` (preinstalled on `ubuntu-latest`),
  and validates against `manifest.schema.json` via the
  existing ajv-cli@5 install. Path filter extended to trigger
  on `src/external_examples/**` and
  `docs/public/spec/**.schema.json`.
* `docs/docs/spec/index.md` — adds a "Manifest surface
  (publication)" section alongside the existing "Verdict
  surface (runtime)" section.

Format choice: TOML over YAML (rationale in ADR-0015).
Manifests are handwritten by external maintainers one time per
recipe; TOML's flat surface (no significant whitespace, no
anchors, no implicit type coercion) minimises handwriting risk
better than YAML, while permitting comments where JSON does
not. Adoption curve in 2026 favours TOML.

Local validation: all three example manifests pass schema
validation via the same TOML → JSON → ajv pipeline CI uses.

Phase 5 sub-stream C per ADR-0013 (private memo). With E
shipped (#109-#112), A' shipped (#114), and D shipped (#119),
this PR completes the second optional Phase 5 closure
deliverable. ADR-0013 closure rule "E + A' + (one of B/C/D)"
is now satisfied via D and re-satisfied via C; sub-stream B
shipped only the research memo without adoption (#117 closed).

Closes #118.
