### PR TITLE
docs(spec): add #:schema directive to manifest v1 examples

### DIFF
--- a/docs/docs/spec/manifest-v1.md
+++ b/docs/docs/spec/manifest-v1.md
@@ -23,6 +23,7 @@ single TOML file at:
 ```
 
 ```toml
+#:schema https://aletheia-works.github.io/vivarium/spec/manifest.schema.json
 manifest = "v1"
 slug = "bash-local-shadows-exit"
 title = "bash: `local` builtin shadows command exit code"
@@ -42,6 +43,25 @@ expected_verdict = "pass"
 A consumer that wants to run the reproduction reads the manifest,
 dispatches on `layer`, and follows the per-layer convention
 defined below.
+
+## Schema directive
+
+Editors with a TOML language server — for example
+[Taplo](https://taplo.tamasfe.dev) and
+[Tombi](https://tombi-toml.github.io/tombi) — autocomplete and
+validate `manifest.toml` against the JSON Schema when the
+manifest opens with a `#:schema` line:
+
+```toml
+#:schema https://aletheia-works.github.io/vivarium/spec/manifest.schema.json
+manifest = "v1"
+…
+```
+
+The directive is a TOML comment, so it is invisible to plain
+parsers (`tomllib` etc.) and CI validation behaves identically
+with or without it. Cargo and pyproject manifests use the same
+pattern.
 
 ## Why TOML
 

--- a/src/external_examples/layer1-pandas-56679/.vivarium/manifest.toml
+++ b/src/external_examples/layer1-pandas-56679/.vivarium/manifest.toml
@@ -1,3 +1,4 @@
+#:schema https://aletheia-works.github.io/vivarium/spec/manifest.schema.json
 # Reference Vivarium manifest — Layer 1 (WASM in-browser).
 #
 # Demonstrates how an external repository would declare a Layer 1

--- a/src/external_examples/layer2-bash-local-shadows-exit/.vivarium/manifest.toml
+++ b/src/external_examples/layer2-bash-local-shadows-exit/.vivarium/manifest.toml
@@ -1,3 +1,4 @@
+#:schema https://aletheia-works.github.io/vivarium/spec/manifest.schema.json
 # Reference Vivarium manifest — Layer 2 (Docker catalogue).
 #
 # Demonstrates how an external repository would declare a Layer 2

--- a/src/external_examples/layer3-lost-update/.vivarium/manifest.toml
+++ b/src/external_examples/layer3-lost-update/.vivarium/manifest.toml
@@ -1,3 +1,4 @@
+#:schema https://aletheia-works.github.io/vivarium/spec/manifest.schema.json
 # Reference Vivarium manifest — Layer 3 (record-replay catalogue).
 #
 # Demonstrates how an external repository would declare a Layer 3


### PR DESCRIPTION

Adds the Taplo / Tombi `#:schema` directive to the Manifest v1
spec example and the three external reference manifests. Editors
with a TOML language server now autocomplete and validate the
manifest against the published JSON Schema as the maintainer
types — Cargo.toml and pyproject.toml use the same pattern.

CI behaviour is unchanged: the directive is a TOML comment, so
`tomllib` and the existing `manifest.toml` → JSON → ajv pipeline
in `repro-regression.yml` ignore it.

What lands:

* docs/docs/spec/manifest-v1.md — `#:schema` line added to the
  "At a glance" example, plus a short "Schema directive" section
  pointing at Taplo and Tombi.
* src/external_examples/layer1-pandas-56679/.vivarium/manifest.toml
* src/external_examples/layer2-bash-local-shadows-exit/.vivarium/manifest.toml
* src/external_examples/layer3-lost-update/.vivarium/manifest.toml
  — `#:schema` line added to each reference manifest's existing
  header comment block.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/126).
* #129
* __->__ #126