### PR TITLE
chore(infra): add scope: docs label with unique colour in labels.tf

### DIFF
--- a/infra/github/labels.tf
+++ b/infra/github/labels.tf
@@ -69,6 +69,10 @@ locals {
       color       = "ededed"
       description = "CI/CD pipeline"
     }
+    "scope: docs" = {
+      color       = "c2e0c6"
+      description = "Documentation site (rspress) and public spec pages under docs/"
+    }
     "scope: ux" = {
       color       = "ff69b4"
       description = "User experience"


### PR DESCRIPTION

The `scope: docs` label exists on the repository (path-rule
labelling has been attaching it from `.github/labeler.yml`) but
was missing from `infra/github/labels.tf`, so its description
was empty and its colour was the default grey that collided
with `scope: ci`. Add the definition with a short description
matching the convention used by the other `scope: *` entries,
plus a unique colour that does not collide with any existing
entry in the palette.

Colour choice: `#c2e0c6` (light green). Survey of the existing
palette:

* The scope:* family covers blues (`docker`, `python`),
  purples (`wasm`, `infra`), warm tones (`rust`, `js`, `ux`),
  and a single grey (`ci`). Light green is unused at the scope
  layer.
* The green band is otherwise occupied only by deep greens —
  priority: p3 (#0e8a16), ai: verified (#28a745), help-wanted
  (#008672) — so a light green sits in the same hue family
  while staying visually distinct from each of those.

If the colour ever clashes with a new label, swapping is a
one-line change in this file.

After `terraform-apply.yml` propagates the change, every label
in the GitHub UI has a description and `scope: docs` no longer
shares its colour with `scope: ci`.
