### PR TITLE
docs: refresh README, roadmap, and public docs for phase 6 status

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,16 @@
 
 ## 🚧 Status
 
-**Phase 0 — Bootstrap**
+**Phase 6 — Usability and visual layer (in flight)**
 
-This project is in the initial setup phase. Infrastructure-as-Code foundations
-are being established. Actual product development has not started yet.
+Phases 0–5 closed between 2026-04-26 and 2026-04-29. Layer 1 ships six
+WASM verticals (Python via Pyodide, Ruby.wasm, php-wasm, Rust on
+`wasm32-wasip1`); Layer 2 ships four Docker recipes published to
+`ghcr.io/aletheia-works/`; Layer 3 ships one `rr` recipe. Public specs
+(**Contract v1**, **Manifest v1**, **Recipes index v1**) and a
+**Vivarium MCP server** for AI agent clients are published.
 
-See [`docs/docs/roadmap.md`](docs/docs/roadmap.md) for the full plan from Phase 0 to Phase 5.
+See [`docs/docs/roadmap.md`](docs/docs/roadmap.md) for the per-phase plan.
 
 ---
 
@@ -46,9 +50,17 @@ The technology is chosen by the problem, not the other way around.
 
 ## Documentation
 
-**[aletheia-works.github.io/vivarium](https://aletheia-works.github.io/vivarium)** — vision, roadmap, architecture, ADRs.
+**[aletheia-works.github.io/vivarium](https://aletheia-works.github.io/vivarium)** — vision, roadmap, architecture, the public spec surface.
 
-Public specification: **[Vivarium Contract v1](https://aletheia-works.github.io/vivarium/spec/contract-v1)** — the reproduction-verdict surface every gallery page emits, with a JSON Schema (`docs/public/spec/verdict.schema.json`) CI validates every Layer 2 / Layer 3 `verdict.json` against.
+Public specs:
+
+- **[Contract v1](https://aletheia-works.github.io/vivarium/spec/contract-v1)** — the reproduction-verdict surface every gallery page emits (revision 2 adds an optional evidence surface). JSON Schema at [`verdict.schema.json`](https://aletheia-works.github.io/vivarium/spec/verdict.schema.json), CI-validated on every Layer 2/3 `verdict.json`.
+- **[Manifest v1](https://aletheia-works.github.io/vivarium/spec/manifest-v1)** — TOML manifest an external repo ships at `.vivarium/manifest.toml` to declare a Vivarium-runnable reproduction. JSON Schema at [`manifest.schema.json`](https://aletheia-works.github.io/vivarium/spec/manifest.schema.json).
+- **[Recipes index v1](https://aletheia-works.github.io/vivarium/spec/recipes-index-v1)** — machine-readable catalogue listing of every reproduction in this repo. Live endpoint: <https://aletheia-works.github.io/vivarium/api/recipes.json>.
+
+Programmatic access:
+
+- **[`@aletheia-works/vivarium-mcp`](packages/mcp-server/)** — Model Context Protocol server exposing `list_recipes` / `get_recipe` / `lookup_verdict` to AI agent clients (Claude Code, Cline, Cursor, Continue, …). Dual-published to JSR (canonical) and npm (fallback).
 
 The docs site is built with [rspress](https://rspress.rs) and deployed to GitHub Pages from [`docs/`](docs/) on every push to `main`. The rspress configuration and lockfile live in `docs/`; the markdown content lives in `docs/docs/`.
 
@@ -69,30 +81,30 @@ The project eats its own dog food:
 ```
 vivarium/
 ├── README.md                 # This file
+├── AGENTS.md                 # Standing instructions for AI coding agents
+├── CLAUDE.md                 # Claude Code-specific addenda
+├── mise.toml                 # Tool versions (bun, opentofu, python, ruby, php, rust)
 ├── .gitignore
 ├── .github/
-│   ├── workflows/            # CI/CD and automation
-│   │   ├── terraform-plan.yml
-│   │   ├── terraform-apply.yml
-│   │   └── terraform-state-backup.yml
-│   └── dependabot.yml        # Automated dependency updates
+│   ├── workflows/            # CI/CD — thin callers into aletheia-works/.github reusables
+│   ├── labeler.yml           # Path-based label rules
+│   └── dependabot.yml        # Automated dependency updates (github-actions, terraform, bun)
 ├── infra/
 │   └── github/               # GitHub Settings as Code (OpenTofu)
-│       ├── versions.tf
-│       ├── providers.tf
-│       ├── variables.tf
-│       ├── main.tf
-│       ├── branch_protection.tf
-│       ├── labels.tf
+│       ├── milestones.tf, labels.tf, branch_protection.tf, …
 │       └── README.md
-├── docs/                     # rspress docs site (config + content)
-│   ├── package.json          # rspress + bun deps
-│   ├── rspress.config.ts
-│   ├── tsconfig.json
-│   ├── bun.lock
-│   └── docs/                 # markdown content (vision, architecture, ADRs)
-└── src/                      # Source code
-    └── ...                   # (to be added)
+├── docs/                     # rspress docs site
+│   ├── public/spec/          # JSON Schemas — verdict.schema.json, manifest.schema.json
+│   ├── public/api/           # recipes.json, recipes.schema.json
+│   ├── scripts/              # build-time scripts (recipes-index generator)
+│   └── docs/                 # vision, architecture, roadmap, spec/, repro/
+├── packages/
+│   └── mcp-server/           # @aletheia-works/vivarium-mcp (JSR + npm dual publish)
+└── src/
+    ├── layer1_wasm/          # 6 Layer 1 recipes (Pyodide, Ruby.wasm, php-wasm, Rust)
+    ├── layer2_docker/        # 4 Layer 2 recipes (Docker images on GHCR)
+    ├── layer3_thirdway/      # 1 Layer 3 recipe (rr replay)
+    └── external_examples/    # reference Manifest v1 fixtures, one per layer
 ```
 
 ## Getting Started
@@ -104,17 +116,28 @@ repository settings via OpenTofu.
 
 ### For Contributors
 
-The project is not yet accepting contributions — the foundations are still
-being laid. Star the repo to follow along.
+External contributions land most naturally as **Vivarium-runnable
+reproductions in your own repo**: ship a `.vivarium/manifest.toml`
+that points at a static page (Layer 1) or a published container image
+(Layer 2/3) per the [Manifest v1 spec](https://aletheia-works.github.io/vivarium/spec/manifest-v1).
+Three reference manifests live under
+[`src/external_examples/`](src/external_examples/), one per layer.
 
-## Tech Stack (Planned)
+Issue and PR contributions to this repo are also welcome; the
+AI-delegated workflow ([`docs/docs/ai-workflow.md`](docs/docs/ai-workflow.md))
+applies regardless of who opens them.
 
-| Layer | Technology |
+## Tech Stack
+
+| Area | Technology |
 |---|---|
-| WASM execution | Pyodide, sqlite-wasm, Rust (wasm32-wasi) |
-| Docker execution | devcontainer, Firecracker (exploration) |
-| Record-replay | rr, Pernosco-style (long-term) |
-| Infrastructure | OpenTofu, GitHub Actions |
+| Layer 1 (WASM) | Pyodide, Ruby.wasm, php-wasm, Rust `wasm32-wasip1` |
+| Layer 2 (Docker) | Docker images published to GHCR per recipe |
+| Layer 3 (record-replay) | `rr` replay against trace baked into a GHCR image |
+| Docs site | rspress + Bun + GitHub Pages |
+| MCP server | TypeScript on Bun, dual-published to JSR + npm with OIDC + Sigstore provenance |
+| Infrastructure | OpenTofu, GitHub Actions (SHA-pinned), aletheia-works/.github reusables |
+| Local toolchain | mise-en-place pinning bun / opentofu / python / uv / php / ruby / rust |
 | AI agents | Claude Code (implementer and reviewer) |
 
 ## License
@@ -127,5 +150,5 @@ Individual developer project.
 
 ---
 
-*This README will evolve as the project moves through phases.*
-*Current version: Phase 0 — Bootstrap.*
+*This README evolves as the project moves through phases.*
+*Current phase: Phase 6.*

--- a/docs/docs/ai-workflow.md
+++ b/docs/docs/ai-workflow.md
@@ -139,7 +139,7 @@ as a *follow-up* Issue linked to an in-flight task.
 Claude Code picks up an Issue when:
 
 - The Issue is unambiguous enough that scope creep is unlikely, **and**
-- The work is within the current phase (Phase 0 today), **and**
+- The work is within the current phase (Phase 6 today), **and**
 - The Issue does **not** carry `status: blocked` (see below), **and**
 - No other agent is already assigned.
 
@@ -278,8 +278,13 @@ stop and hand off.
 
 Tracked elsewhere, not here:
 
-- Install Dosu.
-- Continue seeding the Phase 0 Issue backlog.
+- Issue-triage tooling — Phase 5 closed without adopting one
+  (CodeRabbit Issue Enrichment was declined on prior free-tier
+  experience, paid-API alternatives did not match the
+  zero-recurring-cost constraint). The research memo plus a fresh
+  re-evaluation drives the next decision if external Issue volume
+  ever creates pressure. See the
+  [Phase 5 close on the roadmap](./roadmap.md).
 
 The `/claude`-triggered implementation workflow is in place at
 [`.github/workflows/claude-implement.yml`](https://github.com/aletheia-works/vivarium/blob/main/.github/workflows/claude-implement.yml),

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -325,9 +325,10 @@ observations rather than from up-front design.
 
 ## Current scope
 
-As of 2026-04-27, Phases 0–3 are closed and Phase 4 is active. The
-architectural slots above have filled in unevenly — by design, since
-each layer waits for a concrete Issue before a vertical lands.
+As of 2026-05-01, Phases 0–5 are closed and Phase 6 (usability and
+visual layer) is active. The architectural slots above have filled in
+unevenly — by design, since each layer waits for a concrete Issue
+before a vertical lands.
 
 **Layer 1.** Six verticals live under `src/layer1_wasm/`:
 `cpython-137205`, `numpy-28287`, `pandas-56679`, `regex-779` (Python
@@ -345,12 +346,12 @@ pinned `Dockerfile`, `repro.sh`, GHCR-published image, copy-pasteable
 runtime exists; the visitor's own Docker (or Codespaces) is the
 runtime, exactly as the delivery model above requires.
 
-**Layer 3.** Phase 4 is the active milestone. The trace-shipped
-catalogue model described above is the current design; the first
-recipe is in progress, and `src/layer3_thirdway/` still holds only
-its README plus the design notes ADR-0011 (private memo) refers to.
-Until the first vertical lands, Layer 3 has no canonical recipe
-shape — only a documented intended shape.
+**Layer 3.** Phase 4 closed with one recipe shipped: the
+`pthread`-style canonical lost-update data race under
+`src/layer3_thirdway/lost-update/`, distributed as a GHCR image with
+the `rr` trace baked in. Further Layer 3 verticals are deferred
+until a concrete bug forces another one — Phase 4's close ADR
+(ADR-0012, private memo) accepts the partial outcome explicitly.
 
 The conservative phasing — refuse to commit to runtimes beyond what
 the next concrete Issue actually needs — was the project's

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -26,7 +26,10 @@ features:
     details: Humans set direction and merge. AI agents implement, review, and iterate. Infrastructure runs continuously.
   - title: Lifelong project
     details: Measured in years, not quarters. No false urgency, no shipping-to-launch pressure, no completion deadline.
-  - title: Public spec
-    details: Vivarium Contract v1 — an open, JSON Schema-backed specification for the reproduction-verdict surface every gallery page emits. External tools and third-party reproductions can declare conformance.
+  - title: Public specs
+    details: Contract v1 (verdict surface), Manifest v1 (third-party reproductions declare themselves via .vivarium/manifest.toml), and Recipes index v1 (machine-readable catalogue). Each backed by a JSON Schema.
     link: /spec/
+  - title: Agent integration
+    details: A Model Context Protocol server (@aletheia-works/vivarium-mcp) exposes the recipe catalogue and verdict snapshots to Claude Code, Cline, Cursor, Continue, and other AI agent clients. Dual-published to JSR and npm with OIDC + Sigstore provenance.
+    link: /spec/recipes-index-v1
 ---

--- a/docs/docs/non-goals.md
+++ b/docs/docs/non-goals.md
@@ -83,10 +83,10 @@ refuses that anchoring.
 
 ## We are not a three-year MVP
 
-Phase 0 through Phase 5 in the roadmap span years, not quarters. The
-project is built on the assumption that lifelong scope requires
-lifelong patience: no shipping-to-launch pressure, no feature quota
-to justify a round of funding, no completion deadline.
+The roadmap spans years, not quarters. The project is built on the
+assumption that lifelong scope requires lifelong patience: no
+shipping-to-launch pressure, no feature quota to justify a round of
+funding, no completion deadline.
 
 **Why:** The techniques we respect — record-replay research,
 deterministic simulation, mature WASM runtimes — took decades to
@@ -97,4 +97,4 @@ mature. Reproduction-as-a-primitive deserves the same timescale.
 ## See also
 
 - [Vision](./vision.md) — what we *are* building.
-- [Roadmap](./roadmap.md) — the Phase 0 → Phase 5 plan.
+- [Roadmap](./roadmap.md) — the per-phase plan.

--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> Phase 0 through Phase 5 — what a visitor should expect to see land, in
+> The per-phase plan — what a visitor should expect to see land, in
 > what order, framed in terms of the reproduction primitive.
 >
 > Phase titles mirror the GitHub Milestones in
@@ -228,6 +228,71 @@ ecosystem expects rather than a thing one project does.
 **Non-goals for this phase:** a managed service with an SLA (see
 [Non-goals](./non-goals.md#we-are-not-a-managed-service-with-an-sla));
 closing the source; vendor lock-in of any kind.
+
+## Phase 6 — Usability and visual layer
+
+**Milestone:** [Phase 6 — Usability and visual layer](https://github.com/aletheia-works/vivarium/milestones?state=open) *(active, opened 2026-04-29)*
+
+**What lands:**
+
+- **Visual redesign (V).** Maintainer-driven Claude Design mock for the
+  home page, recipe gallery, individual recipe page, and verdict-comparison
+  page; followed by a reusable component library (`RecipeCard`,
+  `VerdictBadge`, `EvidencePanel`, `CodeDiff`, `FacetFilter`) implemented
+  on top of rspress.
+- **Reproduction comparison (R).** Side-by-side rendering of a recipe's
+  original verdict against a contributor's branch-fix verdict, so an
+  AI-generated fix can be checked against the reproduction before the PR
+  is opened. Shipped piece-by-piece: Contract v1 revision 2 (evidence
+  surface) lands first, then the build & verify pipeline, then the
+  comparison-page UI.
+- **Search & discoverability (S).** Faceted gallery search on `language`
+  / `layer` / `symptom` / `severity`, plus a paste-an-error-message →
+  candidate-recipes matcher. Mechanical text matching only in v1.
+- **Manifest authoring UX (M).** Form-driven `manifest.toml` scaffolder
+  on the docs site that walks an external contributor through the
+  Manifest v1 fields and emits a copy-pasteable TOML block.
+- **External AI integration (X).** A Vivarium MCP server exposing the
+  recipe catalogue, recipe metadata, and cached verdict lookups to AI
+  agent clients. Layer 1 only for synchronous-execution surfaces in v1
+  (Layer 2/3 metadata still surfaced; live execution declined).
+- **Localisation (L).** Japanese ⇄ English i18n on the home and the
+  cross-cutting docs (vision, architecture, ai-workflow, roadmap, repro
+  index). Spec pages stay English-only — they target external implementers
+  and benefit from a single canonical text.
+
+**What has shipped so far (cumulative):**
+
+- Contract v1 **revision 2** — evidence surface (logs / exit code /
+  duration on the in-page DOM and envelope). Non-breaking; v1 consumers
+  feature-detect the new field.
+- **Recipes index v1** — `https://aletheia-works.github.io/vivarium/api/recipes.json`
+  is now a live, machine-readable catalogue endpoint with its own
+  [JSON Schema](https://aletheia-works.github.io/vivarium/api/recipes.schema.json)
+  and [spec page](./spec/recipes-index-v1.md).
+- **Vivarium MCP server** — `@aletheia-works/vivarium-mcp`,
+  dual-published to JSR (canonical) and npm (fallback) under
+  `packages/mcp-server/`. Three tools (`list_recipes`, `get_recipe`,
+  `lookup_verdict`) expose the catalogue to AI agent clients.
+- Manifest v1 examples gain a Taplo / Tombi `#:schema` directive so
+  TOML language servers autocomplete and validate the manifest as the
+  maintainer types.
+
+**Closure rule:** **V + R + at least one of S / M / X / L** ships.
+Same precedent as ADR-0012 / ADR-0016: partial sub-stream completion
+is acceptable when the shape is proved.
+
+**What a visitor sees:** the docs site stops feeling like a primitive
+proof and starts feeling like a coherent product. Recipes are
+searchable. Branch-fix verification is one click. AI agent clients can
+discover Vivarium recipes programmatically without scraping the docs
+site. External adopters can scaffold a manifest in the browser.
+
+**Non-goals for this phase:** Layer 2/3 metadata expansion — the
+catalogue stays at the Phase-5-close size unless a Phase 6 sub-stream
+specifically needs new recipes (e.g. R's branch-fix PoC may add a
+simple Python or Ruby recipe if the existing ones are awkward fits for
+source substitution); per-user accounts; hosted execution.
 
 ---
 

--- a/infra/github/README.md
+++ b/infra/github/README.md
@@ -9,6 +9,7 @@ OpenTofu configuration that manages this repository's settings declaratively.
 | Repository | `main.tf` |
 | Branch protection | `branch_protection.tf` |
 | Issue/PR labels | `labels.tf` |
+| Phase milestones | `milestones.tf` |
 
 ## CI workflows
 
@@ -77,6 +78,7 @@ infra/github/
 ├── main.tf                     # Repository resource
 ├── branch_protection.tf        # Branch protection rules
 ├── labels.tf                   # Issue/PR labels
+├── milestones.tf               # Phase milestones (Phase 0–6)
 ├── terraform.tfvars.example    # Template for terraform.tfvars
 ├── .gitignore                  # Excludes state and secrets
 ├── .terraform.lock.hcl         # Provider version lock (committed)


### PR DESCRIPTION

Companion to PR #136 (AGENTS.md refresh). Same drift cause: the
project is in Phase 6, but the visitor-facing docs surface still
read as Phase 0 — Phase 4 in places. This PR brings README,
roadmap, and the docs/docs/ markdown corpus back in sync with
what has actually shipped.

What changes:

* `README.md`:
  - Status block: Phase 0 → Phase 6, with a one-paragraph summary
    of what shipped through Phases 1–5 (Layer 1: 6 verticals,
    Layer 2: 4 recipes, Layer 3: 1 rr recipe; public Contract /
    Manifest / Recipes-index v1 specs; Vivarium MCP server).
  - Documentation section: links to all three public specs +
    the live recipes.json endpoint + the MCP server package.
  - Repository Structure: was missing `packages/`, the populated
    `src/layer{1,2,3}_*/`, `src/external_examples/`, `mise.toml`,
    `docs/public/`, `docs/scripts/`. The tree now matches reality.
  - For Contributors: was "not yet accepting contributions" — now
    points at the Manifest v1 path for external-repo contributions
    and at ai-workflow.md for in-repo Issue/PR contributions.
  - Tech Stack: was "Planned" with one row per layer. Now lists
    the actual tools in use, including bun + JSR + npm dual publish
    + mise + SHA-pinned actions.
  - Closing note: "Phase 0 — Bootstrap" → "Phase 6".
* `docs/docs/roadmap.md`:
  - Title scope was "Phase 0 through Phase 5"; broadened to
    "the per-phase plan".
  - Adds a full Phase 6 section after Phase 5 with the six
    sub-streams (V/R/S/M/X/L), what has already shipped (Contract
    v1 revision 2, Recipes index v1, MCP server, Manifest v1
    schema directives), the closure rule, and the non-goals.
  - Phase 0–5 entries unchanged (those closed accurately).
* `docs/docs/ai-workflow.md`:
  - §3.2 pickup criterion: "Phase 0 today" → "Phase 6 today".
  - §7 open follow-ups: removed the obsolete "Install Dosu" /
    "Continue seeding the Phase 0 Issue backlog" entries; replaced
    with a one-paragraph note that Phase 5 closed without
    adopting an Issue-triage tool, with a link back to the
    roadmap's Phase 5 close.
* `docs/docs/non-goals.md`:
  - "Phase 0 through Phase 5" → "The roadmap" (lifelong-scope
    point still stands; phase span shouldn't anchor the language).
  - "See also" link text: "Phase 0 → Phase 5 plan" →
    "the per-phase plan".
* `docs/docs/index.md` (homepage):
  - "Public spec" feature card: was Contract v1 only; now mentions
    Contract v1, Manifest v1, and Recipes index v1.
  - New "Agent integration" feature card pointing at the MCP
    server and the recipes-index spec page.
* `docs/docs/architecture.md`:
  - "Current scope" status line: 2026-04-27, Phases 0–3 closed,
    Phase 4 active → 2026-05-01, Phases 0–5 closed, Phase 6 active.
  - Layer 3 paragraph: was "Phase 4 is the active milestone, the
    first recipe is in progress" → reflects that Phase 4 closed
    with the lost-update recipe shipped, further Layer 3 entries
    deferred per ADR-0012.
* `infra/github/README.md`:
  - Managed resources table: adds `Phase milestones | milestones.tf`.
  - File layout block: adds `milestones.tf` line.

What does not change:

* Spec pages (`docs/docs/spec/*`) — already accurate as of the
  most recent landing PRs.
* Vision and core principles in `docs/docs/vision.md` — no Phase-
  number coupling, still current.
* `packages/mcp-server/README.md` — already accurate (shipped
  with PR #130 / #134).
