### PR TITLE
feat(ci): phase 6 R.2 — branch-fix verdict capture pipeline

### DIFF
--- a/.github/workflows/branch-fix-verdict.yml
+++ b/.github/workflows/branch-fix-verdict.yml
@@ -1,0 +1,241 @@
+name: branch-fix verdict
+
+# Phase 6 R.2 — build & verify pipeline.
+#
+# Captures a Vivarium Contract v1 `verdict.json` for a contributor-
+# supplied "branch-fix" Docker image and bundles it alongside the
+# deployed original verdict so the Phase 6 R.3 reproduction-comparison
+# UI can render the two side-by-side. The contributor (human or AI
+# agent) is responsible for building and publishing the branch-fix
+# image to a registry the GitHub Actions runner can pull from; this
+# workflow does not build sources.
+#
+# Verdict semantics (Contract v1 § Verdict semantics):
+#   "pass" → the upstream bug REPRODUCES on the supplied image.
+#   "fail" → the bug does NOT reproduce.
+#
+# A working branch-fix is therefore expected to produce verdict
+# "fail" — the inverse of typical CI green/red framing. The
+# `expected_verdict` input defaults to "fail" for that reason; set
+# it to "pass" only if the branch-fix is meant to leave the bug
+# unaffected (e.g. an unrelated refactor on the recipe path).
+#
+# Triggers:
+# - `workflow_dispatch` only. The verdict comparison is a
+#   contributor-driven action, not something to run on every push.
+#
+# Permissions: `contents: read` is sufficient — the workflow only
+# reads the in-tree recipe to confirm the slug exists; it does not
+# write back to the repo. The artefact upload is repository-scoped
+# and does not need additional grants.
+
+on:
+  workflow_dispatch:
+    inputs:
+      slug:
+        description: 'Recipe slug under src/layer2_docker/ (e.g. bash-local-shadows-exit).'
+        type: string
+        required: true
+      branch_image:
+        description: 'Docker image ref to verify (e.g. ghcr.io/contributor/foo-fix:branch-x). Must be pullable by the runner without authentication, or pull credentials must be added by the maintainer in a follow-up.'
+        type: string
+        required: true
+      expected_verdict:
+        description: 'Verdict the contributor expects to see on the branch-fix image. "fail" (bug does NOT reproduce) is the typical "fix works" answer.'
+        type: choice
+        required: false
+        default: 'fail'
+        options:
+          - fail
+          - pass
+      original_image:
+        description: 'Optional override for the deployed-original image. Default behaviour fetches the deployed verdict.json from GitHub Pages instead of re-running an image, which is cheaper and matches the live snapshot.'
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  # Keep concurrent runs of the same slug+image bounded; an in-flight
+  # run on the same inputs is wasteful, but parallel runs on
+  # different inputs are fine.
+  group: branch-fix-verdict-${{ inputs.slug }}-${{ inputs.branch_image }}
+  cancel-in-progress: true
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PAGES_BASE: https://aletheia-works.github.io/vivarium/repro
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        # Provides `bun add --global ajv-cli` for schema validation
+        # inside the capture helper.
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install ajv-cli for verdict schema validation
+        # Same single-source clause-4 contract validator the
+        # regression workflow uses; mirrored here so the capture
+        # helper's `ajv validate` step finds it on PATH.
+        run: bun add --global ajv-cli@5 ajv-formats
+
+      - name: Confirm recipe slug exists in tree
+        # Slug is the directory name under src/layer2_docker/. Failing
+        # fast with a clear message beats a confusing docker-pull
+        # error on a typoed slug.
+        run: |
+          set -euo pipefail
+          slug="${{ inputs.slug }}"
+          if [ -z "$slug" ]; then
+            echo "::error::slug input is empty"
+            exit 1
+          fi
+          if [ ! -d "src/layer2_docker/${slug}" ]; then
+            echo "::error::No recipe at src/layer2_docker/${slug}/. Layer 2 catalogue:"
+            ls -1 src/layer2_docker/ | grep -v '^_' || true
+            exit 1
+          fi
+          echo "Recipe directory confirmed: src/layer2_docker/${slug}/"
+
+      - name: Pull branch-fix image
+        # Surfaces auth / typo failures cleanly before the capture
+        # step. `docker run` would also pull, but its error message
+        # mixes pull-failure and run-failure modes, which is harder
+        # to read in CI logs.
+        run: |
+          set -euo pipefail
+          docker pull "${{ inputs.branch_image }}"
+
+      - name: Capture branch-fix verdict
+        # Uses the shared helper — same code path as
+        # repro-regression.yml's Layer 2 capture step. Invoked via
+        # `bash` so we do not depend on the script's executable bit
+        # surviving Windows-side commits (Sapling on Windows does
+        # not preserve mode 0755). Output goes to a workflow-local
+        # path so the artefact upload below carries it without
+        # disturbing tracked files.
+        run: |
+          set -euo pipefail
+          mkdir -p verdict-bundle
+          bash scripts/capture_layer2_verdict.sh \
+            "${{ inputs.branch_image }}" \
+            "verdict-bundle/branch-fix-verdict.json" \
+            --image-tag "${{ inputs.branch_image }}"
+
+      - name: Fetch deployed original verdict
+        # Default path: pull the live `verdict.json` from GitHub
+        # Pages so what we compare against is exactly what the
+        # gallery is currently serving. If `original_image` is
+        # provided, re-capture instead — useful when the contributor
+        # wants the comparison anchored at a specific image rather
+        # than at the deployed snapshot.
+        run: |
+          set -euo pipefail
+          slug="${{ inputs.slug }}"
+          original_image="${{ inputs.original_image }}"
+          out="verdict-bundle/original-verdict.json"
+
+          if [ -n "$original_image" ]; then
+            echo "Re-capturing original verdict from supplied image: ${original_image}"
+            docker pull "$original_image"
+            bash scripts/capture_layer2_verdict.sh \
+              "$original_image" \
+              "$out" \
+              --image-tag "$original_image"
+          else
+            url="${PAGES_BASE}/${slug}/verdict.json"
+            echo "Fetching deployed original verdict: ${url}"
+            http_status=$(curl -sS \
+              --connect-timeout 5 \
+              --max-time 30 \
+              --retry 2 \
+              --retry-delay 2 \
+              -o "$out" \
+              -w '%{http_code}' \
+              "$url" || echo "000")
+            case "$http_status" in
+              200)
+                echo "Deployed original verdict fetched."
+                ajv validate \
+                  --spec=draft2020 \
+                  -c ajv-formats \
+                  -s "docs/public/spec/verdict.schema.json" \
+                  -d "$out"
+                ;;
+              404)
+                echo "::warning::No deployed verdict at ${url}. Original-side of the bundle will be omitted."
+                rm -f "$out"
+                ;;
+              *)
+                echo "::warning::Deployed verdict fetch returned HTTP ${http_status}; original-side of the bundle will be omitted."
+                rm -f "$out"
+                ;;
+            esac
+          fi
+
+      - name: Write comparison summary
+        # GitHub Actions renders `$GITHUB_STEP_SUMMARY` as Markdown
+        # on the run page. Used as a lightweight stand-in for the
+        # R.3 comparison UI until that ships.
+        run: |
+          set -euo pipefail
+          slug="${{ inputs.slug }}"
+          expected="${{ inputs.expected_verdict }}"
+          branch_verdict=$(jq -r '.verdict' verdict-bundle/branch-fix-verdict.json)
+          branch_exit=$(jq -r '.exit_code' verdict-bundle/branch-fix-verdict.json)
+
+          if [ -f verdict-bundle/original-verdict.json ]; then
+            original_verdict=$(jq -r '.verdict' verdict-bundle/original-verdict.json)
+            original_exit=$(jq -r '.exit_code // "n/a"' verdict-bundle/original-verdict.json)
+          else
+            original_verdict="(unavailable)"
+            original_exit="n/a"
+          fi
+
+          if [ "$branch_verdict" = "$expected" ]; then
+            status="✅ matches expected"
+          else
+            status="⚠️ does NOT match expected"
+          fi
+
+          {
+            echo "# Branch-fix verdict — \`${slug}\`"
+            echo
+            echo "| | original | branch-fix |"
+            echo "|---|---|---|"
+            echo "| verdict | \`${original_verdict}\` | \`${branch_verdict}\` |"
+            echo "| exit code | ${original_exit} | ${branch_exit} |"
+            echo
+            echo "**Expected** branch-fix verdict: \`${expected}\` — ${status}."
+            echo
+            echo "Bundle artefact: \`branch-fix-verdict-${slug}-${{ github.run_id }}\`."
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload verdict bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: branch-fix-verdict-${{ inputs.slug }}-${{ github.run_id }}
+          path: verdict-bundle/
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Assert expected verdict
+        # Final step rather than first so the artefact upload above
+        # has already preserved the bundle for inspection even when
+        # the assertion fails.
+        run: |
+          set -euo pipefail
+          expected="${{ inputs.expected_verdict }}"
+          actual=$(jq -r '.verdict' verdict-bundle/branch-fix-verdict.json)
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Branch-fix verdict was '${actual}', expected '${expected}'. Bundle uploaded as artefact for inspection."
+            exit 1
+          fi
+          echo "Branch-fix verdict matches expected (${expected})."

--- a/.github/workflows/repro-regression.yml
+++ b/.github/workflows/repro-regression.yml
@@ -228,6 +228,11 @@ jobs:
         # capture rather than fall through to "verdict snapshot
         # unavailable: HTTP 404" and report `fail`.
         #
+        # The capture itself is delegated to
+        # `scripts/capture_layer2_verdict.sh`, which is also the
+        # single source for the Phase 6 R.2 branch-fix verdict
+        # workflow at `.github/workflows/branch-fix-verdict.yml`.
+        #
         # Skipped silently when there are no Layer 2 reproductions.
         working-directory: ${{ github.workspace }}
         run: |
@@ -240,49 +245,12 @@ jobs:
             echo "Building Layer 2 image for regression: ${slug}"
             docker build --tag "$tag" "$slug_dir"
 
-            stdout_file="$(mktemp)"
-            stderr_file="$(mktemp)"
-            set +e
-            docker run --rm "$tag" >"$stdout_file" 2>"$stderr_file"
-            exit_code=$?
-            set -e
+            bash scripts/capture_layer2_verdict.sh \
+              "$tag" \
+              "${slug_dir}/verdict.json"
 
-            if [ "$exit_code" -eq 0 ]; then
-              verdict="pass"
-            else
-              verdict="fail"
-            fi
-
-            captured_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-            jq -n \
-              --arg verdict "$verdict" \
-              --arg image_tag "$tag" \
-              --arg image_digest "" \
-              --arg captured_at "$captured_at" \
-              --arg stdout "$(cat "$stdout_file")" \
-              --arg stderr_tail "$(tail -c 4096 "$stderr_file")" \
-              --argjson exit_code "$exit_code" \
-              '{
-                contract: "v1",
-                verdict: $verdict,
-                exit_code: $exit_code,
-                image_tag: $image_tag,
-                image_digest: $image_digest,
-                captured_at: $captured_at,
-                stdout: $stdout,
-                stderr_tail: $stderr_tail
-              }' >"${slug_dir}/verdict.json"
-
-            # Validate the freshly-written verdict.json against the
-            # contract v1 schema before the Playwright suite reads it.
-            # Single-sourced with deploy-docs.yml and Layer 3 below.
-            ajv validate \
-              --spec=draft2020 \
-              -c ajv-formats \
-              -s "${GITHUB_WORKSPACE}/docs/public/spec/verdict.schema.json" \
-              -d "${slug_dir}/verdict.json"
-
-            rm -f "$stdout_file" "$stderr_file"
+            verdict=$(jq -r '.verdict' "${slug_dir}/verdict.json")
+            exit_code=$(jq -r '.exit_code' "${slug_dir}/verdict.json")
 
             # Pass-expected for now. A future `fail`-expected sentinel
             # page would need the Playwright spec to flag it, which we

