### PR TITLE
ci: skip terraform-apply and state-backup on forks

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -24,6 +24,11 @@ permissions:
 
 jobs:
   apply:
+    # Skip on forks. Apply mutates real org infrastructure and depends on
+    # repo-scoped secrets/variables (TF_TOKEN_GITHUB, LATEST_APPLY_RUN_ID)
+    # that don't exist in forks, so an upstream-sync push to a fork's main
+    # would otherwise trigger a guaranteed failure run.
+    if: github.repository_owner == 'aletheia-works'
     # Pinned by commit SHA (org enforces sha_pinning_required).
     uses: aletheia-works/.github/.github/workflows/terraform-apply.yml@2869d127c99b5cd8bcfb22d7ade8a31d1204019c # main
     with:

--- a/.github/workflows/terraform-state-backup.yml
+++ b/.github/workflows/terraform-state-backup.yml
@@ -36,10 +36,15 @@ jobs:
   backup:
     name: Backup State to Release
     runs-on: ubuntu-latest
-    # When triggered via workflow_run, only run if the apply succeeded.
+    # Skip on forks. The schedule trigger fires in any fork that has
+    # Actions enabled, but forks have no terraform-state artifact to back
+    # up and lack the variables/permissions the upstream backup relies on.
+    # Combined with the workflow_run-success gate so a workflow_run from a
+    # failed (or non-existent) apply never produces a release.
     if: |
-      github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'success'
+      github.repository_owner == 'aletheia-works' &&
+      (github.event_name != 'workflow_run' ||
+       github.event.workflow_run.conclusion == 'success')
 
     steps:
       - name: Checkout


### PR DESCRIPTION

A push to a fork's main (e.g. when syncing from upstream) was triggering
the apply caller, which then errored because forks lack the
TF_TOKEN_GITHUB / LATEST_APPLY_RUN_ID secrets and variables. The schedule
trigger on terraform-state-backup had the same shape: it fired weekly on
any fork with Actions enabled and then failed because no terraform-state
artifact existed.

Add `github.repository_owner == 'aletheia-works'` to both job-level `if:`
gates so neither workflow runs in a fork. This complements the existing
fork-PR gate on terraform-plan, which uses the PR-event form
(`pull_request.head.repo.full_name == github.repository`) and therefore
does not cover push or schedule triggers.
