### PR TITLE
chore(ci): SHA-pin reusable workflows and bump action SHAs to latest

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Let Claude implement the Issue
         if: steps.auth.outputs.allowed == 'true'
-        uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1
+        uses: anthropics/claude-code-action@ef50f123a3a9be95b60040d042717517407c7256 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -18,4 +18,4 @@ permissions:
 
 jobs:
   check:
-    uses: aletheia-works/.github/.github/workflows/commitlint.yml@main
+    uses: aletheia-works/.github/.github/workflows/commitlint.yml@5212c0d0443cbe3ef25281d644f83d5edb0e9986 # main

--- a/.github/workflows/seed-state.yml
+++ b/.github/workflows/seed-state.yml
@@ -74,7 +74,7 @@ jobs:
       # artifact published above. Uses TF_TOKEN_GITHUB because the default
       # GITHUB_TOKEN lacks variables:write permission.
       - name: Point LATEST_APPLY_RUN_ID at this run
-        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.TF_TOKEN_GITHUB }}
           script: |

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   apply:
     # Pinned by commit SHA (org enforces sha_pinning_required).
-    uses: aletheia-works/.github/.github/workflows/terraform-apply.yml@5332565f225f242a263807236a07afb4478d0be4 # main
+    uses: aletheia-works/.github/.github/workflows/terraform-apply.yml@5212c0d0443cbe3ef25281d644f83d5edb0e9986 # main
     with:
       working_directory: infra/github
     secrets: inherit

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -26,7 +26,7 @@ jobs:
   plan:
     # Pinned by commit SHA (org enforces sha_pinning_required). Update
     # this ref when the reusable workflow meaningfully changes.
-    uses: aletheia-works/.github/.github/workflows/terraform-plan.yml@db8aaaef0c0c8dc00152bfb37f1eee15f019a087 # main
+    uses: aletheia-works/.github/.github/workflows/terraform-plan.yml@5212c0d0443cbe3ef25281d644f83d5edb0e9986 # main
     with:
       working_directory: infra/github
     secrets: inherit

--- a/.github/workflows/terraform-state-backup.yml
+++ b/.github/workflows/terraform-state-backup.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Cleanup old backups (keep last 12)
         if: steps.check.outputs.exists == 'true'
