### PR TITLE
chore(ci): bump aletheia-works/.github reusable SHA pins to post-#12 main

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -18,4 +18,4 @@ permissions:
 
 jobs:
   check:
-    uses: aletheia-works/.github/.github/workflows/commitlint.yml@7d0327b430d3760d7d993c426395db6776459a7e # main
+    uses: aletheia-works/.github/.github/workflows/commitlint.yml@2869d127c99b5cd8bcfb22d7ade8a31d1204019c # main

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   apply:
     # Pinned by commit SHA (org enforces sha_pinning_required).
-    uses: aletheia-works/.github/.github/workflows/terraform-apply.yml@7d0327b430d3760d7d993c426395db6776459a7e # main
+    uses: aletheia-works/.github/.github/workflows/terraform-apply.yml@2869d127c99b5cd8bcfb22d7ade8a31d1204019c # main
     with:
       working_directory: infra/github
     secrets: inherit

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -35,7 +35,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     # Pinned by commit SHA (org enforces sha_pinning_required). Update
     # this ref when the reusable workflow meaningfully changes.
-    uses: aletheia-works/.github/.github/workflows/terraform-plan.yml@7d0327b430d3760d7d993c426395db6776459a7e # main
+    uses: aletheia-works/.github/.github/workflows/terraform-plan.yml@2869d127c99b5cd8bcfb22d7ade8a31d1204019c # main
     with:
       working_directory: infra/github
     secrets: inherit

--- a/.github/workflows/tofu-fmt-autofix.yml
+++ b/.github/workflows/tofu-fmt-autofix.yml
@@ -27,7 +27,7 @@ jobs:
   autofix:
     # Pinned by commit SHA (org enforces sha_pinning_required). Update
     # this ref when the reusable workflow meaningfully changes.
-    uses: aletheia-works/.github/.github/workflows/terraform-autofix.yml@7d0327b430d3760d7d993c426395db6776459a7e # main
+    uses: aletheia-works/.github/.github/workflows/terraform-autofix.yml@2869d127c99b5cd8bcfb22d7ade8a31d1204019c # main
     with:
       working_directory: infra/github
       commit_message: 'style(infra): tofu fmt -recursive'

--- a/.github/workflows/vivarium-verdict-self-test.yml
+++ b/.github/workflows/vivarium-verdict-self-test.yml
@@ -39,6 +39,6 @@ jobs:
     # ships from the GHCR public registry on every main deploy,
     # so it has the lowest variance among the current Layer 2
     # entries.
-    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@7d0327b430d3760d7d993c426395db6776459a7e # main
+    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@2869d127c99b5cd8bcfb22d7ade8a31d1204019c # main
     with:
       slug: bash-local-shadows-exit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,7 +283,7 @@ reusable workflows) as a trailing comment for review:
 uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
 # Reusable workflow on main — branch name in trailing comment
-uses: aletheia-works/.github/.github/workflows/commitlint.yml@7d0327b430d3760d7d993c426395db6776459a7e # main
+uses: aletheia-works/.github/.github/workflows/commitlint.yml@2869d127c99b5cd8bcfb22d7ade8a31d1204019c # main
 ```
 
 The trailing `# vX.Y.Z` or `# main` comment is mandatory — the SHA


### PR DESCRIPTION

Bumps every reusable-workflow pin and the AGENTS.md example from
7d0327b430d3760d7d993c426395db6776459a7e to
2869d127c99b5cd8bcfb22d7ade8a31d1204019c.

Picks up two improvements that landed in the org repo since the last
bump (#138):

- aletheia-works/.github#11 — `org-terraform-plan.yml` caller-side
  fork-skip gate. Vivarium already had the equivalent gate on its own
  caller (added in #138); the pin update keeps the two callers
  symmetric.

- aletheia-works/.github#12 — `commitlint.yml` reusable now writes
  failure details to \`\$GITHUB_STEP_SUMMARY\` and skips the inline
  PR-comment step on fork PRs (same Step-Summary fallback pattern
  used by terraform-plan since #9). Fork PRs whose commits violate
  the Conventional Commits rules now surface the failure log on the
  Actions tab instead of 403-ing on `issues/comments`.

Files touched:

- .github/workflows/commitlint.yml
- .github/workflows/terraform-apply.yml
- .github/workflows/terraform-plan.yml
- .github/workflows/tofu-fmt-autofix.yml
- .github/workflows/vivarium-verdict-self-test.yml
- AGENTS.md (documentation example, kept consistent with workflows)
