### PR TITLE
feat(mcp): phase 6 X.1 — vivarium MCP server (@aletheia-works/vivarium-mcp)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,9 +44,35 @@ updates:
       include: "scope"
     open-pull-requests-limit: 3
 
+  # ─── bun — packages/mcp-server ───────────────
+  # Vivarium MCP server (@aletheia-works/vivarium-mcp). See ADR-0019
+  # (private memo) for the package's design. Uses Dependabot's `bun`
+  # ecosystem (GA 2025-02), which reads bun.lock directly rather than
+  # treating the project as npm.
+  - package-ecosystem: "bun"
+    directory: "/packages/mcp-server"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+      timezone: "Asia/Tokyo"
+    labels:
+      - "type: chore"
+      - "scope: js"
+      - "ai: generated"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    # Major bumps need targeted human/AI review — covered by AGENTS.md
+    # §4.9's "latest at authoring time" rule when adding or editing
+    # workflows / packages, not by automated dependabot merges.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 5
+
   # Future ecosystems to enable in Phase 1+:
   #
-  # - package-ecosystem: "pip"      # Python deps
-  # - package-ecosystem: "cargo"    # Rust deps
-  # - package-ecosystem: "npm"      # JS deps
-  # - package-ecosystem: "docker"   # Dockerfile base images
+  # - package-ecosystem: "pip"      # Python deps (Layer 1 Pyodide-side, etc.)
+  # - package-ecosystem: "cargo"    # Rust deps (Layer 1 wasm32-wasi)
+  # - package-ecosystem: "docker"   # Dockerfile base images (Layer 2)

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,97 @@
+name: publish-mcp
+
+# Dual-publishes packages/mcp-server/ to JSR (canonical) and npm
+# (fallback) on `mcp-server-v*.*.*` tag push, with build provenance
+# via OIDC trusted publishing on both registries. See ADR-0019 §2 / §5
+# (private memo) for the design rationale.
+#
+# Tag convention: `mcp-server-v0.1.0` — `<package-name>-v<semver>`,
+# matching semantic-release-monorepo's default for monorepo single-
+# package tags. Future packages in this repo (e.g. a CLI) get their
+# own prefixed tags. The version literal published comes from
+# packages/mcp-server/{package.json,jsr.json} — both must be bumped
+# together; the tag is for triggering, not authority.
+#
+# Manual trigger is supported for re-publishing a specific version
+# after fixing CI plumbing (does not change the version literal).
+#
+# Toolchain: Bun end-to-end. Install / build / test all run on Bun;
+# the npm-side publish goes through `bunx npm publish --provenance`
+# because Bun does not yet support npm OIDC trusted publishing
+# directly (oven-sh/bun#15601, OPEN as of 2026-04). `bunx npm`
+# fetches and runs the npm CLI through Bun without needing a
+# separate Node install — the workflow does not call
+# `actions/setup-node`. JSR publish runs through `bunx jsr publish`,
+# which uses OIDC automatically when `id-token: write` is granted.
+
+on:
+  push:
+    tags:
+      - 'mcp-server-v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag-style label, informational only (e.g. mcp-server-v0.1.0). Version is read from package.json.'
+        required: false
+
+permissions:
+  contents: read
+  id-token: write   # OIDC for both npm provenance and JSR
+
+jobs:
+  publish:
+    name: Publish to JSR + npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: packages/mcp-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Sync bundled recipes snapshot
+        # Copy the latest tracked recipes index into the package so the
+        # offline fallback embedded with this release is current at
+        # publish time. The Pages-hosted live version remains canonical
+        # at runtime; this snapshot only matters when the agent is
+        # offline or the Pages fetch fails.
+        run: cp ../../docs/public/api/recipes.json src/bundled/recipes.json
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build
+        run: bun run build
+
+      - name: Test
+        run: bun test
+
+      - name: Publish to npm (provenance via OIDC trusted publishing, npm CLI run through bunx)
+        run: bunx npm publish --provenance --access public
+        env:
+          # Tells the npm CLI which registry to authenticate against; in
+          # combination with `id-token: write` permissions and
+          # `publishConfig.access: public` in package.json, this is what
+          # OIDC trusted publishing requires on the consuming side.
+          NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org/'
+
+      - name: Publish to JSR (provenance via OIDC)
+        run: bunx jsr publish
+
+      - name: Summary
+        run: |
+          {
+            echo "## Published"
+            echo ""
+            echo "* **npm**: https://www.npmjs.com/package/@aletheia-works/vivarium-mcp"
+            echo "* **JSR**: https://jsr.io/@aletheia-works/vivarium-mcp"
+            echo ""
+            echo "Provenance is recorded in the public Sigstore Rekor"
+            echo "transparency log for both registries."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/packages/mcp-server/.gitignore
+++ b/packages/mcp-server/.gitignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+*.tgz
+.tsbuildinfo

--- a/packages/mcp-server/LICENSE
+++ b/packages/mcp-server/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,0 +1,83 @@
+# `@aletheia-works/vivarium-mcp`
+
+[Model Context Protocol](https://modelcontextprotocol.io) server that
+exposes the [Vivarium](https://github.com/aletheia-works/vivarium)
+reproduction catalogue to AI agent clients (Claude Code, Cline, Cursor,
+Continue, etc.).
+
+Vivarium is the universal bug-reproduction platform of the
+[`aletheia-works`](https://github.com/aletheia-works) organisation —
+"reproduce any bug, in any language, any environment, at any scale."
+This package is the agent-callable surface that lets AI tools
+*discover* what reproductions exist, look up their metadata, and read
+deployed verdict snapshots, without scraping the docs site.
+
+## Tools
+
+| Tool | Returns | Layer coverage |
+|---|---|---|
+| `list_recipes(layer?, project?, q?)` | Filtered list of catalogue entries. | All layers (1, 2, 3). |
+| `get_recipe(slug)` | Full metadata for one recipe (title, project, issue, page URL, verdict snapshot URL, GitHub source URL). | All layers. |
+| `lookup_verdict(slug)` | Layer 1 → `kind: "live"` + page URL (verdicts run in the browser). Layer 2/3 → `kind: "snapshot"` with the deployed `verdict.json` contents (verdict, exit code, image digest, stdout, stderr tail). | All layers (Layer 1 returns a stub). |
+
+## Install
+
+### npm (default for `npx`-based MCP launchers)
+
+Add the server to your client's MCP configuration. The exact file
+location varies by client (Claude Code: `~/.claude/mcp.json`; Cline:
+its VS Code settings; Cursor: `~/.cursor/mcp.json`). Snippet:
+
+```json
+{
+  "mcpServers": {
+    "vivarium": {
+      "command": "npx",
+      "args": ["-y", "@aletheia-works/vivarium-mcp@latest"]
+    }
+  }
+}
+```
+
+### JSR (Deno / Bun-native install)
+
+For clients with native JSR support (Bun ≥ 1.1, Deno):
+
+```bash
+bunx jsr:@aletheia-works/vivarium-mcp
+# or
+deno run --allow-net --allow-read jsr:@aletheia-works/vivarium-mcp
+```
+
+## Why dual-channel distribution
+
+Per [ADR-0019](https://github.com/aletheia-works/vivarium) (private
+memo), this package publishes to both registries with **JSR canonical
+and npm fallback**. JSR contributes structural supply-chain defences
+(no postinstall scripts, OIDC-only publish via Sigstore provenance,
+GitHub-org-bound scope ownership, source-only publish); npm carries
+the `npx` ergonomics most MCP launchers expect today. Both registries
+ship with build provenance — verifiable via the public Sigstore Rekor
+transparency log.
+
+## Configuration
+
+The server reads no environment variables and accepts no command-line
+flags in v1. It fetches the catalogue index from
+<https://aletheia-works.github.io/vivarium/api/recipes.json> with a
+5-minute in-process TTL, falling back to a build-time bundled snapshot
+when the network is unavailable.
+
+## Versioning
+
+The MCP server's surface (the three tools above and their input
+schemas) is locked at v1 by ADR-0019. Optional additive changes ship
+as minor revisions; breaking changes require a v2 design ADR.
+
+The recipes index format consumed by this server is locked separately
+at `index = "v1"` — see
+<https://aletheia-works.github.io/vivarium/spec/recipes-index-v1>.
+
+## License
+
+Apache-2.0 — see [LICENSE](./LICENSE).

--- a/packages/mcp-server/bun.lock
+++ b/packages/mcp-server/bun.lock
@@ -1,0 +1,210 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@aletheia-works/vivarium-mcp",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.13",
+        "@types/node": "^25.6.0",
+        "typescript": "^6.0.3",
+      },
+    },
+  },
+  "packages": {
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.4.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "hono": ["hono@4.12.16", "", {}, "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+  }
+}

--- a/packages/mcp-server/jsr.json
+++ b/packages/mcp-server/jsr.json
@@ -1,0 +1,23 @@
+{
+  "name": "@aletheia-works/vivarium-mcp",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server.ts"
+  },
+  "publish": {
+    "include": [
+      "src/**/*.ts",
+      "src/bundled/recipes.json",
+      "README.md",
+      "LICENSE",
+      "jsr.json"
+    ],
+    "exclude": [
+      "tests",
+      "**/*.test.ts",
+      "dist"
+    ]
+  }
+}

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@aletheia-works/vivarium-mcp",
+  "version": "0.1.0",
+  "description": "MCP server exposing the Vivarium reproduction catalogue (list_recipes, get_recipe, lookup_verdict) to AI agent clients (Claude Code, Cline, Cursor, Continue, etc.).",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/aletheia-works/vivarium/tree/main/packages/mcp-server",
+  "bugs": {
+    "url": "https://github.com/aletheia-works/vivarium/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aletheia-works/vivarium.git",
+    "directory": "packages/mcp-server"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "vivarium-mcp": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "src/bundled",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "bun test",
+    "prepublishOnly": "bun run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.13",
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
+  },
+  "engines": {
+    "node": ">=24",
+    "bun": ">=1.2.0"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "vivarium",
+    "bug-reproduction",
+    "catalogue",
+    "ai-tools"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/packages/mcp-server/src/bundled/recipes.json
+++ b/packages/mcp-server/src/bundled/recipes.json
@@ -1,0 +1,5 @@
+{
+  "index": "v1",
+  "contract": "v1",
+  "recipes": []
+}

--- a/packages/mcp-server/src/catalogue.ts
+++ b/packages/mcp-server/src/catalogue.ts
@@ -1,0 +1,77 @@
+// Catalogue fetcher with a 5-minute in-process TTL and a build-time
+// bundled fallback. See ADR-0019 §4 for the data-source decision.
+//
+// Two modes:
+//   1. Runtime fetch from the canonical Pages endpoint with a TTL cache
+//      so the agent always sees a catalogue recent enough to reflect a
+//      same-day recipe addition.
+//   2. Bundled snapshot fallback for offline use, network failure, or
+//      cold start before the first successful fetch.
+//
+// The bundled snapshot is shipped in src/bundled/recipes.json — it is
+// refreshed at publish time by the GHA workflow that copies the latest
+// docs/public/api/recipes.json into the package before publish.
+
+import type { RecipesIndex, VerdictSnapshot } from './types.js';
+import bundledIndex from './bundled/recipes.json' with { type: 'json' };
+
+export const INDEX_URL =
+  'https://aletheia-works.github.io/vivarium/api/recipes.json';
+
+const TTL_MS = 5 * 60 * 1000;
+
+interface CacheEntry {
+  index: RecipesIndex;
+  fetchedAt: number;
+}
+
+let cache: CacheEntry | null = null;
+
+// Reset cache; only used by tests.
+export function _resetCacheForTesting(): void {
+  cache = null;
+}
+
+export function getBundledIndex(): RecipesIndex {
+  return bundledIndex as unknown as RecipesIndex;
+}
+
+export async function getCatalogue(): Promise<RecipesIndex> {
+  const now = Date.now();
+  if (cache && now - cache.fetchedAt < TTL_MS) {
+    return cache.index;
+  }
+
+  try {
+    const res = await fetch(INDEX_URL, {
+      headers: { 'accept': 'application/json' },
+    });
+    if (res.ok) {
+      const data = (await res.json()) as RecipesIndex;
+      if (data && data.index === 'v1' && Array.isArray(data.recipes)) {
+        cache = { index: data, fetchedAt: now };
+        return data;
+      }
+    }
+  } catch {
+    // Network failure → fall through to bundled fallback.
+  }
+
+  return getBundledIndex();
+}
+
+export async function fetchVerdictSnapshot(
+  verdictUrl: string,
+): Promise<VerdictSnapshot | null> {
+  try {
+    const res = await fetch(verdictUrl, {
+      headers: { 'accept': 'application/json' },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as VerdictSnapshot;
+    if (data && data.contract === 'v1') return data;
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+//
+// Vivarium MCP server — stdio entrypoint.
+//
+// Spawned by an MCP client (Claude Code, Cline, Cursor, Continue, …)
+// via `npx -y @aletheia-works/vivarium-mcp` or the equivalent JSR
+// invocation. Speaks the MCP protocol over stdin / stdout.
+//
+// See packages/mcp-server/README.md for client configuration snippets
+// and ADR-0019 (private memo) for the design rationale.
+
+import { runServer } from './server.js';
+
+runServer().catch((err: unknown) => {
+  // The MCP transport itself uses stdout, so all human-visible
+  // diagnostics go to stderr.
+  console.error('vivarium-mcp: fatal:', err);
+  process.exit(1);
+});

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,0 +1,97 @@
+// MCP server wiring — registers the three v1 tools (list_recipes,
+// get_recipe, lookup_verdict) and connects a stdio transport.
+//
+// See ADR-0019 §3 for the tool surface decision and §1 for the
+// stdio-transport choice.
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import { GET_RECIPE_TOOL, getRecipe } from './tools/get_recipe.js';
+import {
+  LIST_RECIPES_TOOL,
+  listRecipes,
+  type ListRecipesArgs,
+} from './tools/list_recipes.js';
+import {
+  LOOKUP_VERDICT_TOOL,
+  lookupVerdict,
+} from './tools/lookup_verdict.js';
+
+const SERVER_NAME = 'vivarium-mcp';
+// Keep in sync with package.json + jsr.json. Updated by the publish
+// workflow on tag push; unsynced values produce a confusing client
+// experience (the MCP `initialize` response carries this string).
+const SERVER_VERSION = '0.1.0';
+
+export function createServer(): Server {
+  const server = new Server(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [LIST_RECIPES_TOOL, GET_RECIPE_TOOL, LOOKUP_VERDICT_TOOL],
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const name = req.params.name;
+    const args = (req.params.arguments ?? {}) as Record<string, unknown>;
+
+    let payload: unknown;
+    try {
+      switch (name) {
+        case 'list_recipes':
+          payload = await listRecipes(args as ListRecipesArgs);
+          break;
+        case 'get_recipe':
+          payload = await getRecipe(args as { slug: string });
+          break;
+        case 'lookup_verdict':
+          payload = await lookupVerdict(args as { slug: string });
+          break;
+        default:
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: `unknown tool: ${name}`,
+              },
+            ],
+          };
+      }
+    } catch (err) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text',
+            text: `tool ${name} threw: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(payload, null, 2),
+        },
+      ],
+    };
+  });
+
+  return server;
+}
+
+export async function runServer(): Promise<void> {
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/packages/mcp-server/src/tools/get_recipe.ts
+++ b/packages/mcp-server/src/tools/get_recipe.ts
@@ -1,0 +1,43 @@
+import { getCatalogue } from '../catalogue.js';
+import type { RecipeEntry } from '../types.js';
+
+export interface GetRecipeArgs {
+  slug: string;
+}
+
+export type GetRecipeResult =
+  | { found: true; recipe: RecipeEntry }
+  | { found: false; error: string };
+
+export async function getRecipe(
+  args: GetRecipeArgs,
+): Promise<GetRecipeResult> {
+  const slug = args.slug?.trim();
+  if (!slug) {
+    return { found: false, error: 'missing required argument: slug' };
+  }
+  const { recipes } = await getCatalogue();
+  const recipe = recipes.find((r) => r.slug === slug);
+  if (!recipe) {
+    return { found: false, error: `recipe not found: ${slug}` };
+  }
+  return { found: true, recipe };
+}
+
+export const GET_RECIPE_TOOL = {
+  name: 'get_recipe',
+  description:
+    'Get full metadata for a single recipe by slug, including the live page URL, verdict snapshot URL (Layer 2/3), and GitHub source URL. Use `list_recipes` first to discover available slugs. Returns `found: false` with an error message if the slug is unknown.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      slug: {
+        type: 'string' as const,
+        pattern: '^[a-z0-9]+(-[a-z0-9]+)*$',
+        description:
+          "Kebab-case recipe slug (e.g. 'pandas-56679', 'bash-local-shadows-exit'). Same convention as Manifest v1's `slug`.",
+      },
+    },
+    required: ['slug'],
+  },
+} as const;

--- a/packages/mcp-server/src/tools/list_recipes.ts
+++ b/packages/mcp-server/src/tools/list_recipes.ts
@@ -1,0 +1,62 @@
+import { getCatalogue } from '../catalogue.js';
+import type { Layer, RecipeEntry } from '../types.js';
+
+export interface ListRecipesArgs {
+  layer?: Layer;
+  project?: string;
+  q?: string;
+}
+
+export interface ListRecipesResult {
+  count: number;
+  recipes: RecipeEntry[];
+}
+
+export async function listRecipes(
+  args: ListRecipesArgs,
+): Promise<ListRecipesResult> {
+  const { recipes } = await getCatalogue();
+
+  const layer = args.layer;
+  const project = args.project?.trim().toLowerCase();
+  const q = args.q?.trim().toLowerCase();
+
+  const filtered = recipes.filter((r) => {
+    if (layer !== undefined && r.layer !== layer) return false;
+    if (project && r.project.toLowerCase() !== project) return false;
+    if (q) {
+      const hay = (r.slug + ' ' + r.project + ' ' + r.title).toLowerCase();
+      if (!hay.includes(q)) return false;
+    }
+    return true;
+  });
+
+  return { count: filtered.length, recipes: filtered };
+}
+
+export const LIST_RECIPES_TOOL = {
+  name: 'list_recipes',
+  description:
+    'List Vivarium reproduction recipes — pages or container images that demonstrate a specific upstream bug. Returns metadata only; live verdicts come from `lookup_verdict`. Filter by `layer` (1=WASM in browser, 2=Docker, 3=record-replay), `project` (upstream project name like "pandas" or "bash"), or `q` (substring search across slug, project, and title).',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      layer: {
+        type: 'integer' as const,
+        enum: [1, 2, 3],
+        description:
+          'Optional layer filter. 1 = WASM in browser, 2 = Docker, 3 = record-replay.',
+      },
+      project: {
+        type: 'string' as const,
+        description:
+          "Optional upstream project name (e.g. 'pandas', 'bash'). Case-insensitive exact match.",
+      },
+      q: {
+        type: 'string' as const,
+        description:
+          'Optional substring search across slug, project, and title. Case-insensitive.',
+      },
+    },
+  },
+} as const;

--- a/packages/mcp-server/src/tools/lookup_verdict.ts
+++ b/packages/mcp-server/src/tools/lookup_verdict.ts
@@ -1,0 +1,98 @@
+import { fetchVerdictSnapshot, getCatalogue } from '../catalogue.js';
+import type { VerdictSnapshot } from '../types.js';
+
+export interface LookupVerdictArgs {
+  slug: string;
+}
+
+export type LookupVerdictResult =
+  | {
+      kind: 'live';
+      slug: string;
+      page_url: string;
+      note: string;
+    }
+  | {
+      kind: 'snapshot';
+      slug: string;
+      snapshot: VerdictSnapshot;
+    }
+  | {
+      kind: 'unavailable';
+      slug: string;
+      reason: string;
+    }
+  | {
+      kind: 'not_found';
+      slug: string;
+      error: string;
+    };
+
+export async function lookupVerdict(
+  args: LookupVerdictArgs,
+): Promise<LookupVerdictResult> {
+  const slug = args.slug?.trim();
+  if (!slug) {
+    return {
+      kind: 'not_found',
+      slug: '',
+      error: 'missing required argument: slug',
+    };
+  }
+
+  const { recipes } = await getCatalogue();
+  const recipe = recipes.find((r) => r.slug === slug);
+  if (!recipe) {
+    return {
+      kind: 'not_found',
+      slug,
+      error: `recipe not found: ${slug}`,
+    };
+  }
+
+  if (recipe.layer === 1) {
+    return {
+      kind: 'live',
+      slug,
+      page_url: recipe.page_url,
+      note:
+        'Layer 1 reproductions produce verdicts live in the browser; the agent can open the page or delegate to a browser MCP to obtain an actual verdict.',
+    };
+  }
+
+  if (!recipe.verdict_url) {
+    return {
+      kind: 'unavailable',
+      slug,
+      reason: 'recipe entry has no verdict_url',
+    };
+  }
+
+  const snapshot = await fetchVerdictSnapshot(recipe.verdict_url);
+  if (!snapshot) {
+    return {
+      kind: 'unavailable',
+      slug,
+      reason: `verdict snapshot fetch failed or returned non-v1 data: ${recipe.verdict_url}`,
+    };
+  }
+
+  return { kind: 'snapshot', slug, snapshot };
+}
+
+export const LOOKUP_VERDICT_TOOL = {
+  name: 'lookup_verdict',
+  description:
+    "Look up the latest verdict for a recipe by slug. Layer 1 recipes produce live in-browser verdicts and have no static snapshot — this returns kind='live' with the page URL and a note suggesting the agent open the page directly. Layer 2/3 recipes return kind='snapshot' with the deployed verdict.json contents (verdict, exit code, image digest, captured-at timestamp, stdout, stderr tail). Returns kind='unavailable' or kind='not_found' on failure.",
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      slug: {
+        type: 'string' as const,
+        pattern: '^[a-z0-9]+(-[a-z0-9]+)*$',
+        description: 'Kebab-case recipe slug.',
+      },
+    },
+    required: ['slug'],
+  },
+} as const;

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -1,0 +1,47 @@
+// Type definitions for the Vivarium recipes index (locked at v1 by
+// ADR-0019, private memo) and the per-recipe verdict snapshot (Contract
+// v1, ADR-0014, with the optional revision-2 evidence surface from
+// ADR-0018). Kept structural and surface-only — the canonical schemas
+// live at:
+//
+//   https://aletheia-works.github.io/vivarium/api/recipes.schema.json
+//   https://aletheia-works.github.io/vivarium/spec/verdict.schema.json
+//
+// Consumers who need runtime validation should fetch and validate against
+// those JSON Schemas; this module's types are an ergonomic façade for
+// the in-process tool implementations.
+
+export type Layer = 1 | 2 | 3;
+
+export interface RecipeEntry {
+  slug: string;
+  layer: Layer;
+  project: string;
+  issue: number;
+  title: string;
+  page_url: string;
+  verdict_url?: string;
+  source_url: string;
+}
+
+export interface RecipesIndex {
+  index: 'v1';
+  contract: 'v1';
+  recipes: RecipeEntry[];
+}
+
+export type Verdict = 'pass' | 'fail';
+
+// Layer 2 / 3 verdict snapshot shape per Contract v1.
+// `stderr_tail` keeps its source-side name; the in-page contract surface
+// renames it to `evidence.stderr` at the lift boundary (see ADR-0018).
+export interface VerdictSnapshot {
+  contract: 'v1';
+  verdict: Verdict;
+  exit_code: number;
+  image_tag: string;
+  image_digest: string;
+  captured_at: string;
+  stdout: string;
+  stderr_tail: string;
+}

--- a/packages/mcp-server/tests/catalogue.test.ts
+++ b/packages/mcp-server/tests/catalogue.test.ts
@@ -1,0 +1,128 @@
+// Catalogue fetcher tests. Uses Bun's built-in test runner with
+// `bun:test` globals and a stubbed global fetch — no network access
+// in CI.
+//
+// Coverage focus: TTL behaviour, network-failure fallback to bundled
+// snapshot, malformed-response rejection.
+
+import { afterEach, beforeEach, describe, it } from 'bun:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  _resetCacheForTesting,
+  fetchVerdictSnapshot,
+  getBundledIndex,
+  getCatalogue,
+  INDEX_URL,
+} from '../src/catalogue.ts';
+
+type FetchMock = (input: string | URL | Request, init?: RequestInit) =>
+  Promise<Response>;
+
+const realFetch = globalThis.fetch;
+
+function mockFetch(handler: FetchMock): void {
+  globalThis.fetch = handler as typeof globalThis.fetch;
+}
+
+function restoreFetch(): void {
+  globalThis.fetch = realFetch;
+}
+
+describe('catalogue', () => {
+  beforeEach(() => {
+    _resetCacheForTesting();
+  });
+  afterEach(() => {
+    restoreFetch();
+    _resetCacheForTesting();
+  });
+
+  it('returns parsed v1 payload on a successful fetch', async () => {
+    mockFetch(async (input) => {
+      assert.equal(String(input), INDEX_URL);
+      return new Response(
+        JSON.stringify({
+          index: 'v1',
+          contract: 'v1',
+          recipes: [
+            {
+              slug: 'pandas-56679',
+              layer: 1,
+              project: 'pandas',
+              issue: 56679,
+              title: 'pandas-dev/pandas#56679',
+              page_url: 'https://example.invalid/repro/pandas-56679/',
+              source_url: 'https://example.invalid/src/pandas-56679',
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+
+    const idx = await getCatalogue();
+    assert.equal(idx.index, 'v1');
+    assert.equal(idx.recipes.length, 1);
+    assert.equal(idx.recipes[0]!.slug, 'pandas-56679');
+  });
+
+  it('falls back to the bundled snapshot on network failure', async () => {
+    mockFetch(async () => {
+      throw new TypeError('network fail');
+    });
+    const idx = await getCatalogue();
+    const bundled = getBundledIndex();
+    assert.equal(idx.index, bundled.index);
+    assert.equal(idx.recipes.length, bundled.recipes.length);
+  });
+
+  it('falls back to the bundled snapshot on non-200', async () => {
+    mockFetch(
+      async () =>
+        new Response('not found', { status: 404 }),
+    );
+    const idx = await getCatalogue();
+    assert.equal(idx.index, getBundledIndex().index);
+  });
+
+  it('rejects a malformed payload (wrong index literal)', async () => {
+    mockFetch(
+      async () =>
+        new Response(
+          JSON.stringify({ index: 'v999', contract: 'v1', recipes: [] }),
+          { status: 200 },
+        ),
+    );
+    const idx = await getCatalogue();
+    // Wrong literal → fall through to bundled.
+    assert.equal(idx.index, getBundledIndex().index);
+  });
+
+  it('caches within TTL', async () => {
+    let calls = 0;
+    mockFetch(async () => {
+      calls += 1;
+      return new Response(
+        JSON.stringify({ index: 'v1', contract: 'v1', recipes: [] }),
+        { status: 200 },
+      );
+    });
+    await getCatalogue();
+    await getCatalogue();
+    await getCatalogue();
+    assert.equal(calls, 1);
+  });
+
+  it('returns null verdict snapshot on non-v1 payload', async () => {
+    mockFetch(
+      async () =>
+        new Response(
+          JSON.stringify({ contract: 'v999', verdict: 'pass' }),
+          { status: 200 },
+        ),
+    );
+    const snap = await fetchVerdictSnapshot('https://example.invalid/v.json');
+    assert.equal(snap, null);
+  });
+});

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -1,0 +1,155 @@
+// Tool-level smoke tests. Stub fetch with a fixture catalogue and
+// exercise list_recipes / get_recipe / lookup_verdict's branching.
+
+import { afterEach, beforeEach, describe, it } from 'bun:test';
+import { strict as assert } from 'node:assert';
+
+import { _resetCacheForTesting, INDEX_URL } from '../src/catalogue.ts';
+import { getRecipe } from '../src/tools/get_recipe.ts';
+import { listRecipes } from '../src/tools/list_recipes.ts';
+import { lookupVerdict } from '../src/tools/lookup_verdict.ts';
+
+const FIXTURE_INDEX = {
+  index: 'v1',
+  contract: 'v1',
+  recipes: [
+    {
+      slug: 'pandas-56679',
+      layer: 1,
+      project: 'pandas',
+      issue: 56679,
+      title: 'pandas-dev/pandas#56679',
+      page_url: 'https://example.invalid/repro/pandas-56679/',
+      source_url: 'https://example.invalid/src/pandas-56679',
+    },
+    {
+      slug: 'bash-local-shadows-exit',
+      layer: 2,
+      project: 'bash',
+      issue: 0,
+      title: 'bash local-shadows-exit',
+      page_url: 'https://example.invalid/repro/bash-local-shadows-exit/',
+      verdict_url: 'https://example.invalid/repro/bash-local-shadows-exit/verdict.json',
+      source_url: 'https://example.invalid/src/bash-local-shadows-exit',
+    },
+    {
+      slug: 'lost-update',
+      layer: 3,
+      project: 'pthread',
+      issue: 0,
+      title: 'pthread lost-update data race',
+      page_url: 'https://example.invalid/repro/lost-update/',
+      verdict_url: 'https://example.invalid/repro/lost-update/verdict.json',
+      source_url: 'https://example.invalid/src/lost-update',
+    },
+  ],
+};
+
+const FIXTURE_VERDICT = {
+  contract: 'v1',
+  verdict: 'pass',
+  exit_code: 0,
+  image_tag: 'ghcr.io/example-org/bash:latest',
+  image_digest: 'sha256:deadbeef',
+  captured_at: '2026-04-30T00:00:00Z',
+  stdout: '',
+  stderr_tail: '',
+};
+
+const realFetch = globalThis.fetch;
+
+beforeEach(() => {
+  _resetCacheForTesting();
+  globalThis.fetch = (async (input) => {
+    const url = String(input);
+    if (url === INDEX_URL) {
+      return new Response(JSON.stringify(FIXTURE_INDEX), { status: 200 });
+    }
+    if (url.endsWith('/verdict.json')) {
+      return new Response(JSON.stringify(FIXTURE_VERDICT), { status: 200 });
+    }
+    return new Response('not found', { status: 404 });
+  }) as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  _resetCacheForTesting();
+});
+
+describe('list_recipes', () => {
+  it('returns all when no filters', async () => {
+    const r = await listRecipes({});
+    assert.equal(r.count, 3);
+  });
+
+  it('filters by layer', async () => {
+    const r = await listRecipes({ layer: 1 });
+    assert.equal(r.count, 1);
+    assert.equal(r.recipes[0]!.slug, 'pandas-56679');
+  });
+
+  it('filters by project (case-insensitive)', async () => {
+    const r = await listRecipes({ project: 'PTHREAD' });
+    assert.equal(r.count, 1);
+    assert.equal(r.recipes[0]!.slug, 'lost-update');
+  });
+
+  it('filters by free-text q across slug/project/title', async () => {
+    const r = await listRecipes({ q: 'shadows' });
+    assert.equal(r.count, 1);
+    assert.equal(r.recipes[0]!.slug, 'bash-local-shadows-exit');
+  });
+
+  it('combines filters with logical AND', async () => {
+    const r = await listRecipes({ layer: 2, project: 'pandas' });
+    assert.equal(r.count, 0);
+  });
+});
+
+describe('get_recipe', () => {
+  it('returns the recipe when slug exists', async () => {
+    const r = await getRecipe({ slug: 'pandas-56679' });
+    assert.equal(r.found, true);
+    if (r.found) assert.equal(r.recipe.layer, 1);
+  });
+
+  it('returns found=false on unknown slug', async () => {
+    const r = await getRecipe({ slug: 'does-not-exist' });
+    assert.equal(r.found, false);
+  });
+
+  it('returns found=false on missing slug arg', async () => {
+    const r = await getRecipe({ slug: '' });
+    assert.equal(r.found, false);
+  });
+});
+
+describe('lookup_verdict', () => {
+  it('returns kind=live for Layer 1', async () => {
+    const r = await lookupVerdict({ slug: 'pandas-56679' });
+    assert.equal(r.kind, 'live');
+    if (r.kind === 'live') {
+      assert.match(r.page_url, /pandas-56679/);
+    }
+  });
+
+  it('returns kind=snapshot for Layer 2', async () => {
+    const r = await lookupVerdict({ slug: 'bash-local-shadows-exit' });
+    assert.equal(r.kind, 'snapshot');
+    if (r.kind === 'snapshot') {
+      assert.equal(r.snapshot.verdict, 'pass');
+      assert.equal(r.snapshot.contract, 'v1');
+    }
+  });
+
+  it('returns kind=snapshot for Layer 3', async () => {
+    const r = await lookupVerdict({ slug: 'lost-update' });
+    assert.equal(r.kind, 'snapshot');
+  });
+
+  it('returns kind=not_found for unknown slug', async () => {
+    const r = await lookupVerdict({ slug: 'does-not-exist' });
+    assert.equal(r.kind, 'not_found');
+  });
+});

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ESNext"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": false,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests"]
+}


### PR DESCRIPTION

Phase 6 sub-stream X.1 main implementation per ADR-0019 (private
memo). Adds the Vivarium MCP server: a stdio-transport package
that exposes the recipe catalogue and verdict snapshots to AI
agent clients (Claude Code, Cline, Cursor, Continue, etc.).

Distribution per ADR-0019 §2: dual-channel publish to JSR
(canonical) and npm (fallback). JSR contributes structural
supply-chain defences (no postinstall lifecycle, OIDC-only
publish via Sigstore provenance, scope ↔ GitHub-org binding,
source-only publish) while npm carries the npx ergonomics MCP
launchers expect today. Both registries publish with build
provenance recorded in the public Sigstore Rekor transparency
log.

Tag convention: `mcp-server-v<semver>` (e.g. `mcp-server-v0.1.0`),
matching semantic-release-monorepo's default for monorepo
single-package tags.

Toolchain: Bun end-to-end, no Node runtime needed in CI or local
dev. Install / build / test / publish all run on Bun. The
npm-side publish uses `bunx npm publish --provenance` because
Bun does not yet support npm OIDC trusted publishing directly
([oven-sh/bun#15601](https://github.com/oven-sh/bun/issues/15601),
OPEN as of 2026-04). JSR publish runs through `bunx jsr publish`.

Action pinning: GitHub-recommended security-hardening style
(https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions),
which is the only way to use a Marketplace action as an
immutable release. Each action is pinned to a full 40-char
commit SHA with the human-readable version as a trailing
comment for review:

* `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` # v6.0.2
* `oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6` # v2.2.0

Both are at the latest published release as of 2026-04-30 per
AGENTS.md §4.9. Dependabot's `github-actions` ecosystem keeps
the SHA bumped going forward.

`.mise.toml` (will be renamed mise.toml in PR #133) is not
modified — `bun = "latest"` already covers every script in
this package, and Bun handles `bunx npm publish` end-to-end so
no Node entry is required for dev or CI.

Dependencies pinned to current latest as of 2026-04-30, with a
committed `bun.lock` so Dependabot's `bun` ecosystem (GA
2025-02) reads it directly:

* `@modelcontextprotocol/sdk` ^1.29.0
* `typescript` ^6.0.3
* `@types/bun` ^1.3.13
* `@types/node` ^25.6.0
* engines: node ≥24, bun ≥1.2

tsconfig target / module / lib raised to ESNext / NodeNext per
the maintainer's preference for the latest TS surface.

Dependabot now watches `packages/mcp-server/bun.lock` as a
proper bun-ecosystem entry. Weekly Monday 03:00 JST,
major-version bumps gated for human review per AGENTS.md §4.9
and the existing github-actions / terraform pattern in
`.github/dependabot.yml`.

Tools per ADR-0019 §3:

* `list_recipes(layer?, project?, q?)` — filtered catalogue
  listing. All layers covered (the "Layer 1 only" wording in
  ADR-0017 §X.1 is clarified by ADR-0019 as "synchronous
  *execution* is Layer 1 only" — metadata is uniformly cheap
  to surface).
* `get_recipe(slug)` — full per-recipe metadata.
* `lookup_verdict(slug)` — Layer 1 returns kind=live + page URL
  (verdicts run in the browser, the agent decides whether to
  open the page); Layer 2 / 3 returns kind=snapshot with the
  deployed verdict.json contents.

Data source per ADR-0019 §4: catalogue is fetched from
https://aletheia-works.github.io/vivarium/api/recipes.json with
a 5-minute in-process TTL, falling back to a build-time bundled
snapshot in src/bundled/recipes.json on network failure or cold
start. The bundled snapshot is refreshed by the publish workflow
on every release; this initial commit ships an empty stub so the
package builds without depending on the catalogue index PR
having merged first.

What lands:

* `packages/mcp-server/` — new package directory:
  - `package.json` / `jsr.json` — dual-registry metadata, both
    declaring `@aletheia-works/vivarium-mcp` v0.1.0. npm bin
    entry exposes `vivarium-mcp` CLI; JSR publishes TS source
    directly per the registry's source-only model. Test
    runner is `bun test`; build is `tsc` driven via
    `bun run build`.
  - `bun.lock` — committed lockfile so Dependabot's bun
    ecosystem can read it.
  - `tsconfig.json` — strict TS, ESNext target, NodeNext
    module resolution, JSON imports enabled.
  - `src/index.ts` — stdio entrypoint (npx-launchable).
  - `src/server.ts` — MCP server wiring; registers the three
    tools and connects a StdioServerTransport.
  - `src/catalogue.ts` — Pages-fetch + 5-min TTL + bundled
    fallback. Validates the v1 literal before caching.
  - `src/tools/{list_recipes,get_recipe,lookup_verdict}.ts`
    — per-tool implementations and MCP tool descriptors.
  - `src/types.ts` — surface types mirroring the published
    JSON Schemas (recipes index v1, verdict snapshot v1).
  - `src/bundled/recipes.json` — empty stub initial snapshot;
    publish workflow overwrites with the live recipes index.
  - `tests/{catalogue,tools}.test.ts` — bun:test smoke
    suites covering TTL caching, network-failure fallback,
    layer-aware verdict dispatch, and tool input filtering.
  - `README.md` — install snippets for both registries +
    client-side `mcpServers` configuration example.
  - `LICENSE` — Apache-2.0 (copy of repo root LICENSE,
    required for `npm publish`'s tarball).
* `.github/workflows/publish-mcp.yml` — Tag-triggered
  (`mcp-server-v*.*.*`) workflow on Bun-only toolchain with
  SHA-pinned actions. Syncs the bundled snapshot from
  `docs/public/api/recipes.json`, runs build + tests on Bun,
  publishes to npm (provenance via OIDC trusted publishing,
  npm CLI run through `bunx npm`) and JSR (provenance via
  OIDC, `bunx jsr publish`). workflow_dispatch supported for
  re-publishing.
* `.github/dependabot.yml` — adds the bun ecosystem entry for
  `/packages/mcp-server`.

Out of scope (deferred):

* `submit_reproduction` / `verify_fix` tools — depend on
  Phase 6 stream R.2 (branch-fix build & verify pipeline).
* Synchronous `run_recipe` (live execution) — declined by
  ADR-0019 §3 / §F (a stdio MCP cannot run a WASM page in a
  browser, and Layer 2/3 docker run is too heavy for a
  synchronous MCP call).
* Headless-browser-driven Layer 1 verdict — declined by
  ADR-0019 §F (doubles install footprint for a capability the
  agent can already reach via a separate browser MCP).
* Authentication / per-consumer telemetry — declined by
  ADR-0019 §6 / §G.
* SHA-pinning the rest of the repo's GitHub Actions workflows —
  handled by a separate cross-cutting PR alongside the
  AGENTS.md §4.9 SHA-pin rule.

Initial version 0.1.0 (pre-1.0) signals the v1 surface is
locked but real-world consumer feedback may yet shape minor
adjustments; 1.0.0 follows once at least one external client
has reported successful installs against both registries.

Closes #128.

Note: this PR registers the workflow only; the first publish
requires manual one-time setup (JSR scope claim under
@aletheia-works, npm package name reservation under the same
scope, GitHub-side trusted-publisher registration on both
registries). That setup is human-only and out of scope for
this PR.
