### PR TITLE
feat(spec): phase 6 X.1 — catalogue index endpoint (api/recipes.json)

### DIFF
--- a/docs/docs/spec/index.md
+++ b/docs/docs/spec/index.md
@@ -25,7 +25,16 @@ cannot run live in-page.
   JSON Schema (draft 2020-12) for the manifest after TOML → JSON
   conversion.
 
-There is no v2 of either surface today. Future bumps will land as
+### Catalogue index (machine-readable)
+
+- [Recipes index v1](./recipes-index-v1.md) — current. Machine-generated
+  JSON listing of every reproduction this repository hosts. Consumed by
+  the Vivarium MCP server and other programmatic catalogue tooling.
+- [`recipes.schema.json`](https://aletheia-works.github.io/vivarium/api/recipes.schema.json) —
+  JSON Schema (draft 2020-12) for the index.
+- Live endpoint: <https://aletheia-works.github.io/vivarium/api/recipes.json>
+
+There is no v2 of any surface today. Future bumps will land as
 siblings on this page; v1 will remain readable for
 backward-compatible consumers.
 

--- a/docs/docs/spec/recipes-index-v1.md
+++ b/docs/docs/spec/recipes-index-v1.md
@@ -1,0 +1,120 @@
+# Vivarium recipes index (v1)
+
+> Machine-generated catalogue index of every reproduction this repository hosts.
+> Locked at v1 by [ADR-0019](https://github.com/aletheia-works/vivarium/blob/main/_context/decisions/0019-vivarium-mcp-server-design.md)
+> (private memo). Consumed by the
+> [Vivarium MCP server](https://github.com/aletheia-works/vivarium/tree/main/packages/mcp-server)
+> and any other programmatic tool that wants to list, filter, or look up
+> recipes.
+
+## At a glance
+
+URL: <https://aletheia-works.github.io/vivarium/api/recipes.json>
+
+```json
+{
+  "index": "v1",
+  "contract": "v1",
+  "recipes": [
+    {
+      "slug": "pandas-56679",
+      "layer": 1,
+      "project": "pandas",
+      "issue": 56679,
+      "title": "pandas-dev/pandas#56679",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/pandas-56679/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/pandas-56679"
+    },
+    {
+      "slug": "bash-local-shadows-exit",
+      "layer": 2,
+      "project": "bash",
+      "issue": 0,
+      "title": "bash `local` shadows command-substitution exit code",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/bash-local-shadows-exit/",
+      "verdict_url": "https://aletheia-works.github.io/vivarium/repro/bash-local-shadows-exit/verdict.json",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker/bash-local-shadows-exit"
+    }
+  ]
+}
+```
+
+## Top-level fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `index` | `"v1"` literal | ✅ | Format version. New optional fields ship as same-page revisions; breaking changes are v2. |
+| `contract` | `"v1"` literal | ✅ | The [Contract v1](./contract-v1.md) version that recipes' pages publish. |
+| `recipes` | array of [recipe entries](#recipe-entry-fields) | ✅ | Every reproduction this repository hosts, sorted by layer then by slug. |
+
+## Recipe entry fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `slug` | string (kebab-case) | ✅ | Recipe directory name under `src/layer{N}_*/`. Same convention as Manifest v1's `slug`. |
+| `layer` | integer (`1` \| `2` \| `3`) | ✅ | Layer 1 = WASM in browser; Layer 2 = Docker; Layer 3 = record-replay. |
+| `project` | string | ✅ | Upstream project name (e.g. `"pandas"`, `"bash"`). |
+| `issue` | integer | ✅ | Upstream issue number; `0` if no upstream tracker entry. |
+| `title` | string | ✅ | Human-readable title, from the recipe README's first H1. |
+| `page_url` | URI | ✅ | Live reproduction page (Layer 1: WASM page; Layer 2 / 3: docker-run instructions page). |
+| `verdict_url` | URI | ⏳ | Layer 2 / 3 only — deployed `verdict.json` snapshot. Layer 1 verdicts are produced live in-page and have no static snapshot. |
+| `source_url` | URI | ✅ | GitHub link to the recipe directory. |
+
+## Versioning
+
+The version is carried as `index = "v1"` on the top-level object. Per
+[ADR-0018](https://github.com/aletheia-works/vivarium/blob/main/_context/decisions/0018-contract-v1-evidence-extension.md)
+(private memo)'s minor-revision policy:
+
+- **Optional additive fields** (e.g. a future `language` field once Phase 6
+  stream S.1 lands frontmatter tags) ship as same-`v1` revisions; consumers
+  feature-detect them.
+- **Breaking changes** (renamed fields, type changes, optional → required)
+  require a v2 schema sibling and a separate ADR.
+
+There is no current v2.
+
+## Generation
+
+The index is built by
+[`docs/scripts/generate-recipes-index.ts`](https://github.com/aletheia-works/vivarium/blob/main/docs/scripts/generate-recipes-index.ts),
+wired into the rspress `dev` and `build` scripts in
+`docs/package.json`. The script walks the recipe directories, parses each
+recipe README's first H1 for the title, and derives `project` / `issue`
+from the slug pattern (`<project>-<digits>` for slugs with a trailing
+issue number; first dash-segment otherwise, with a small override map for
+recipes whose slug shape diverges).
+
+The output is tracked in git so PRs that add a recipe also show the index
+update in the diff. Phase 6 stream S.1 will replace the slug-derived
+heuristic with explicit per-recipe frontmatter, at which point the
+`project` and (eventually) `language` fields become first-class
+per-recipe declarations rather than slug-derived guesses.
+
+## Conformance
+
+A `recipes.json` document conforms to v1 when:
+
+1. It validates against
+   [`recipes.schema.json`](https://aletheia-works.github.io/vivarium/api/recipes.schema.json).
+2. `index === "v1"` and `contract === "v1"`.
+3. Every entry's `slug` matches `^[a-z0-9]+(-[a-z0-9]+)*$`.
+4. Every Layer 2 / 3 entry includes `verdict_url`; Layer 1 entries omit it.
+
+Clauses 1–3 are mechanically enforceable via schema validation. Clause 4
+is a derivation-rule constraint not encoded in the schema's `oneOf` (kept
+deliberately permissive: the MCP server treats a missing `verdict_url` on
+a Layer 2 / 3 entry the same as `verdict_url` pointing at a 404 — both
+are surfaced to the consumer as "no snapshot available").
+
+## See also
+
+- [Contract v1](./contract-v1.md) — the runtime verdict surface each
+  recipe page publishes.
+- [Manifest v1](./manifest-v1.md) — the upstream-side manifest format an
+  external repo ships at `.vivarium/manifest.toml`. Recipe entries in
+  this index correspond to internal recipes; external repos publish their
+  own per-repo manifest instead of being listed here.
+- ADR-0019 — load-bearing decision for this index and the Vivarium MCP
+  server that consumes it (private memo).
+- ADR-0018 — minor-revision policy this index reuses (private memo).

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,8 +5,9 @@
   "description": "Documentation site for Vivarium, built with rspress.",
   "type": "module",
   "scripts": {
-    "dev": "rspress dev",
-    "build": "rspress build",
+    "generate-index": "bun run scripts/generate-recipes-index.ts",
+    "dev": "bun run generate-index && rspress dev",
+    "build": "bun run generate-index && rspress build",
     "preview": "rspress preview"
   },
   "devDependencies": {

--- a/docs/public/api/recipes.json
+++ b/docs/public/api/recipes.json
@@ -1,0 +1,110 @@
+{
+  "index": "v1",
+  "contract": "v1",
+  "recipes": [
+    {
+      "slug": "cpython-137205",
+      "layer": 1,
+      "project": "cpython",
+      "issue": 137205,
+      "title": "python/cpython#137205",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/cpython-137205/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/cpython-137205"
+    },
+    {
+      "slug": "numpy-28287",
+      "layer": 1,
+      "project": "numpy",
+      "issue": 28287,
+      "title": "numpy/numpy#28287",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/numpy-28287/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/numpy-28287"
+    },
+    {
+      "slug": "pandas-56679",
+      "layer": 1,
+      "project": "pandas",
+      "issue": 56679,
+      "title": "pandas-dev/pandas#56679",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/pandas-56679/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/pandas-56679"
+    },
+    {
+      "slug": "php-12167",
+      "layer": 1,
+      "project": "php",
+      "issue": 12167,
+      "title": "php/php-src#12167",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/php-12167/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/php-12167"
+    },
+    {
+      "slug": "regex-779",
+      "layer": 1,
+      "project": "regex",
+      "issue": 779,
+      "title": "rust-lang/regex#779",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/regex-779/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/regex-779"
+    },
+    {
+      "slug": "ruby-21709",
+      "layer": 1,
+      "project": "ruby",
+      "issue": 21709,
+      "title": "ruby/ruby#21709",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/ruby-21709/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/ruby-21709"
+    },
+    {
+      "slug": "bash-local-shadows-exit",
+      "layer": 2,
+      "project": "bash",
+      "issue": 0,
+      "title": "bash `local` shadows command-substitution exit code",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/bash-local-shadows-exit/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker/bash-local-shadows-exit",
+      "verdict_url": "https://aletheia-works.github.io/vivarium/repro/bash-local-shadows-exit/verdict.json"
+    },
+    {
+      "slug": "find-xargs-whitespace",
+      "layer": 2,
+      "project": "find",
+      "issue": 0,
+      "title": "`find … | xargs cmd` is unsafe for whitespace in filenames",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/find-xargs-whitespace/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker/find-xargs-whitespace",
+      "verdict_url": "https://aletheia-works.github.io/vivarium/repro/find-xargs-whitespace/verdict.json"
+    },
+    {
+      "slug": "flock-is-advisory",
+      "layer": 2,
+      "project": "flock",
+      "issue": 0,
+      "title": "`flock(2)` is advisory only",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/flock-is-advisory/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker/flock-is-advisory",
+      "verdict_url": "https://aletheia-works.github.io/vivarium/repro/flock-is-advisory/verdict.json"
+    },
+    {
+      "slug": "postgres-lost-update",
+      "layer": 2,
+      "project": "postgres",
+      "issue": 0,
+      "title": "PostgreSQL lost update under READ COMMITTED",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/postgres-lost-update/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker/postgres-lost-update",
+      "verdict_url": "https://aletheia-works.github.io/vivarium/repro/postgres-lost-update/verdict.json"
+    },
+    {
+      "slug": "lost-update",
+      "layer": 3,
+      "project": "pthread",
+      "issue": 0,
+      "title": "pthread lost-update data race (canonical)",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/lost-update/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer3_thirdway/lost-update",
+      "verdict_url": "https://aletheia-works.github.io/vivarium/repro/lost-update/verdict.json"
+    }
+  ]
+}

--- a/docs/public/api/recipes.schema.json
+++ b/docs/public/api/recipes.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia-works.github.io/vivarium/api/recipes.schema.json",
+  "title": "Vivarium recipes index (v1)",
+  "description": "Machine-generated index of every reproduction this repository hosts. Built at docs build time by docs/scripts/generate-recipes-index.ts and deployed to https://aletheia-works.github.io/vivarium/api/recipes.json. Consumed by the Vivarium MCP server (ADR-0019, private memo) and any other programmatic tool that wants to list, filter, or look up reproductions. The `index` literal carries the format version; minor additive revisions follow ADR-0018's two-tier policy.",
+  "type": "object",
+  "required": ["index", "contract", "recipes"],
+  "additionalProperties": false,
+  "properties": {
+    "index": {
+      "const": "v1",
+      "description": "Index format version literal. Always 'v1' for files validating against this schema. Future versions will be siblings (recipes-v2.schema.json) with their own const."
+    },
+    "contract": {
+      "const": "v1",
+      "description": "The Vivarium runtime verdict contract version that the recipes' pages publish. Always 'v1' as long as Contract v1 is the canonical surface; see https://aletheia-works.github.io/vivarium/spec/contract-v1."
+    },
+    "recipes": {
+      "type": "array",
+      "description": "All reproductions hosted in this repository, sorted by layer then by slug.",
+      "items": { "$ref": "#/$defs/recipeEntry" }
+    }
+  },
+  "$defs": {
+    "recipeEntry": {
+      "type": "object",
+      "required": [
+        "slug",
+        "layer",
+        "project",
+        "issue",
+        "title",
+        "page_url",
+        "source_url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "slug": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "description": "Kebab-case identifier for the recipe; matches the recipe's directory name under src/layer{N}_*. Same convention as Manifest v1's `slug` field."
+        },
+        "layer": {
+          "type": "integer",
+          "enum": [1, 2, 3],
+          "description": "The reproduction's runtime layer. 1 = WASM in-browser. 2 = Docker (visitor runs `docker run`). 3 = record-replay (image ships with recorded `rr` trace baked in)."
+        },
+        "project": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Upstream project name (e.g. 'pandas', 'bash', 'pthread'). Heuristically derived from the slug pattern in v1; will be replaced by frontmatter-driven values when Phase 6 stream S.1 ships."
+        },
+        "issue": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Upstream issue number, parsed from the slug's trailing digits when the slug matches '<project>-<digits>'. Recipes with no upstream issue tracker entry use 0."
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable title, extracted from the recipe README's first H1 (with the leading 'Reproduction —' prefix stripped)."
+        },
+        "page_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Live reproduction page URL on GitHub Pages. Layer 1: a WASM-in-browser page that produces a verdict client-side. Layer 2 / 3: a docker-run instructions page that loads the verdict.json snapshot."
+        },
+        "verdict_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the deployed verdict.json snapshot. Layer 2 / 3 only; Layer 1 verdicts are produced live in-page and have no static snapshot. See https://aletheia-works.github.io/vivarium/spec/contract-v1#verdict-snapshot-file-verdictjson."
+        },
+        "source_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "GitHub link to the recipe directory in this repository, useful for human navigation from a programmatic catalogue lookup."
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "index": "v1",
+      "contract": "v1",
+      "recipes": [
+        {
+          "slug": "pandas-56679",
+          "layer": 1,
+          "project": "pandas",
+          "issue": 56679,
+          "title": "pandas-dev/pandas#56679",
+          "page_url": "https://aletheia-works.github.io/vivarium/repro/pandas-56679/",
+          "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/pandas-56679"
+        },
+        {
+          "slug": "bash-local-shadows-exit",
+          "layer": 2,
+          "project": "bash",
+          "issue": 0,
+          "title": "bash `local` shadows command-substitution exit code",
+          "page_url": "https://aletheia-works.github.io/vivarium/repro/bash-local-shadows-exit/",
+          "verdict_url": "https://aletheia-works.github.io/vivarium/repro/bash-local-shadows-exit/verdict.json",
+          "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker/bash-local-shadows-exit"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/scripts/generate-recipes-index.ts
+++ b/docs/scripts/generate-recipes-index.ts
@@ -1,0 +1,198 @@
+#!/usr/bin/env bun
+//
+// Walks vivarium's recipe directories under src/layer1_wasm,
+// src/layer2_docker, and src/layer3_thirdway (each holding kebab-case
+// recipe sub-directories) and emits docs/public/api/recipes.json — the
+// catalogue index consumed by the Vivarium MCP server (ADR-0019, private
+// memo) and any other programmatic tool that wants to list, filter, or
+// look up reproductions.
+//
+// The output is tracked in git so PRs adding a recipe also show the index
+// update in the diff. Run by `bun run generate-index` (wired into the
+// `dev` and `build` scripts in docs/package.json).
+//
+// Heuristics for v1:
+//   - slug = recipe directory name.
+//   - project / issue = parsed from "<project>-<digits>" slug pattern;
+//     for slugs without a trailing number, project = first dash-segment,
+//     issue = 0.
+//   - title = first H1 of the recipe README, with the leading
+//     "Reproduction —" prefix stripped.
+//   - language is intentionally NOT emitted in v1; Phase 6 stream S.1
+//     will add it as an explicit per-recipe frontmatter field.
+//
+// Schema is locked at `index = "v1"` per ADR-0019 §4 and follows
+// ADR-0018's minor-revision policy: optional fields can be added without
+// bumping the literal; breaking changes require v2.
+
+import { readdir, readFile, stat, mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PAGES_BASE = 'https://aletheia-works.github.io/vivarium';
+const REPO_BASE = 'https://github.com/aletheia-works/vivarium';
+
+type Layer = 1 | 2 | 3;
+
+interface RecipeEntry {
+  slug: string;
+  layer: Layer;
+  project: string;
+  issue: number;
+  title: string;
+  page_url: string;
+  verdict_url?: string;
+  source_url: string;
+}
+
+interface RecipesIndex {
+  index: 'v1';
+  contract: 'v1';
+  recipes: RecipeEntry[];
+}
+
+const LAYERS: ReadonlyArray<{ layer: Layer; dir: string }> = [
+  { layer: 1, dir: 'src/layer1_wasm' },
+  { layer: 2, dir: 'src/layer2_docker' },
+  { layer: 3, dir: 'src/layer3_thirdway' },
+];
+
+const LAYER_DIRNAME: Record<Layer, string> = {
+  1: 'layer1_wasm',
+  2: 'layer2_docker',
+  3: 'layer3_thirdway',
+};
+
+const NON_RECIPE_NAMES = new Set([
+  '_shared',
+  '_layer2-shared',
+  'node_modules',
+  'tests',
+  'test-results',
+]);
+
+async function isDir(p: string): Promise<boolean> {
+  try {
+    return (await stat(p)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function listRecipeSlugs(layerDir: string): Promise<string[]> {
+  const entries = await readdir(layerDir);
+  const slugs: string[] = [];
+  for (const entry of entries) {
+    if (entry.startsWith('_') || entry.startsWith('.')) continue;
+    if (NON_RECIPE_NAMES.has(entry)) continue;
+    if (!(await isDir(join(layerDir, entry)))) continue;
+    slugs.push(entry);
+  }
+  return slugs.sort();
+}
+
+// Slugs whose first dash-segment is not the upstream project name. The
+// heuristic in parseSlug() works for "<project>-<digits>" and most
+// "<project>-<rest>" slugs, but a handful of recipe directory names diverge
+// (e.g. layer 3 "lost-update" reproduces a pthread data race, not a
+// "lost" project). These overrides bridge to the day Phase 6 stream S.1
+// adds explicit per-recipe frontmatter and the heuristic retires.
+const PROJECT_OVERRIDES: Record<string, string> = {
+  'lost-update': 'pthread',
+};
+
+function parseSlug(slug: string): { project: string; issue: number } {
+  if (PROJECT_OVERRIDES[slug]) {
+    return { project: PROJECT_OVERRIDES[slug]!, issue: 0 };
+  }
+  const match = slug.match(/^([a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*?)-(\d+)$/);
+  if (match) {
+    return { project: match[1]!, issue: Number(match[2]) };
+  }
+  const firstDash = slug.indexOf('-');
+  return {
+    project: firstDash === -1 ? slug : slug.slice(0, firstDash),
+    issue: 0,
+  };
+}
+
+async function readTitle(readmePath: string, fallback: string): Promise<string> {
+  try {
+    const md = await readFile(readmePath, 'utf-8');
+    const lines = md.split(/\r?\n/);
+    const h1 = lines.find((l) => l.startsWith('# '));
+    if (!h1) return fallback;
+    return h1
+      .replace(/^#\s+/, '')
+      .replace(/^Reproduction[\s—–-]+/i, '')
+      .trim();
+  } catch {
+    return fallback;
+  }
+}
+
+async function buildEntry(
+  layer: Layer,
+  slug: string,
+  recipeDir: string,
+): Promise<RecipeEntry> {
+  const { project, issue } = parseSlug(slug);
+  const title = await readTitle(join(recipeDir, 'README.md'), slug);
+  const pageUrl = `${PAGES_BASE}/repro/${slug}/`;
+  const sourceUrl = `${REPO_BASE}/tree/main/src/${LAYER_DIRNAME[layer]}/${slug}`;
+  const entry: RecipeEntry = {
+    slug,
+    layer,
+    project,
+    issue,
+    title,
+    page_url: pageUrl,
+    source_url: sourceUrl,
+  };
+  if (layer === 2 || layer === 3) {
+    entry.verdict_url = `${PAGES_BASE}/repro/${slug}/verdict.json`;
+  }
+  return entry;
+}
+
+async function main(): Promise<void> {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const REPO_ROOT = join(__dirname, '..', '..');
+
+  const recipes: RecipeEntry[] = [];
+  for (const { layer, dir } of LAYERS) {
+    const layerDir = join(REPO_ROOT, dir);
+    const slugs = await listRecipeSlugs(layerDir);
+    for (const slug of slugs) {
+      recipes.push(await buildEntry(layer, slug, join(layerDir, slug)));
+    }
+  }
+
+  const out: RecipesIndex = {
+    index: 'v1',
+    contract: 'v1',
+    recipes,
+  };
+
+  const outDir = join(__dirname, '..', 'public', 'api');
+  await mkdir(outDir, { recursive: true });
+  const outPath = join(outDir, 'recipes.json');
+  await writeFile(outPath, JSON.stringify(out, null, 2) + '\n', 'utf-8');
+
+  const counts = recipes.reduce<Record<Layer, number>>(
+    (acc, r) => {
+      acc[r.layer] = (acc[r.layer] ?? 0) + 1;
+      return acc;
+    },
+    { 1: 0, 2: 0, 3: 0 },
+  );
+  console.error(
+    `Wrote ${recipes.length} recipe(s) to ${outPath} ` +
+      `(layer 1: ${counts[1]}, layer 2: ${counts[2]}, layer 3: ${counts[3]})`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION

Phase 6 sub-stream X.1 load-bearing data endpoint per ADR-0019
(private memo). Adds the `/api/recipes.json` static endpoint
that the forthcoming Vivarium MCP server consumes for
catalogue lookup, together with its JSON Schema and prose spec.
The endpoint is generated at docs build time from the existing
recipe directory tree, so a recipe addition automatically
updates the index in the same PR.

Why JSON, not TOML: per ADR-0019 §4, the convention split is
"TOML for human-handwritten configuration (Manifest v1), JSON
for machine-generated artefacts (verdict.json, this index)."
The index is build-output consumed programmatically; TOML's
handwriting ergonomics don't apply.

What lands:

* `docs/scripts/generate-recipes-index.ts` — Node/Bun script
  that walks src/layer1_wasm, src/layer2_docker, and
  src/layer3_thirdway, parses each recipe README's first H1
  for the title, and derives `project` / `issue` from the
  slug pattern. Phase 6 stream S.1 will replace the heuristic
  with explicit per-recipe frontmatter; until then a small
  PROJECT_OVERRIDES map handles the one slug whose first
  dash-segment is not the upstream project (`lost-update` →
  `pthread`).
* `docs/public/api/recipes.json` — generated index, tracked
  in git so PRs adding a recipe show the index update in the
  diff. Initial run yields 11 recipes (Layer 1: 6, Layer 2:
  4, Layer 3: 1).
* `docs/public/api/recipes.schema.json` — JSON Schema (draft
  2020-12) for the index. `$id` points at the deployed URL
  so consumers can fetch and validate against the live
  schema. `index = "v1"` literal locks the format; minor
  additive revisions follow ADR-0018's two-tier policy.
* `docs/docs/spec/recipes-index-v1.md` — prose spec page
  documenting the at-a-glance shape, top-level fields,
  recipe-entry fields, versioning, generation, and
  conformance.
* `docs/docs/spec/index.md` — new "Catalogue index
  (machine-readable)" section linking the spec page,
  schema, and live endpoint.
* `docs/package.json` — wires `bun run generate-index` into
  the `dev` and `build` scripts so the index is regenerated
  on every site build (locally and in CI).

Out of scope (handled by the MCP server PR, follow-up to
this one): the MCP server package itself
(`packages/mcp-server/`), the dual-publish CI workflow
(`publish-mcp.yml`), and the JSR + npm scope reservation.
S.1's frontmatter-driven `language` field is also deferred
to its own stream.

The index `contract = "v1"` literal mirrors what the recipe
pages publish per ADR-0014 (Contract v1 publication, locked)
and ADR-0018 (revision 2 evidence surface, optional).
Consumers reading the index can dispatch on this literal
just like they do on the in-page `<meta name="vivarium-contract">`.

Closes #127.
