### PR TITLE
chore(infra): open phase 6 milestone for usability and visual layer

### DIFF
--- a/infra/github/milestones.tf
+++ b/infra/github/milestones.tf
@@ -50,6 +50,10 @@ locals {
       state       = "closed"
       due_date    = "2026-04-29"
     }
+    "Phase 6 — Usability and visual layer" = {
+      description = "Interaction layer above existing primitives: visual redesign (Claude Design mock + component library), reproduction comparison (branch-fix vs original verdict), search & discoverability, manifest authoring UX, MCP server, i18n. Closes when V + R + at least one of S/M/X/L ships."
+      state       = "open"
+    }
   }
 }
 


### PR DESCRIPTION

Adds the "Phase 6 — Usability and visual layer" milestone to
`infra/github/milestones.tf`, per ADR-0017 (Phase 6 opener;
private memo).

Phase 6 scope is the interaction layer above the primitives
shipped through Phase 5: visual redesign (Claude Design mock +
component library), reproduction comparison (branch-fix vs
original verdict), search & discoverability, manifest
authoring UX, MCP server, and i18n. Closure rule per ADR-0017:
V + R + at least one of S/M/X/L ships (precedent: ADR-0012,
ADR-0016).

`due_date` is intentionally omitted. Per the comment block at
the top of `milestones.tf`, phase durations in the lifelong
roadmap are directional rather than commitments; the closing
date is added with `state = "closed"` when the phase actually
closes (precedent: every Phase 0–5 entry).

After this lands and `terraform-apply.yml` propagates the
milestone to GitHub, the Phase 6 R.1 work-in-flight — Issue
#123 (Contract v1 evidence surface) and PR #124 (the spec PR
itself) — will be assigned to the new milestone.
