### PR TITLE
chore(ci): bump reusable SHA pins to post-#9 main + skip plan on fork PRs

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -18,4 +18,4 @@ permissions:
 
 jobs:
   check:
-    uses: aletheia-works/.github/.github/workflows/commitlint.yml@5212c0d0443cbe3ef25281d644f83d5edb0e9986 # main
+    uses: aletheia-works/.github/.github/workflows/commitlint.yml@7d0327b430d3760d7d993c426395db6776459a7e # main

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   apply:
     # Pinned by commit SHA (org enforces sha_pinning_required).
-    uses: aletheia-works/.github/.github/workflows/terraform-apply.yml@5212c0d0443cbe3ef25281d644f83d5edb0e9986 # main
+    uses: aletheia-works/.github/.github/workflows/terraform-apply.yml@7d0327b430d3760d7d993c426395db6776459a7e # main
     with:
       working_directory: infra/github
     secrets: inherit

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -24,9 +24,18 @@ permissions:
 
 jobs:
   plan:
+    # Skip on fork PRs: the reusable workflow downloads the state
+    # artifact from a prior apply run via `actions/download-artifact`,
+    # which fails on fork PRs because the cross-run-id download requires
+    # a repo-scoped token. Without state, `tofu plan` would compare
+    # against an empty state and report every existing resource as a
+    # spurious "to add" — useless for review and noisy in CI. A
+    # maintainer can re-run the plan from a same-repo branch when the
+    # fork's changes are merged through a trusted-fork branch.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     # Pinned by commit SHA (org enforces sha_pinning_required). Update
     # this ref when the reusable workflow meaningfully changes.
-    uses: aletheia-works/.github/.github/workflows/terraform-plan.yml@5212c0d0443cbe3ef25281d644f83d5edb0e9986 # main
+    uses: aletheia-works/.github/.github/workflows/terraform-plan.yml@7d0327b430d3760d7d993c426395db6776459a7e # main
     with:
       working_directory: infra/github
     secrets: inherit

--- a/.github/workflows/tofu-fmt-autofix.yml
+++ b/.github/workflows/tofu-fmt-autofix.yml
@@ -27,7 +27,7 @@ jobs:
   autofix:
     # Pinned by commit SHA (org enforces sha_pinning_required). Update
     # this ref when the reusable workflow meaningfully changes.
-    uses: aletheia-works/.github/.github/workflows/terraform-autofix.yml@5212c0d0443cbe3ef25281d644f83d5edb0e9986 # main
+    uses: aletheia-works/.github/.github/workflows/terraform-autofix.yml@7d0327b430d3760d7d993c426395db6776459a7e # main
     with:
       working_directory: infra/github
       commit_message: 'style(infra): tofu fmt -recursive'

--- a/.github/workflows/vivarium-verdict-self-test.yml
+++ b/.github/workflows/vivarium-verdict-self-test.yml
@@ -39,6 +39,6 @@ jobs:
     # ships from the GHCR public registry on every main deploy,
     # so it has the lowest variance among the current Layer 2
     # entries.
-    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@5212c0d0443cbe3ef25281d644f83d5edb0e9986 # main
+    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@7d0327b430d3760d7d993c426395db6776459a7e # main
     with:
       slug: bash-local-shadows-exit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,7 +283,7 @@ reusable workflows) as a trailing comment for review:
 uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
 # Reusable workflow on main — branch name in trailing comment
-uses: aletheia-works/.github/.github/workflows/commitlint.yml@5212c0d0443cbe3ef25281d644f83d5edb0e9986 # main
+uses: aletheia-works/.github/.github/workflows/commitlint.yml@7d0327b430d3760d7d993c426395db6776459a7e # main
 ```
 
 The trailing `# vX.Y.Z` or `# main` comment is mandatory — the SHA


### PR DESCRIPTION

Bumps every aletheia-works/.github reusable-workflow pin and the
AGENTS.md example from 5212c0d0443cbe3ef25281d644f83d5edb0e9986 to
7d0327b430d3760d7d993c426395db6776459a7e (the merge commit of
aletheia-works/.github#9).

Also gates the local terraform-plan caller on
\`head.repo.full_name == github.repository\` so it skips on fork PRs.

The reusable workflow downloads the state artifact via
\`actions/download-artifact\` with a cross-run-id request, which fails
on fork PRs because the token is repo-scoped to the fork. Without
state, \`tofu plan\` compares against an empty state and reports every
existing resource as a spurious \"to add\" — useless for review and
noisy in CI. A maintainer can re-run the plan from a same-repo branch
when the fork's changes are merged through a trusted-fork branch.

#9 in the org repo:

- Made the reusable terraform-plan workflow safe for fork PRs at the
  PR-comment level (Step Summary fallback when GITHUB_TOKEN is
  read-only on \`pull_request\` from forks; inline PR comment kept for
  same-repo PRs only).
- Synced org-wide defaults with vivarium's phase 6 state (mise.toml
  rename, profile/README.md, SECURITY.md, labeler.yml, PR/Issue
  templates, infra/github-org/main.tf comment).

Files touched:

- .github/workflows/terraform-plan.yml (SHA bump + fork-skip gate)
- .github/workflows/terraform-apply.yml (SHA bump)
- .github/workflows/tofu-fmt-autofix.yml (SHA bump)
- .github/workflows/commitlint.yml (SHA bump)
- .github/workflows/vivarium-verdict-self-test.yml (SHA bump)
- AGENTS.md (documentation example, kept consistent with workflows)
