### PR TITLE
chore(infra): close phase 5 milestone after E + A' + C + D ship; B closes without adoption

### DIFF
--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -176,25 +176,54 @@ the visitor side or in CI** (the trace is recorded once by the
 maintainer and shipped — see ADR-0011 for the rationale, in
 particular why GitHub Actions hosted runners cannot record).
 
-## Phase 5 — Ecosystem *(current)*
+## Phase 5 — Ecosystem
 
-**Milestone:** [Phase 5 — Ecosystem](https://github.com/aletheia-works/vivarium/milestone/1)
+**Milestone:** [Phase 5 — Ecosystem](https://github.com/aletheia-works/vivarium/milestone/1) *(closed 2026-04-29 with the contract / manifest / reusable-workflow surfaces published; Issue-triage tooling deferred without adoption)*
 
-**What lands:**
+**What landed:**
 
-- Integrations with the tools on either side of the reproduction
-  primitive: AI review (CodeRabbit, Greptile, etc.), Issue triage
-  (Dosu), IDEs, CI systems.
-- Third-party reproduction definitions — projects describing their own
-  reproduction protocols in a format Vivarium runs without bespoke
-  glue.
-- Positioning the reproduction primitive as an industry-standard
-  concept, not a single project's feature.
+- **Contract v1 published as an external standard** —
+  [`docs/docs/spec/contract-v1.md`](./spec/contract-v1.md),
+  [`verdict.schema.json`](https://aletheia-works.github.io/vivarium/spec/verdict.schema.json),
+  and CI enforcement via `ajv-cli` against every Layer 2 and
+  Layer 3 `verdict.json` on each write.
+- **Manifest v1 published** —
+  [`docs/docs/spec/manifest-v1.md`](./spec/manifest-v1.md),
+  [`manifest.schema.json`](https://aletheia-works.github.io/vivarium/spec/manifest.schema.json),
+  and three reference TOML manifests under
+  [`src/external_examples/`](https://github.com/aletheia-works/vivarium/tree/main/src/external_examples).
+  An external repository can now declare a Vivarium-runnable
+  reproduction by shipping a single `.vivarium/manifest.toml`
+  file — no bespoke glue required.
+- **Reusable verdict-capture GitHub Actions workflow** —
+  [`aletheia-works/.github/.github/workflows/vivarium-verdict.yml`](https://github.com/aletheia-works/.github/blob/main/.github/workflows/vivarium-verdict.yml).
+  Any consumer repo can `uses:` this workflow to verify a
+  Vivarium-hosted reproduction in their own CI; documented at
+  [Consumer workflow](./spec/consumer-workflow.md).
+- **Verdict drift detection on the weekly cron** — the
+  `repro-regression.yml` workflow now contrasts the
+  freshly-captured Layer 2 verdict against the deployed Pages
+  snapshot; a divergence (upstream / runtime drift while the
+  repo did not change) fails the workflow and surfaces via
+  GitHub's native workflow-failure email.
 
-**What a visitor sees:** reproduction stops being a thing one project
-does and starts being a capability the ecosystem expects — the way
-"CI ran" is today. Vivarium is one implementation of the primitive, not
-the primitive itself.
+**What did not adopt:** Issue triage tooling (Dosu replacement).
+A research memo evaluated CodeRabbit Issue Enrichment, Sweep AI,
+Greptile, Cody / Sourcegraph, GitHub-native Copilot for Issues,
+and Anthropic's `claude-code-action`. The recommended primary
+(CodeRabbit Issue Enrichment) was declined based on prior
+free-tier experience on the PR-review side; the fallback's
+per-issue API token cost did not match the zero-recurring-cost
+constraint. **No Issue-triage tool is in place** as Phase 5
+closes; if external Issue volume creates pressure later, the
+research memo plus a fresh re-evaluation drives the next
+decision.
+
+**What a visitor sees:** reproduction has external surfaces —
+contract, manifest, reusable workflow — that any project can
+consume without changing how Vivarium itself is built.
+Reproduction is on its way to becoming a capability the
+ecosystem expects rather than a thing one project does.
 
 **Non-goals for this phase:** a managed service with an SLA (see
 [Non-goals](./non-goals.md#we-are-not-a-managed-service-with-an-sla));

--- a/infra/github/milestones.tf
+++ b/infra/github/milestones.tf
@@ -47,6 +47,8 @@ locals {
     }
     "Phase 5 — Ecosystem" = {
       description = "Platform integrations, third-party reproduction definitions, industry standardisation around the bug-reproduction primitive."
+      state       = "closed"
+      due_date    = "2026-04-29"
     }
   }
 }


### PR DESCRIPTION

* Close the **Phase 5 — Ecosystem** milestone in IaC
  (`state = "closed"`, `due_date = "2026-04-29"`). Sub-streams
  E (#110-#112), A' (#114), C (#121), and D
  (.github#8 + #120) all shipped per ADR-0013's order;
  sub-stream B closed via #117 with the research memo as
  deliverable but no Issue-triage tool adopted (rationale:
  maintainer's prior free-tier experience with the recommended
  vendor was inadequate, fallback's per-issue token cost did not
  match the zero-recurring-cost constraint).
* Mark Phase 5 closed on the public roadmap. Drop the
  `*(current)*` marker; add the closing tagline; rewrite "What
  lands" → "What landed" listing the four published surfaces
  (contract v1, manifest v1, reusable GHA workflow, verdict
  drift detection) and the one explicit non-adoption (Issue
  triage tooling).

The ADR-0013 closure rule "E + A' + (one of B / C / D)" was
satisfied first by D, then re-satisfied by C; both optional
sub-streams that shipped expanded the Phase 5 surface beyond
the minimum.

## What did not happen

* No Phase 6 milestone is added in this PR. The next phase is a
  deliberate decision the maintainer will make when ready;
  speculatively scoping "Phase 6 — TBD" would commit to nothing
  and add UI noise. The pattern from Phase 4 close (ADR-0012)
  is to mark the closing phase honestly and let the next opener
  ADR define the next scope.
* No public retrospective document. ADRs (private) carry the
  reasoning; the roadmap (public) carries the closing line.

Full reasoning trail and the alternatives considered (hold
Phase 5 open until external adopters appear / re-open B for an
alternative tool / defer close until Phase 6 is scoped /
publish a retrospective) are in **ADR-0016** (private memo,
`_context/decisions/0016-phase5-close.md`).
