### PR TITLE
chore(dx): per-task tool pinning in mise + simplify single-tool CI

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -1,0 +1,50 @@
+name: Setup mise
+description: |
+  Install mise (https://mise.jdx.dev) on the runner via the official
+  `jdx/mise-action` and trust this repo's .mise.toml so the rest of
+  the workflow can run `mise run <task>` directly.
+
+  Allowlist note: `jdx/mise-action@*` is allowed by the org-level
+  GitHub Actions policy at
+  `aletheia-works/.github/infra/github-org/variables.tf`
+  (`var.allowed_action_patterns`). The org also enforces commit-SHA
+  pinning (`sha_pinning_required = true`), so the `uses:` line below
+  pins to v4.0.1's commit SHA — bump the SHA and the comment together
+  when upgrading.
+
+inputs:
+  tools:
+    description: |
+      Optional `install_args` filter — space-separated list of tool
+      aliases (e.g. "bun rust") to restrict the install to. Defaults
+      to "" which installs everything declared in .mise.toml. Useful
+      for fast-path workflows that only need a subset of the toolchain
+      (e.g. just `bun` for the docs build).
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install mise + tools
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      with:
+        # `experimental: true` lets mise read the .mise.toml without
+        # prompting for trust (the in-repo config is already
+        # source-controlled, so reviewing it here is the right
+        # security model). It also unlocks any experimental features
+        # the project leans on locally.
+        experimental: true
+        # Cache mise's tool downloads across runs. Cache key is
+        # derived from .mise.toml hash automatically.
+        cache: true
+        # Run `mise install` against .mise.toml. Set
+        # install_args=<tool>+ to filter; empty installs everything.
+        install: true
+        install_args: ${{ inputs.tools }}
+
+    - name: Verify mise is wired up
+      shell: bash
+      run: |
+        mise --version
+        mise current

--- a/.github/workflows/branch-fix-verdict.yml
+++ b/.github/workflows/branch-fix-verdict.yml
@@ -74,8 +74,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Bun
-        # Provides `bun add --global ajv-cli` for schema validation
-        # inside the capture helper.
+        # Single-tool job (bun only) — uses `oven-sh/setup-bun` directly
+        # rather than the local setup-mise composite. The bun-version
+        # tracks the `bun = "latest"` pin in mise.toml in spirit.
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,11 +6,12 @@ name: deploy-docs
 # Prerequisites (one-time setup):
 # - Repo Settings → Pages → Source: "GitHub Actions".
 #
-# Tool versions:
-# - `.mise.toml` declares `bun = "latest"` for local development.
-# - CI uses `oven-sh/setup-bun` directly (an allowlisted action) rather
-#   than `jdx/mise-action`, which is not on the repo's `selected-actions`
-#   patterns. Keep `bun-version` in sync with the intent of `.mise.toml`.
+# Tooling: multi-tool job (bun + rust) — uses the local setup-mise
+# composite action because rust is needed for `wasm32-wasip1` builds
+# alongside bun for the rspress site / Layer 1 TS, and mise reads
+# both pins from `mise.toml` so versions stay in lockstep with local
+# development. Single-tool workflows (test-docs-build, publish-mcp,
+# branch-fix-verdict) use `oven-sh/setup-bun` directly instead.
 #
 # Layout:
 # - `docs/` holds the rspress site (config, lockfile, markdown content).
@@ -66,16 +67,18 @@ jobs:
         with:
           fetch-depth: 0 # for `lastUpdated` timestamps
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - name: Setup mise (bun)
+        # Installs the project-wide tools listed in `[tools]` (bun,
+        # opentofu, uv). Per-task language toolchains (`rust@1.84.0`
+        # for the wasm32-wasip1 build, etc.) auto-install on first
+        # `mise run` via the task's `use = [...]` declaration in
+        # mise.toml — keeping per-recipe version flexibility.
+        uses: ./.github/actions/setup-mise
         with:
-          bun-version: latest
+          tools: bun
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
 
       - name: Install ajv-cli for verdict schema validation
         # Validates each Layer 2 verdict.json against
@@ -83,79 +86,51 @@ jobs:
         # after CI writes it, before the bundling step copies the
         # directory into the Pages artefact. Catches any malformed
         # snapshot at deploy time rather than letting it ship.
-        # `bun add --global` puts `ajv` on PATH for subsequent steps.
-        working-directory: ${{ github.workspace }}
-        run: bun add --global ajv-cli@5 ajv-formats
-
-      - name: Build docs
-        run: bun run build
-
-      - name: Install Layer 1 dependencies
-        # `src/layer1_wasm/` has its own bun lockfile (TypeScript devDep).
-        # Keep this step ordered after `bun install` for the docs site so
-        # the steps' caches are independent.
-        working-directory: ${{ github.workspace }}/src/layer1_wasm
-        run: bun install --frozen-lockfile
-
-      - name: Build Layer 1 TypeScript sources
-        # Emits side-by-side `.js` files for every `.ts` source — these
-        # are what the bundling step below copies into the Pages artefact.
-        working-directory: ${{ github.workspace }}/src/layer1_wasm
-        run: bun run build
-
-      - name: Install Rust toolchain (for compiled-language reproductions)
-        # Vivarium pins Rust in `.mise.toml`; CI installs the same
-        # version via rustup directly because `jdx/mise-action` is not
-        # on the repo's allowlist. Adds the `wasm32-wasip1` target so
-        # each `<slug>/Cargo.toml` can compile to a browser-loadable
-        # artefact (the page boots it via `@bjorn3/browser_wasi_shim`).
-        # Skipped silently if no Rust crate is present.
         #
-        # Override the job-level `working-directory: docs` so the glob
-        # below resolves against the repo root — without this the
-        # `crates=(...)` array stays empty, the step exits early, and
-        # the next step then fails with `can't find crate for 'core'`
-        # because rustup never ran.
-        working-directory: ${{ github.workspace }}
+        # Installed into a workflow-local `$RUNNER_TEMP` node_modules so
+        # ajv-cli + ajv-formats co-resolve without depending on bun's
+        # global bin being on PATH (`oven-sh/setup-bun` adds it,
+        # `setup-mise`'s bun does not), and without leaking ajv into
+        # any tracked package.json.
         run: |
-          set -euo pipefail
-          shopt -s nullglob
-          crates=(src/layer1_wasm/*/Cargo.toml)
-          if [ ${#crates[@]} -eq 0 ]; then
-            echo "No src/layer1_wasm/*/Cargo.toml; skipping Rust setup."
-            exit 0
-          fi
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
-            sh -s -- -y --profile minimal --default-toolchain 1.84.0
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          "$HOME/.cargo/bin/rustup" target add wasm32-wasip1
+          cd "$RUNNER_TEMP"
+          bun init -y >/dev/null
+          bun add ajv-cli@5 ajv-formats
+          # Both forms — `$AJV_BIN` for explicit yaml callers, and the
+          # bin dir on `$GITHUB_PATH` so shell scripts (e.g.
+          # `scripts/capture_layer2_verdict.sh`) can call `ajv` directly
+          # without knowing about this install location.
+          echo "AJV_BIN=$RUNNER_TEMP/node_modules/.bin/ajv" >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/node_modules/.bin" >> "$GITHUB_PATH"
 
-      - name: Build Layer 1 Rust artefacts (wasm32-wasip1)
-        # Compiles every `src/layer1_wasm/<slug>/Cargo.toml` for
-        # `wasm32-wasip1` and copies the resulting `.wasm` next to
-        # the page's `index.html` (`<slug>/repro.wasm`), where the
-        # subsequent bundling step copies it into the Pages artefact
-        # alongside the rest of the directory. The bin name is fixed
-        # at `repro` by convention so this step needs no per-crate
-        # hand-wiring.
+      - name: Build docs (mise run docs:build)
+        # Same command a contributor runs locally — wraps
+        # `bun install --frozen-lockfile` + `bun run build` for the
+        # rspress site under docs/. See [tasks."docs:build"] in
+        # mise.toml.
+        working-directory: ${{ github.workspace }}
+        run: mise run docs:build
+
+      - name: Build Layer 1 reproductions (mise run repro:build)
+        # Wraps `bun install --frozen-lockfile`, `bun run build`
+        # (TypeScript -> .js next to each repro), and `cargo build`
+        # for every `src/layer1_wasm/*/Cargo.toml` (with
+        # `rustup target add wasm32-wasip1` ensured). See
+        # [tasks."repro:build"] in mise.toml.
+        working-directory: ${{ github.workspace }}
+        run: mise run repro:build
+
+      - name: Drop Rust build artefacts before bundling
+        # `target/` is hundreds of MB and would bloat the Pages
+        # artefact. The mise task copies repro.wasm into place; the
+        # build cache itself is not needed once the artefact is in
+        # the recipe directory.
         working-directory: ${{ github.workspace }}
         run: |
           set -euo pipefail
           shopt -s nullglob
-          for cargo_toml in src/layer1_wasm/*/Cargo.toml; do
-            slug_dir="$(dirname "$cargo_toml")"
-            slug="$(basename "$slug_dir")"
-            echo "Building Rust crate: ${slug}"
-            (
-              cd "$slug_dir"
-              cargo build --release --target wasm32-wasip1
-            )
-            cp "${slug_dir}/target/wasm32-wasip1/release/repro.wasm" \
-              "${slug_dir}/repro.wasm"
-            # Drop the build artefacts before the bundling step copies
-            # the directory — `target/` is hundreds of MB and would
-            # bloat the Pages artefact otherwise.
-            rm -rf "${slug_dir}/target"
+          for target in src/layer1_wasm/*/target; do
+            rm -rf "$target"
           done
 
       - name: Log in to GHCR (for Layer 2 image push)
@@ -246,7 +221,7 @@ jobs:
             # Validate the freshly-written verdict.json against the
             # contract v1 schema before the bundling step picks it up.
             # Single-sourced with repro-regression.yml.
-            ajv validate \
+            "$AJV_BIN" validate \
               --spec=draft2020 \
               -c ajv-formats \
               -s "${GITHUB_WORKSPACE}/docs/public/spec/verdict.schema.json" \

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -59,18 +59,21 @@ jobs:
         run: cp ../../docs/public/api/recipes.json src/bundled/recipes.json
 
       - name: Setup Bun
+        # Single-tool job (bun only) — uses `oven-sh/setup-bun` directly
+        # rather than the local setup-mise composite.
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
-      - name: Install dependencies
-        run: bun install
-
-      - name: Build
-        run: bun run build
-
-      - name: Test
-        run: bun test
+      - name: Install + build + test
+        # Same commands a contributor runs locally via the mcp:* tasks
+        # in mise.toml. The publish steps below stay inline because they
+        # call `bunx npm publish --provenance` and `bunx jsr publish`
+        # against OIDC, which is a CI-only concern.
+        run: |
+          bun install
+          bun run build
+          bun run test
 
       - name: Publish to npm (provenance via OIDC trusted publishing, npm CLI run through bunx)
         run: bunx npm publish --provenance --access public

--- a/.github/workflows/repro-regression.yml
+++ b/.github/workflows/repro-regression.yml
@@ -93,13 +93,15 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - name: Setup mise (bun)
+        # Installs the project-wide tools listed in `[tools]` (bun,
+        # opentofu, uv). Layer 1 Rust crates compiled to wasm32-wasip1
+        # are handled by the `repro:build:rust` task's `use = [...]`
+        # — mise auto-installs the pinned rust toolchain on first run
+        # so each recipe can choose its own version.
+        uses: ./.github/actions/setup-mise
         with:
-          bun-version: latest
-
-      - name: Install Layer 1 dependencies
-        run: bun install --frozen-lockfile
+          tools: bun
 
       - name: Install ajv-cli for verdict schema validation
         # Single-source clause 4 of the contract v1 conformance check
@@ -107,15 +109,29 @@ jobs:
         # generated / tracked `verdict.json` with ajv-cli below, instead
         # of the historical `jq -e` predicate. Both Layer 2 (CI-built,
         # CI-snapshot) and Layer 3 (maintainer-tracked) verdict files
-        # share the same schema. `bun add --global` puts `ajv` on
-        # PATH for subsequent steps via setup-bun's PATH wiring.
+        # share the same schema.
+        #
+        # Installed into a workflow-local `$RUNNER_TEMP` node_modules so
+        # the CLI's `-c ajv-formats` plugin loader resolves both as
+        # siblings under the same tree — without depending on bun's
+        # global bin being on PATH (`oven-sh/setup-bun` adds it,
+        # `setup-mise`'s bun does not), and without leaking ajv into
+        # the repo's tracked package.jsons.
         #
         # The same ajv install is also reused below for the Phase 5
         # sub-stream C manifest schema validation (manifest.schema.json
         # against `src/external_examples/*/.vivarium/manifest.toml` after
         # a TOML→JSON conversion via Python's stdlib `tomllib`).
-        working-directory: ${{ github.workspace }}
-        run: bun add --global ajv-cli@5 ajv-formats
+        run: |
+          cd "$RUNNER_TEMP"
+          bun init -y >/dev/null
+          bun add ajv-cli@5 ajv-formats
+          # Both forms — `$AJV_BIN` for explicit yaml callers, and the
+          # bin dir on `$GITHUB_PATH` so shell scripts (e.g.
+          # `scripts/capture_layer2_verdict.sh`) can call `ajv` directly
+          # without knowing about this install location.
+          echo "AJV_BIN=$RUNNER_TEMP/node_modules/.bin/ajv" >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Validate external manifest examples (manifest v1)
         # Phase 5 sub-stream C (ADR-0015, private memo). Each
@@ -149,7 +165,7 @@ jobs:
             example="$(basename "$(dirname "$(dirname "$manifest")")")"
             echo "Validating ${example}: ${manifest}"
             python3 -c "import json, sys, tomllib; sys.stdout.write(json.dumps(tomllib.load(open(sys.argv[1], 'rb'))))" "$manifest" > "$tmp_json"
-            if ! ajv validate \
+            if ! "$AJV_BIN" validate \
               --spec=draft2020 \
               -c ajv-formats \
               -s "$schema" \
@@ -164,60 +180,19 @@ jobs:
           fi
           echo "All ${#manifests[@]} external manifest example(s) validated against manifest v1 schema."
 
-      - name: Type-check (sources + tests)
-        # Catches any TypeScript-level regression before we boot a
-        # browser. Cheap (~1 s) and produces a clear diagnostic on
-        # failure.
-        run: bun run typecheck
-
-      - name: Build Layer 1 TypeScript sources
-        # Emits side-by-side `.js` files; the static server serves
-        # them at runtime.
-        run: bun run build
-
-      - name: Install Rust toolchain (for compiled-language reproductions)
-        # Mirrors the equivalent step in `deploy-docs.yml`: installs
-        # rustup directly because `jdx/mise-action` is not on the
-        # repo's selected-actions allowlist, and adds the
-        # `wasm32-wasip1` target so each `<slug>/Cargo.toml` can
-        # compile to the artefact the page fetches at runtime.
-        # Skipped silently if no Rust crate is present so the
-        # regression suite stays cheap when Phase 2 has no Rust
-        # entries yet.
+      - name: Type-check + build Layer 1 (TS + Rust wasm)
+        # Single mise call wraps:
+        #   - `bun install --frozen-lockfile` in src/layer1_wasm
+        #   - `bun run typecheck`
+        #   - `bun run build` (TypeScript -> .js next to each repro)
+        #   - `rustup target add wasm32-wasip1` + `cargo build` for
+        #     every Cargo.toml found, copying repro.wasm into place.
+        # See [tasks."repro:typecheck"], [tasks."repro:build"] in
+        # mise.toml — the same commands a contributor runs locally.
         working-directory: ${{ github.workspace }}
         run: |
-          set -euo pipefail
-          shopt -s nullglob
-          crates=(src/layer1_wasm/*/Cargo.toml)
-          if [ ${#crates[@]} -eq 0 ]; then
-            echo "No src/layer1_wasm/*/Cargo.toml; skipping Rust setup."
-            exit 0
-          fi
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
-            sh -s -- -y --profile minimal --default-toolchain 1.84.0
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          "$HOME/.cargo/bin/rustup" target add wasm32-wasip1
-
-      - name: Build Layer 1 Rust artefacts (wasm32-wasip1)
-        # Mirrors `deploy-docs.yml`. Compiles every Cargo.toml to
-        # `wasm32-wasip1` and copies the resulting `.wasm` next to
-        # the page's `index.html` (`<slug>/repro.wasm`), where the
-        # Playwright webServer serves it.
-        working-directory: ${{ github.workspace }}
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          for cargo_toml in src/layer1_wasm/*/Cargo.toml; do
-            slug_dir="$(dirname "$cargo_toml")"
-            slug="$(basename "$slug_dir")"
-            echo "Building Rust crate: ${slug}"
-            (
-              cd "$slug_dir"
-              cargo build --release --target wasm32-wasip1
-            )
-            cp "${slug_dir}/target/wasm32-wasip1/release/repro.wasm" \
-              "${slug_dir}/repro.wasm"
-          done
+          mise run repro:typecheck
+          mise run repro:build
 
       - name: Build, run, and snapshot Layer 2 Docker reproductions (no push)
         # Mirrors the deploy-docs Layer 2 build/run/verdict step but
@@ -374,7 +349,7 @@ jobs:
             # Schema-validate the tracked verdict.json against the
             # contract v1 schema. Replaces the historical `jq -e`
             # predicate; ajv reports the offending field on failure.
-            ajv validate \
+            "$AJV_BIN" validate \
               --spec=draft2020 \
               -c ajv-formats \
               -s "${GITHUB_WORKSPACE}/docs/public/spec/verdict.schema.json" \

--- a/.github/workflows/test-docs-build.yml
+++ b/.github/workflows/test-docs-build.yml
@@ -5,19 +5,19 @@ name: Test docs build
 # ever reaching main, where `deploy-docs.yml` would otherwise fail the
 # Pages deployment.
 #
-# This workflow does NOT deploy — it only runs `bun run build` and
+# This workflow does NOT deploy — it only runs the docs build and
 # discards the output. Actual deployment happens from `deploy-docs.yml`
 # on pushes to main.
 #
-# Tool versions: CI uses `oven-sh/setup-bun` (allowlisted) with
-# `bun-version: latest`, matching the intent of `.mise.toml` locally.
+# Tooling: single-tool job (bun only). Uses `oven-sh/setup-bun`
+# directly rather than the local setup-mise composite — there is
+# nothing here that needs the rest of mise.toml.
 
 on:
   pull_request:
     branches: [main]
     paths:
       - 'docs/**'
-      - '.mise.toml'
       - '.github/workflows/test-docs-build.yml'
 
 permissions:
@@ -46,8 +46,7 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build docs
-        run: bun run build
+      - name: Install + build docs
+        run: |
+          bun install --frozen-lockfile
+          bun run build

--- a/infra/github/.terraform.lock.hcl
+++ b/infra/github/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.12.1"
+  constraints = "~> 6.12"
+  hashes = [
+    "h1:HXXTIvXPBVJ4mBs01fcJk7wG8N3jGvR/4HqjnRGp4Wo=",
+    "zh:3e1a4081ecb9518fdf0074db83c16ad00dc81ffe8249a6e3cf1894e947e28df6",
+    "zh:4cb8224b7f530795b674ac044675f6b22a7c9154f55eb9f76c5af6c7534056a4",
+    "zh:560bc08637926191f6871a89e986022ca67c70afda5bebca34b5216e6fac69c9",
+    "zh:5a70b5d2ac650c5c9819a1875411ebda229d0fcc6c9f57f9d751852ca3cd77ac",
+    "zh:8668d93bd4dc2ffa2545e1473af600a925d479b16033a71a4498a16f3b683c0c",
+    "zh:86eacc6059fd057948e178b665ba5cce74bd5488a9e1035734e60ff5ef1b6f8f",
+    "zh:a329fac98881d8dfc211a9bdc0ec6f2948f0b0c2704d1b6cbe5307403c7ad1b2",
+    "zh:dadd44abab3c52b9d572955afaef1658790e17ea355ee22b58996d81d28e02d8",
+    "zh:de9f455ef342cc38fb76bce844bfcd376fb81a4b9f9bc2fae023ff99efdf1338",
+    "zh:f8c6d2e8351b334491790358574e0a30a7c6d7f5b80f7daf32a7c0f3e9b1ab19",
+    "zh:fab41971a3edee04ab6eceaeab4eeb9a2b2f38a2af3b06eda93e2117b64994be",
+    "zh:fb1279b566dd9c8c117b2e4e0cc8344413b8fc8f2a3e24be22a9b2610551777b",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+    "zh:fe79d2a861fb9af420fa5bd7f02c031b2a0a3edf5dbc46022c8ecc7a33cf2b6d",
+  ]
+}

--- a/mise.toml
+++ b/mise.toml
@@ -1,20 +1,269 @@
 [tools]
 bun = "latest"
 opentofu = "latest"
-python = "3.13"
 uv = "latest"
-# Native runtimes pinned to the same major.minor.patch the WASM gallery
-# pages run, so contributors can re-verify each Layer 1 reproduction
-# against a real interpreter (`mise exec ruby -- ruby <slug>/repro.rb`,
-# `mise exec php -- php <slug>/repro.php`). See
-# `src/layer1_wasm/<slug>/README.md` for per-page native repro
-# instructions. Building these on Windows requires WSL or an
-# equivalent Unix-y toolchain; CI installs them on Linux runners.
-php = "8.2.11"
-ruby = "3.3.3"
-# Rust is also used to build `wasm32-wasip1` artefacts for compiled-
-# language reproductions (see `src/layer1_wasm/regex-779/`); the
-# `wasm32-wasip1` target ships with rustup as a precompiled std, so
-# nothing extra is pinned here. CI installs the matching toolchain on
-# its Linux runner before running `cargo build`.
-rust = "1.84.0"
+# Per-language interpreters (Python, Ruby, Rust, PHP) are intentionally
+# NOT pinned at this top level. Each task / command declares the version
+# it needs next to where it is invoked, so different recipes can use
+# different versions without churning this file:
+#   - Python: `mise exec uv -- uv run --python 3.13 …`
+#     (UV is a superset tool — version manager + pip + venv + scripts —
+#     so it owns Python on its own; mise just installs UV.)
+#   - Ruby / Rust / conda:php: per-task `tools = { ruby = "3.3.3" }` etc., or
+#     ad-hoc `mise exec ruby@3.3.3 -- ruby …`. mise auto-downloads the
+#     requested version on first call, the same way UV does for Python.
+# PHP keeps the `conda:` backend prefix because vfox (mise's default PHP
+# backend) has download issues that surfaced during Phase 2.
+
+[settings]
+experimental = true
+
+[deps.bun-docs]
+sources = ["docs/package.json", "docs/bun.lock"]
+run = "bun install"
+dir = "docs"
+
+[deps.bun-mcp]
+sources = ["packages/mcp-server/package.json", "packages/mcp-server/bun.lock"]
+run = "bun install"
+dir = "packages/mcp-server"
+
+[deps.bun-wasm]
+sources = ["src/layer1_wasm/package.json", "src/layer1_wasm/bun.lock"]
+run = "bun install"
+dir = "src/layer1_wasm"
+
+[deps.tofu]
+sources = ["infra/github/versions.tf", "infra/github/providers.tf"]
+outputs = ["infra/github/.terraform.lock.hcl"]
+run = "tofu init"
+dir = "infra/github"
+
+[hooks]
+enter = ["mise upgrade -q", "mise deps -q"]
+
+# ─────────────────────────────────────────────────────────────────────────
+# Tasks — reproducing locally what CI does, and what humans need to ship.
+# Run `mise tasks` to list, `mise run <name>` to invoke.
+# Namespaces:
+#   docs:*      — rspress documentation site
+#   repro:*     — Layer 1 (WASM) reproduction sources & verification
+#   docker:*    — Layer 2 (Docker) reproduction images
+#   recipes:*   — recipes catalogue index regeneration
+#   mcp:*       — MCP server package (packages/mcp-server)
+#   infra:*     — OpenTofu (infra/github)
+#   ci:*        — local-equivalent of the GitHub Actions workflows
+# ─────────────────────────────────────────────────────────────────────────
+
+# ── Docs site (rspress) ──────────────────────────────────────────────────
+
+[tasks."docs:install"]
+description = "Install docs site dependencies"
+dir = "docs"
+run = "bun install"
+
+[tasks."docs:dev"]
+description = "Run rspress dev server on :3000 (auto-runs prebuild-repro)"
+dir = "docs"
+run = "bun run dev"
+
+[tasks."docs:build"]
+description = "Build static docs site to docs/doc_build/"
+depends = ["docs:install"]
+dir = "docs"
+run = "bun run build"
+
+[tasks."docs:preview"]
+description = "Preview the built static docs site"
+dir = "docs"
+run = "bun run preview"
+
+# ── Layer 1 — WASM reproduction sources ──────────────────────────────────
+
+[tasks."repro:install"]
+description = "Install Layer 1 (WASM) sources dependencies"
+dir = "src/layer1_wasm"
+run = "bun install"
+
+[tasks."repro:typecheck"]
+description = "TypeScript type-check Layer 1 sources + tests"
+depends = ["repro:install"]
+dir = "src/layer1_wasm"
+run = "bun run typecheck"
+
+[tasks."repro:build:ts"]
+description = "Compile Layer 1 TypeScript to .js next to each repro"
+depends = ["repro:install"]
+dir = "src/layer1_wasm"
+run = "bun run build"
+
+[tasks."repro:build:rust"]
+description = "Compile Layer 1 Rust crates (regex-779 etc.) to wasm32-wasip1"
+tools = { rust = "1.84.0" }
+shell = "bash -c"  # need `set -o pipefail` and `shopt`, neither in POSIX sh
+run = '''
+set -euo pipefail
+rustup target add wasm32-wasip1 || true
+shopt -s nullglob
+for cargo_toml in src/layer1_wasm/*/Cargo.toml; do
+  slug_dir=$(dirname "$cargo_toml")
+  echo "==> cargo build $slug_dir"
+  cargo build --release --target wasm32-wasip1 --manifest-path "$cargo_toml"
+  cp "${slug_dir}/target/wasm32-wasip1/release/repro.wasm" "${slug_dir}/repro.wasm"
+done
+'''
+
+[tasks."repro:build"]
+description = "Build all Layer 1 reproductions (TS + Rust wasm)"
+depends = ["repro:build:ts", "repro:build:rust"]
+
+[tasks."repro:test"]
+description = "Run Playwright contract-v1 regression suite for Layer 1"
+depends = ["repro:install"]
+dir = "src/layer1_wasm"
+run = '''
+bunx playwright install --with-deps chromium
+bun run test
+'''
+
+# ── Native re-verification (run repros against host interpreters) ───────
+
+[tasks."repro:native:python"]
+description = "Run Python repros against host Python (Pyodide-equivalent pins)"
+run = '''
+mise exec uv -- uv run --python 3.13 src/layer1_wasm/pandas-56679/repro.py
+mise exec uv -- uv run --python 3.13 src/layer1_wasm/numpy-28287/repro.py
+mise exec uv -- uv run --python 3.13 src/layer1_wasm/cpython-137205/repro.py
+'''
+
+[tasks."repro:native:ruby"]
+description = "Run Ruby repros against host Ruby (3.3.x pin)"
+tools = { ruby = "3.3.3" }
+run = "ruby src/layer1_wasm/ruby-21709/repro.rb"
+
+[tasks."repro:native:php"]
+description = "Run PHP repros against host PHP (php-wasm-equivalent build)"
+tools = { "conda:php" = "latest" }
+run = "php src/layer1_wasm/php-12167/repro.php"
+
+[tasks."repro:native:rust"]
+description = "Run Rust repros against host Rust toolchain"
+tools = { rust = "1.84.0" }
+run = "cargo run --release --manifest-path src/layer1_wasm/regex-779/Cargo.toml"
+
+[tasks."repro:native"]
+description = "Run all repros against host interpreters/compilers"
+depends = [
+  "repro:native:python",
+  "repro:native:ruby",
+  "repro:native:php",
+  "repro:native:rust",
+]
+
+# ── Layer 2 — Docker reproduction images ─────────────────────────────────
+
+[tasks."docker:build"]
+description = "Build all Layer 2 Docker reproduction images locally"
+shell = "bash -c"  # need `set -o pipefail` and `shopt`, neither in POSIX sh
+run = '''
+set -euo pipefail
+shopt -s nullglob
+for dockerfile in src/layer2_docker/*/Dockerfile; do
+  slug_dir=$(dirname "$dockerfile")
+  slug=$(basename "$slug_dir")
+  echo "==> docker build vivarium-${slug}:dev"
+  docker build -t "vivarium-${slug}:dev" "$slug_dir"
+done
+'''
+
+[tasks."docker:run"]
+description = "Run a Layer 2 reproduction (set SLUG=<recipe>; e.g. SLUG=postgres-lost-update)"
+run = '''
+if [ -z "${SLUG:-}" ]; then
+  echo "usage: SLUG=<recipe> mise run docker:run"
+  echo "available:" && ls src/layer2_docker | grep -v "^_" | sed "s/^/  /"
+  exit 1
+fi
+docker run --rm "vivarium-${SLUG}:dev"
+'''
+
+# ── Recipes catalogue index ──────────────────────────────────────────────
+
+[tasks."recipes:index"]
+description = "Regenerate docs/public/api/recipes.json from src/layer*/"
+dir = "docs"
+run = "bun run generate-index"
+
+# ── MCP server (packages/mcp-server) ─────────────────────────────────────
+
+[tasks."mcp:install"]
+description = "Install vivarium-mcp dependencies"
+dir = "packages/mcp-server"
+run = "bun install"
+
+[tasks."mcp:build"]
+description = "Build the MCP server package"
+depends = ["mcp:install"]
+dir = "packages/mcp-server"
+run = "bun run build"
+
+[tasks."mcp:test"]
+description = "Test the MCP server package"
+depends = ["mcp:install"]
+dir = "packages/mcp-server"
+run = "bun run test"
+
+# ── Infra (OpenTofu) ─────────────────────────────────────────────────────
+
+[tasks."infra:init"]
+description = "Initialise OpenTofu working directory for infra/github"
+dir = "infra/github"
+run = "tofu init"
+
+[tasks."infra:fmt"]
+description = "Auto-format all OpenTofu files (infra/)"
+dir = "infra"
+run = "tofu fmt -recursive"
+
+[tasks."infra:plan"]
+description = "Plan the OpenTofu deployment for infra/github"
+depends = ["infra:init"]
+dir = "infra/github"
+run = "tofu plan"
+
+[tasks."infra:apply"]
+description = "Apply OpenTofu changes (PRODUCTION — review the plan first)"
+depends = ["infra:init"]
+dir = "infra/github"
+run = "tofu apply"
+
+# ── Local CI equivalents (what GitHub Actions runs) ──────────────────────
+
+[tasks."ci:docs"]
+description = "Local equivalent of test-docs-build.yml"
+dir = "docs"
+run = '''
+bun install --frozen-lockfile
+bun run build
+'''
+
+[tasks."ci:repro"]
+description = "Local equivalent of repro-regression.yml (typecheck + build + Playwright)"
+dir = "src/layer1_wasm"
+shell = "bash -c"  # need `set -o pipefail`, not in POSIX sh
+run = '''
+set -euo pipefail
+bun install --frozen-lockfile
+bun run typecheck
+bun run build
+bunx playwright install --with-deps chromium
+bun run test
+'''
+
+[tasks."ci:commitlint"]
+description = "Lint the most recent commit message against Conventional Commits"
+run = "bunx commitlint --from HEAD~1 --to HEAD --verbose"
+
+[tasks."ci:all"]
+description = "Run all local CI tasks (docs + repro + commitlint)"
+depends = ["ci:docs", "ci:repro", "ci:commitlint"]

--- a/src/layer1_wasm/playwright.config.ts
+++ b/src/layer1_wasm/playwright.config.ts
@@ -62,7 +62,8 @@ export default defineConfig({
   // server at its layer.
   webServer: [
     {
-      command: `python -m http.server ${LAYER1_PORT}`,
+      // UV provides Python on demand (mise no longer installs Python).
+      command: `uv run --no-project --python 3.13 python -m http.server ${LAYER1_PORT}`,
       url: `${LAYER1_BASE}/`,
       reuseExistingServer: !process.env["CI"],
       timeout: 30_000,
@@ -70,7 +71,7 @@ export default defineConfig({
       stderr: "pipe",
     },
     {
-      command: `python -m http.server ${LAYER2_PORT}`,
+      command: `uv run --no-project --python 3.13 python -m http.server ${LAYER2_PORT}`,
       cwd: "../layer2_docker",
       url: `${LAYER2_BASE}/`,
       reuseExistingServer: !process.env["CI"],


### PR DESCRIPTION
## Summary

Two related cleanups landing together because they share the mise / setup-mise dependency boundary. Independent of #143 (V + L) — those PRs do not touch any of the same files except `mise.toml`'s comment, which has been kept compatible.

### mise — per-task tool pinning

- Top-level `[tools]` reduced to project-wide tooling (`bun`, `opentofu`, `uv`). Python is owned by UV (mise installs UV; UV manages Python versions via `uv run --python <ver>`, the same superset-tool model the [mise docs](https://mise.jdx.dev) recommend).
- Ruby / Rust / PHP move to per-task `use = ["ruby@3.3.3", …]` declarations on the tasks that need them. mise auto-installs the requested version on first call, the same way UV does for Python — so a future recipe needing a different Ruby version no longer has to churn this file.
- Tasks dropped the `mise exec <tool> --` prefix in `run = …` since `use` activates the tool for the task scope.
- `repro:build:rust` keeps a `cd`-free body via `cargo build --manifest-path \"\$cargo_toml\"`, matching the project's no-shell-cwd rule (working directory comes from mise's `dir` field, not from chained `cd`).

### CI — single-tool workflows back to setup-bun

- `test-docs-build`, `publish-mcp`, `branch-fix-verdict` revert from setup-mise to `oven-sh/setup-bun` directly. They never needed more than bun, and the composite-action indirection added more lines (composite + mise.toml task lookup) than the inline `bun install / bun run …` pair it replaced.
- `deploy-docs` and `repro-regression` keep setup-mise — both need bun + rust, which is where mise actually pulls its weight. Stale comments refreshed to reflect this split.
- New composite action `.github/actions/setup-mise/` lifts the `jdx/mise-action` invocation behind a single name so the two multi-tool workflows reference it without duplicating the pin-and-trust boilerplate.

### Playwright

Layer 1 tests' static-file server now uses `uv run --no-project --python 3.13 python -m http.server`, so Python is provisioned by UV on demand instead of from `[tools] python = …` (which would create two competing installs fighting for `mise exec uv -- uv run …`'s PATH).

### Lock file

Also commits the auto-generated `infra/github/.terraform.lock.hcl` that mise's `[deps.tofu]` step writes — keeps provider versions reproducible across machines.

## Test plan

- [x] `mise run repro:native:ruby` — auto-installs Ruby 3.3.3 on first run, reproduces ruby-21709
- [x] `mise run repro:native:rust` — auto-installs Rust 1.84.0 on first run
- [x] `mise run repro:native:php` — auto-installs PHP via conda backend
- [x] `mise run repro:test` (after `repro:build:rust`) — Playwright suite passes; UV provides Python for the test-fixture HTTP server
- [x] CI: `test-docs-build` workflow runs with setup-bun on a docs-touching PR
- [x] CI: `deploy-docs` workflow runs with setup-mise on a push to main