### PR TITLE
docs(agents): mandate pre-PR local CI parity check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,6 +386,37 @@ A trivial style choice or a day-to-day implementation pick does not
 warrant an ADR; AGENTS.md or tooling configuration is the right home
 for those.
 
+### 4.14 Pre-PR local validation
+
+**Run the matching CI checks locally before pushing a PR branch.**
+
+Every PR triggers a set of CI workflows based on its file changes
+(see each workflow's `paths:` filter under `.github/workflows/`).
+Before opening or force-pushing to the PR branch, run the equivalent
+steps locally for every triggered workflow.
+
+The `mise run ci:*` tasks in [`mise.toml`](mise.toml) are the
+canonical local entry points and mirror the workflows job-for-job:
+
+- `mise run ci:docs` — `test-docs-build.yml`
+- `mise run ci:repro` — `repro-regression.yml` (typecheck + build +
+  Playwright; needs Linux for the Playwright browser fixture)
+- `mise run ci:commitlint` — commitlint on the latest commit
+- `mise run ci:all` — the union of the above
+
+If a `ci:*` task is missing for the workflow you triggered, transcribe
+its `run:` steps from the YAML and execute them by hand — do **not**
+skip the check. The cost of a PR that fails on something a local run
+would have caught is multiple round-trips of red CI eating reviewer
+attention; the cost of running the suite once locally is minutes.
+
+**When CI catches something the local run missed** (an OS-specific
+shell behaviour, a path-resolution edge case, a tool only setup-bun's
+PATH wiring exposed, etc.), treat it as a gap in the local-validation
+toolchain: extend the matching `ci:*` task — or add a new one — so
+the next contributor catches it locally too. CI and local should
+converge on the same surface, in both directions.
+
 ## 5. Three-layer architecture (reference)
 
 Product-level technology choices are framed by these three layers. Do not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,3 +84,17 @@ Claude Code (as both implementer and reviewer), Dosu, Dependabot, and
 GitHub Actions compose — is documented in
 [`docs/docs/ai-workflow.md`](docs/docs/ai-workflow.md). Defer to it for process
 questions.
+
+## 7. Pre-PR local validation (mandatory)
+
+Before opening or force-pushing a PR branch, run the matching CI checks
+locally first — every workflow whose `paths:` filter matches the diff.
+The canonical entry points are the `mise run ci:*` tasks in
+[`mise.toml`](mise.toml); `mise run ci:all` covers the union. Where a
+`ci:*` task is missing for the workflow you triggered, transcribe its
+`run:` steps from the YAML and execute them by hand. Do **not** push
+hoping CI catches things — pushing red-then-fix burns the human's
+review attention faster than a local rerun. See
+[`AGENTS.md § 4.14`](AGENTS.md) for the full rationale and the
+"convergence in both directions" requirement (when CI catches what
+local missed, extend the local task).


### PR DESCRIPTION
## Summary

Adds **AGENTS.md §4.14 — Pre-PR local validation** requiring the matching CI workflows to be run locally before pushing a PR branch, with `mise run ci:*` tasks named as the canonical entry points.

The rule is bidirectional:
- If CI checks exist for files you changed, run them locally first
- If CI catches something local missed, **extend the matching `ci:*` task** so the next contributor catches it locally too

CLAUDE.md gets a §7 pointer to the same rule, since this is the kind of guardrail Claude Code in particular tends to forget under push-fix pressure.

## Motivation

A recent PR (#143 / #144) went through six push-fix cycles on red CI for issues a single local run would have caught:

1. Hand-written `chrome.js` excluded by `.gitignore`'s blanket `*.js` rule → 404 in tests
2. Hand-written `sw.js` same problem → 404 in tests
3. mise task `set -o pipefail` failing under `sh` (POSIX dash, not bash) → workflow crash
4. ajv-cli not on PATH after `setup-bun` → `setup-mise` switch (mise's bun doesn't add `~/.bun/install/global/bin` to PATH like setup-bun does)
5. Layer 2's Playwright server can't see Layer 1's `_shared/chrome.js` (cross-layer import) → architectural fix
6. (and combinations of the above visible only after each fix)

Each cycle burned ~15 minutes of CI time + reviewer attention. A single five-minute `mise run ci:all` round before opening the PR would have caught most of these locally.

## Test plan

- [x] AGENTS.md renders cleanly (no broken markdown)
- [x] CLAUDE.md cross-link to `AGENTS.md §4.14` resolves
- [x] No CI parity to test in this PR — it only adds documentation