-        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { data: releases } = await github.rest.repos.listReleases({

--- a/.github/workflows/tofu-fmt-autofix.yml
+++ b/.github/workflows/tofu-fmt-autofix.yml
@@ -27,7 +27,7 @@ jobs:
   autofix:
     # Pinned by commit SHA (org enforces sha_pinning_required). Update
     # this ref when the reusable workflow meaningfully changes.
-    uses: aletheia-works/.github/.github/workflows/terraform-autofix.yml@fafae94f3c7691a02e05746c53aa833b0489efab # main
+    uses: aletheia-works/.github/.github/workflows/terraform-autofix.yml@5212c0d0443cbe3ef25281d644f83d5edb0e9986 # main
     with:
       working_directory: infra/github
       commit_message: 'style(infra): tofu fmt -recursive'

--- a/.github/workflows/vivarium-verdict-self-test.yml
+++ b/.github/workflows/vivarium-verdict-self-test.yml
@@ -39,6 +39,6 @@ jobs:
     # ships from the GHCR public registry on every main deploy,
     # so it has the lowest variance among the current Layer 2
     # entries.
-    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@5212c0d0443cbe3ef25281d644f83d5edb0e9986 # main
     with:
       slug: bash-local-shadows-exit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,33 +204,67 @@ including this one — host only thin caller workflows plus any
 `workflow_run` listeners. If a workflow here starts duplicating logic that
 would belong in the org, flag it for promotion rather than copying.
 
-### 4.9 GitHub Actions: latest versions only
+### 4.9 GitHub Actions: latest versions, pinned by SHA
 
-When **adding** a new GitHub Actions workflow or **editing** an existing
-one, use the latest published versions of every action and runtime
-referenced. This applies to:
+Two coupled rules.
 
-- Marketplace actions — pin to the most recent major tag at the time of
-  authoring (e.g. `actions/checkout@v4`, `actions/setup-node@v4`,
-  `oven-sh/setup-bun@v2`, `denoland/setup-deno@v2`). Do not copy older
-  pins from a sibling workflow that is itself out of date.
-- Runtime versions — Node.js, Deno, Bun, Python, Go, etc.: the current
-  stable release.
-- Reusable-workflow refs — call the `aletheia-works/.github` reusables at
-  their latest tag, not a stale SHA.
+**(a) Latest at authoring time.** When adding a new GitHub Actions
+workflow or editing an existing one, use the latest published version
+of every action and runtime referenced. This applies to:
 
-Do **not** ship a workflow that is already known to be one Dependabot run
-behind. Dependabot opens its bumps daily; a stale-on-arrival workflow
-just creates an immediate follow-up PR for no benefit. Catching the
-version at authoring time costs one CI roundtrip; catching it via
-Dependabot costs an extra review cycle and an extra merge — strictly
-more expensive.
+- Marketplace actions — the most recent published release at the
+  time of authoring (e.g. `actions/checkout` v6.0.2,
+  `oven-sh/setup-bun` v2.2.0). Do not copy older pins from a sibling
+  workflow that is itself out of date.
+- Runtime versions — Node.js, Deno, Bun, Python, Go, etc.: the
+  current stable release.
+- Reusable-workflow refs — call the `aletheia-works/.github`
+  reusables at the latest commit on their tracked branch (usually
+  `main`).
 
-Reasonable exception: if a newer major bumps an action's interface and
-the migration is non-trivial, pin the older major **with a one-line
-comment** (`# pinned at v3 until <link to issue>`) so the next
-maintainer sees the deliberate choice rather than guessing it is an
-oversight.
+Do **not** ship a workflow that is already known to be one Dependabot
+run behind. Dependabot opens its bumps daily; a stale-on-arrival
+workflow just creates an immediate follow-up PR for no benefit.
+Catching the version at authoring time costs one CI roundtrip;
+catching it via Dependabot costs an extra review cycle and an extra
+merge — strictly more expensive.
+
+**(b) Pin by full commit SHA, not by tag or branch.** Marketplace tags
+are mutable — `actions/checkout@v6` points at whatever commit the
+action's maintainer last decided should be `v6`. The GitHub
+security-hardening guide
+(https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
+states explicitly that *"pinning an action to a full length commit
+SHA is currently the only way to use an action as an immutable
+release."* Always pin to the full 40-char commit SHA, with the
+human-readable version (for marketplace actions) or branch name (for
+reusable workflows) as a trailing comment for review:
+
+```yaml
+# Marketplace action — tag literal in trailing comment
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+# Reusable workflow on main — branch name in trailing comment
+uses: aletheia-works/.github/.github/workflows/commitlint.yml@5212c0d0443cbe3ef25281d644f83d5edb0e9986 # main
+```
+
+The trailing `# vX.Y.Z` or `# main` comment is mandatory — the SHA
+alone is unreviewable. Dependabot's `github-actions` ecosystem
+rebumps the SHA on every release the same way it bumps tags, so SHA
+pinning does not freeze updates; it just makes each update a
+deliberate, reviewable change.
+
+To resolve the latest SHA for a tag or branch from the shell:
+
+```bash
+gh api repos/<owner>/<repo>/commits/<tag-or-branch> --jq '.sha'
+```
+
+**Exception clause.** If a newer major bumps an action's interface
+and the migration is non-trivial, pin the older major's latest SHA
+**with a one-line comment** (`# pinned at v3 until <link to issue>`)
+so the next maintainer sees the deliberate choice rather than
+guessing it is an oversight.
 
 ## 5. Three-layer architecture (reference)
 


### PR DESCRIPTION

Brings every workflow in this repo into compliance with the
SHA-pin rule introduced in AGENTS.md §4.9 (extended in this PR
to make the SHA-pin requirement explicit), and bumps action
SHAs that had drifted behind their tag's latest release.

What changes in workflows:

* `commitlint.yml` and `vivarium-verdict-self-test.yml` were
  still calling reusable workflows by branch name (`@main`).
  GitHub treats branch refs as mutable, which is exactly what
  AGENTS.md §4.9(b) forbids. Both now SHA-pin to the current
  `aletheia-works/.github` main HEAD with the branch name as
  a trailing comment for review.
* `claude-implement.yml`'s `anthropics/claude-code-action@v1`
  pin was at an older SHA than the v1 tag's current target
  (the v1 tag is mutable upstream and has moved). Bumped to
  the present v1 SHA.
* `seed-state.yml` and `terraform-state-backup.yml` both used
  `actions/github-script@v9.0.0` but pinned at a SHA that no
  longer matches the v9.0.0 tag's current target. Unified on
  the present v9.0.0 SHA so both call sites match.
* `terraform-apply.yml`, `terraform-plan.yml`, and
  `tofu-fmt-autofix.yml` all SHA-pinned to older
  `aletheia-works/.github` main commits. Bumped to the
  present main HEAD so the toolchain matches what the org
  reusables actually run today.

Resolved SHAs (as of 2026-04-30):

* `aletheia-works/.github` main HEAD — `5212c0d0443cbe3ef25281d644f83d5edb0e9986`
* `actions/github-script@v9.0.0` — `3a2844b7e9c422d3c10d287c895573f7108da1b3`
* `anthropics/claude-code-action@v1` — `ef50f123a3a9be95b60040d042717517407c7256`

What changes in AGENTS.md §4.9:

The previous wording covered "use the latest version" but only
implied SHA pinning. The maintainer reported that AI agents
kept shipping tag-only pins (`@v4`) despite the existing rule,
so the section is restructured into two explicit, coupled
rules:

* **(a) Latest at authoring time** — unchanged in spirit.
* **(b) Pin by full commit SHA, not by tag or branch** — new
  explicit rule. Quotes GitHub's security-hardening guide
  ("the only way to use an action as an immutable release"),
  shows worked examples for both marketplace actions
  (`actions/checkout@<sha> # v6.0.2`) and reusable workflows
  (`aletheia-works/.github/.github/workflows/foo.yml@<sha> # main`),
  spells out that the trailing comment is mandatory, and
  documents the one-liner for resolving a SHA from the shell:

  ```
  gh api repos/<owner>/<repo>/commits/<tag-or-branch> --jq '.sha'
  ```

The exception clause (older majors with non-trivial migrations
get a `# pinned at v3 until <issue>` comment) is preserved.

Section title changed from "GitHub Actions: latest versions
only" to "GitHub Actions: latest versions, pinned by SHA" to
make the SHA requirement visible at the table-of-contents
level.

Out of scope:

* The 8 marketplace actions whose SHA already matches the
  upstream tag's current target (`actions/checkout` v6.0.2,
  `oven-sh/setup-bun` v2.2.0, `actions/upload-artifact` v7.0.1,
  etc.) are left untouched — Dependabot's `github-actions`
  ecosystem will rebump them on the next upstream release.
* Bumping the `aletheia-works/.github` reusables themselves to
  add new functionality is a separate cross-org change.