--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -266,6 +266,13 @@ closing the source; vendor lock-in of any kind.
 - Contract v1 **revision 2** — evidence surface (logs / exit code /
   duration on the in-page DOM and envelope). Non-breaking; v1 consumers
   feature-detect the new field.
+- **Branch-fix verdict pipeline** — `workflow_dispatch` workflow at
+  [`.github/workflows/branch-fix-verdict.yml`](https://github.com/aletheia-works/vivarium/blob/main/.github/workflows/branch-fix-verdict.yml)
+  captures a Contract v1 verdict for a contributor-supplied
+  branch-fix Docker image and bundles it alongside the deployed
+  original for side-by-side comparison. The R.3 comparison-page UI
+  consumes this artefact directly. Spec page:
+  [Branch-fix verdict pipeline](./spec/branch-fix-pipeline.md).
 - **Recipes index v1** — `https://aletheia-works.github.io/vivarium/api/recipes.json`
   is now a live, machine-readable catalogue endpoint with its own
   [JSON Schema](https://aletheia-works.github.io/vivarium/api/recipes.schema.json)

--- a/docs/docs/spec/branch-fix-pipeline.md
+++ b/docs/docs/spec/branch-fix-pipeline.md
@@ -1,0 +1,136 @@
+# Branch-fix verdict pipeline
+
+> A `workflow_dispatch` GitHub Actions workflow that captures a
+> [Contract v1](./contract-v1.md) verdict for a contributor-supplied
+> branch-fix Docker image, alongside the deployed original verdict,
+> for side-by-side comparison.
+
+The workflow lives at
+[`.github/workflows/branch-fix-verdict.yml`](https://github.com/aletheia-works/vivarium/blob/main/.github/workflows/branch-fix-verdict.yml).
+It is the **build & verify** half of Phase 6 sub-stream R
+(reproduction comparison). The comparison-page UI half (R.3) is a
+separate deliverable that consumes the artefact this pipeline
+produces.
+
+## Why this exists
+
+Vivarium recipes pin one specific runtime (image, package version,
+toolchain) so the gallery's verdict snapshot is stable. When a
+contributor — human or AI agent — produces a candidate fix for the
+upstream bug, they need a way to ask **"does my fix actually stop
+the recipe from reproducing?"** before opening a PR.
+
+The mechanical answer is: re-run the recipe against an image that
+contains the fix, capture a fresh `verdict.json`, and compare it to
+the original. If the original verdict was `"pass"` (bug reproduces)
+and the branch-fix verdict is `"fail"` (bug does not reproduce), the
+fix is doing its job.
+
+This pipeline runs that comparison in CI. The contributor builds and
+publishes the branch-fix image themselves; this workflow is purely a
+verification surface.
+
+## Five-line invocation
+
+```bash
+gh workflow run branch-fix-verdict.yml \
+  --repo aletheia-works/vivarium \
+  -f slug=bash-local-shadows-exit \
+  -f branch_image=ghcr.io/contributor/bash-fix:branch-x \
+  -f expected_verdict=fail
+```
+
+The run page renders a Markdown comparison summary, and the captured
+verdicts are uploaded as a workflow artefact named
+`branch-fix-verdict-<slug>-<run_id>` for download or programmatic
+fetch.
+
+## Inputs
+
+| Input | Type | Required | Default | Purpose |
+|---|---|---|---|---|
+| `slug` | string | ✅ | — | Recipe slug under [`src/layer2_docker/`](https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker), e.g. `bash-local-shadows-exit`. The slug must exist in tree on the workflow's checkout; the workflow fails fast on a typo. |
+| `branch_image` | string | ✅ | — | Docker image ref to verify (e.g. `ghcr.io/contributor/foo-fix:branch-x`). Must be pullable by the runner without authentication. Private-registry support is a follow-up. |
+| `expected_verdict` | choice (`pass`\|`fail`) | — | `fail` | Verdict the contributor expects on the branch-fix image. `fail` (bug does NOT reproduce) is the typical "fix works" answer. The workflow's final step asserts the captured verdict matches this and exits non-zero on divergence. |
+| `original_image` | string | — | (empty) | Optional override. By default the workflow fetches the deployed original verdict from GitHub Pages — cheaper than re-running an image and identical to what the gallery serves. Supplying an `original_image` re-captures from that image instead, useful for anchoring the comparison at a specific tag or testing a private fork. |
+
+## Verdict semantics (reminder)
+
+`pass` means **the upstream bug reproduces** in this run. `fail`
+means it **does not**. This is the inverse of typical "green CI =
+good" framing; see
+[Contract v1: Verdict semantics](./contract-v1.md#verdict-semantics)
+for the full reasoning.
+
+For a recipe whose original verdict is `pass`, a successful
+branch-fix is therefore expected to flip the verdict to `fail`. For
+a recipe whose original verdict is already `fail` (a sentinel page
+tracking an upstream-fix-detected event), a contributor is unlikely
+to need this workflow at all.
+
+## Artefact
+
+The workflow uploads a directory artefact named
+`branch-fix-verdict-<slug>-<run_id>` with 30-day retention. The
+bundle contains:
+
+| File | Source | Notes |
+|---|---|---|
+| `branch-fix-verdict.json` | Captured live from `branch_image`. | Always present. Conforms to [Contract v1](./contract-v1.md) and validates against [`verdict.schema.json`](https://aletheia-works.github.io/vivarium/spec/verdict.schema.json). |
+| `original-verdict.json` | Default: fetched from `https://aletheia-works.github.io/vivarium/repro/<slug>/verdict.json`. With `original_image`: captured from that image. | Omitted when the deployed Pages snapshot returns 404 (e.g. brand-new recipe not yet on the live site). |
+
+The R.3 comparison-page UI consumes this exact bundle structure;
+naming the files this way commits R.2 to a wire format R.3 can
+program against without further coordination.
+
+## Comparison summary
+
+The workflow writes a Markdown table to `$GITHUB_STEP_SUMMARY`,
+visible on the run page:
+
+| | original | branch-fix |
+|---|---|---|
+| verdict | (e.g.) `pass` | (e.g.) `fail` |
+| exit code | (e.g.) 0 | (e.g.) 1 |
+
+…followed by a one-line "matches expected" / "does NOT match
+expected" line for the `expected_verdict` assertion. The summary is
+intentionally a stand-in for the R.3 UI until that ships; the
+artefact is the source of truth either way.
+
+## What this pipeline does **not** do
+
+- **Build the branch-fix image.** The contributor is expected to
+  build and publish to a registry the runner can pull from. Bundling
+  source-build steps would couple the pipeline to an unbounded set
+  of upstream toolchains; keeping the image as the input boundary
+  matches Phase 3's catalogue model.
+- **Verify Layer 1 (WASM) reproductions.** Layer 1 verdicts are
+  produced live in-page by a browser; there is no Docker image to
+  swap. The Layer 1 equivalent is editing the page sources locally
+  and re-running the existing Playwright suite.
+- **Verify Layer 3 (rr replay) reproductions on hosted runners.** As
+  with the [Consumer workflow](./consumer-workflow.md), GitHub-hosted
+  Ubuntu runners cannot drive `rr replay` per
+  [ADR-0011](https://github.com/aletheia-works/vivarium/blob/main/_context/decisions/0011-phase4-first-vertical-rr.md)
+  (private memo). Layer 3 branch-fix verification needs a self-hosted
+  runner exposing CPUID faulting.
+- **Authenticate to private registries.** v1 assumes the supplied
+  image ref is anonymously pullable. Adding pull-secret plumbing is
+  a deliberate follow-up gated on real demand.
+
+## See also
+
+- [Contract v1](./contract-v1.md) — the verdict surface this
+  pipeline emits and consumes.
+- [`verdict.schema.json`](https://aletheia-works.github.io/vivarium/spec/verdict.schema.json) —
+  the schema both bundle entries validate against.
+- [Consumer workflow](./consumer-workflow.md) — the sibling
+  reusable workflow for verifying a Vivarium recipe in a consumer
+  repo's CI; the branch-fix pipeline reuses the same Layer 2
+  capture helper internally.
+- [Layer 2 catalogue](https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker)
+  — the slugs available for `inputs.slug`.
+
+Phase 6 sub-stream R.2 per the
+[roadmap](../roadmap.md#phase-6--usability-and-visual-layer).

--- a/docs/docs/spec/index.md
+++ b/docs/docs/spec/index.md
@@ -44,6 +44,11 @@ backward-compatible consumers.
   GitHub Actions workflow any repo can `uses:` to verify a
   Vivarium-hosted reproduction in their own CI. Phase 5
   sub-stream D.
+- [Branch-fix verdict pipeline](./branch-fix-pipeline.md) — a
+  `workflow_dispatch` workflow that captures a verdict for a
+  contributor-supplied branch-fix Docker image and bundles it
+  alongside the deployed original for side-by-side comparison.
+  Phase 6 sub-stream R.2.
 
 ## What this spec is for
 

--- a/scripts/capture_layer2_verdict.sh
+++ b/scripts/capture_layer2_verdict.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Vivarium Layer 2 verdict capture — single-source helper.
+#
+# Runs the given Docker image, captures stdout / stderr / exit code,
+# and writes a Vivarium Contract v1 `verdict.json` to the requested
+# output path. The same logic is used by:
+#
+#   - .github/workflows/repro-regression.yml — captures the in-tree
+#     recipe's verdict on every push / PR / weekly cron.
+#   - .github/workflows/branch-fix-verdict.yml — Phase 6 R.2 build &
+#     verify pipeline; captures a contributor-supplied branch-fix
+#     image's verdict for side-by-side comparison against the
+#     deployed original.
+#
+# Contract v1 reference:
+#   docs/docs/spec/contract-v1.md
+#   docs/public/spec/verdict.schema.json
+#
+# Usage:
+#   capture_layer2_verdict.sh <image_ref> <output_path>
+#       [--image-tag <tag>] [--image-digest <digest>]
+#
+# Required arguments:
+#   <image_ref>     The image to `docker run` (e.g. "vivarium-foo:test"
+#                   or "ghcr.io/contributor/foo-fix:branch").
+#   <output_path>   Where to write the verdict.json file.
+#
+# Optional flags:
+#   --image-tag     Value for verdict.json#image_tag. Defaults to
+#                   <image_ref>.
+#   --image-digest  Value for verdict.json#image_digest. Defaults to
+#                   the empty string (Contract v1 allows "" when
+#                   neither RepoDigest nor local ID is meaningful).
+#
+# Exit code:
+#   0  — verdict.json written and schema-validated successfully.
+#        The captured verdict itself ("pass" or "fail") is recorded
+#        inside the file; this script does not assert which it should
+#        be — that is the caller's responsibility.
+#   non-zero — could not run the image, could not write the file, or
+#        the produced JSON failed schema validation.
+#
+# Verdict semantics (catalogue model from ADR-0010, private memo):
+#   container exit 0 → verdict "pass" (bug reproduces)
+#   container exit ≠ 0 → verdict "fail" (bug did not reproduce)
+#
+# Schema validation requires `ajv` (ajv-cli) on PATH and
+# `docs/public/spec/verdict.schema.json` reachable via $REPO_ROOT
+# (default: the repository this script lives in).
+
+set -euo pipefail
+
+usage() {
+  sed -n '2,40p' "$0"
+}
+
+if [ "$#" -lt 2 ]; then
+  usage >&2
+  exit 64
+fi
+
+image_ref="$1"
+output_path="$2"
+shift 2
+
+image_tag="$image_ref"
+image_digest=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --image-tag)
+      image_tag="${2:?--image-tag requires a value}"
+      shift 2
+      ;;
+    --image-digest)
+      image_digest="${2:?--image-digest requires a value}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "::error::Unknown argument: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+# Locate the repository root. Honour an explicit override
+# ($REPO_ROOT) so callers from arbitrary working directories can
+# reuse the helper, then fall back to the script's own location.
+if [ -z "${REPO_ROOT:-}" ]; then
+  REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+fi
+schema="${REPO_ROOT}/docs/public/spec/verdict.schema.json"
+if [ ! -f "$schema" ]; then
+  echo "::error::Contract v1 schema missing at ${schema}" >&2
+  exit 1
+fi
+
+# `mktemp -d` to keep stdout / stderr capture on the same volume,
+# trapped for cleanup so a mid-run failure does not leak files.
+tmp_dir="$(mktemp -d)"
+stdout_file="${tmp_dir}/stdout"
+stderr_file="${tmp_dir}/stderr"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+set +e
+docker run --rm "$image_ref" >"$stdout_file" 2>"$stderr_file"
+exit_code=$?
+set -e
+
+if [ "$exit_code" -eq 0 ]; then
+  verdict="pass"
+else
+  verdict="fail"
+fi
+
+captured_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+mkdir -p "$(dirname "$output_path")"
+jq -n \
+  --arg verdict "$verdict" \
+  --arg image_tag "$image_tag" \
+  --arg image_digest "$image_digest" \
+  --arg captured_at "$captured_at" \
+  --arg stdout "$(cat "$stdout_file")" \
+  --arg stderr_tail "$(tail -c 4096 "$stderr_file")" \
+  --argjson exit_code "$exit_code" \
+  '{
+    contract: "v1",
+    verdict: $verdict,
+    exit_code: $exit_code,
+    image_tag: $image_tag,
+    image_digest: $image_digest,
+    captured_at: $captured_at,
+    stdout: $stdout,
+    stderr_tail: $stderr_tail
+  }' >"$output_path"
+
+# Schema-validate the freshly-written verdict.json. Single-sources
+# clause 4 of the Contract v1 conformance check; same predicate as
+# the in-line ajv invocation in repro-regression.yml.
+ajv validate \
+  --spec=draft2020 \
+  -c ajv-formats \
+  -s "$schema" \
+  -d "$output_path"
+
+echo "Captured Layer 2 verdict: image=${image_ref} verdict=${verdict} exit=${exit_code} → ${output_path}"


### PR DESCRIPTION

Adds the build & verify half of Phase 6 sub-stream R (reproduction
comparison): a `workflow_dispatch` workflow that captures a Contract
v1 verdict for a contributor-supplied branch-fix Docker image and
bundles it alongside the deployed original verdict for side-by-side
comparison. The R.3 comparison-page UI consumes the artefact this
pipeline produces.

Changes:

- `scripts/capture_layer2_verdict.sh` — single-source helper for
  Layer 2 verdict capture (docker run → verdict.json → ajv schema
  validate). Reused by both the new workflow and the existing
  `repro-regression.yml`, eliminating the duplicated bash block in
  the latter.
- `.github/workflows/branch-fix-verdict.yml` — new workflow.
  Inputs: `slug`, `branch_image`, `expected_verdict` (default
  `fail` — i.e. the bug should NOT reproduce on a working fix),
  optional `original_image` override. Pulls the branch-fix image,
  captures its verdict, fetches the deployed original from GitHub
  Pages (or re-captures from `original_image`), writes a Markdown
  comparison summary to `\$GITHUB_STEP_SUMMARY`, and uploads both
  verdicts as a `branch-fix-verdict-<slug>-<run_id>` artefact. The
  final step asserts the captured verdict matches `expected_verdict`.
- `.github/workflows/repro-regression.yml` — Layer 2 capture step
  now delegates to the shared helper; no behaviour change.
- `docs/docs/spec/branch-fix-pipeline.md` — spec page documenting
  inputs, artefact bundle structure, verdict semantics, and the
  deliberate non-goals (no source build, no Layer 1/3, no private
  registries in v1).
- `docs/docs/spec/index.md` — link the new spec page under "Tooling"
  alongside the consumer workflow.
- `docs/docs/roadmap.md` — add the pipeline to Phase 6's "What has
  shipped so far" list.

The contributor builds and publishes the branch-fix image themselves;
this workflow is a verification surface only. Image build is left
outside the pipeline boundary to keep the pipeline decoupled from
upstream toolchains, matching the Phase 3 catalogue model.
