### PR TITLE
feat(docs): phase 6 S.2 — error → recipe matcher

### DIFF
--- a/docs/components/ErrorRecipeMatcher.tsx
+++ b/docs/components/ErrorRecipeMatcher.tsx
@@ -1,0 +1,363 @@
+import { useMemo, useState } from 'react';
+import './error-recipe-matcher.css';
+import recipesIndex from '../public/api/recipes.json';
+
+/* ============================================================================
+ * Phase 6 S.2 — error → recipe matcher (mechanical, no LLM).
+ *
+ * Mechanical token-overlap scoring per ADR-0025:
+ *   symptom segment match → +5
+ *   tag segment match     → +3
+ *   project / slug match  → +2
+ * Recipes with score 0 are hidden. Ties broken by (layer asc, slug asc).
+ *
+ * No LLM, no fuzzy match, no synonym table. Visitors pasting an error
+ * with no overlap to the overlay see the empty-state pointing at the
+ * gallery (S.1).
+ * ========================================================================== */
+
+interface RecipeEntry {
+  slug: string;
+  layer: 1 | 2 | 3;
+  project: string;
+  issue: number;
+  title: string;
+  page_url: string;
+  source_url: string;
+  language: string;
+  symptom?: string;
+  severity?: string;
+  tags: string[];
+}
+
+interface RecipesIndex {
+  index: 'v1';
+  contract: 'v1';
+  recipes: RecipeEntry[];
+}
+
+const INDEX = recipesIndex as RecipesIndex;
+
+const MAX_INPUT_BYTES = 16 * 1024;
+
+/* English + Japanese stopwords. Kept short; the goal is to drop noise
+ * tokens that would never sit in a recipe's overlay anyway, not to
+ * provide full lexical coverage. */
+const STOPWORDS = new Set([
+  'the', 'and', 'for', 'with', 'from', 'that', 'this', 'have',
+  'has', 'are', 'was', 'were', 'will', 'not', 'but', 'all',
+  'error', 'errors', 'exception', 'failed', 'failure', 'trace',
+  'traceback', 'stack', 'line', 'file', 'most', 'recent', 'call',
+  'です', 'ます', 'した', 'する', 'これ', 'それ', 'その', 'この',
+  'エラー', '例外', '失敗', 'スタック',
+]);
+
+function tokenise(input: string): string[] {
+  let trimmed = input;
+  if (trimmed.length > MAX_INPUT_BYTES) {
+    trimmed = trimmed.slice(trimmed.length - MAX_INPUT_BYTES);
+  }
+  const lower = trimmed.toLowerCase();
+  const raw = lower.split(/[^a-z0-9_]+/);
+  const tokens: string[] = [];
+  const seen = new Set<string>();
+  for (const t of raw) {
+    if (t.length < 3) continue;
+    if (STOPWORDS.has(t)) continue;
+    if (seen.has(t)) continue;
+    seen.add(t);
+    tokens.push(t);
+  }
+  return tokens;
+}
+
+function kebabSegments(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length >= 3 && !STOPWORDS.has(t));
+}
+
+interface Score {
+  recipe: RecipeEntry;
+  score: number;
+  matched: { source: 'symptom' | 'tags' | 'project' | 'slug'; token: string }[];
+}
+
+function scoreRecipe(recipe: RecipeEntry, tokens: Set<string>): Score {
+  const matched: Score['matched'] = [];
+  let score = 0;
+
+  if (recipe.symptom) {
+    for (const seg of kebabSegments(recipe.symptom)) {
+      if (tokens.has(seg)) {
+        score += 5;
+        matched.push({ source: 'symptom', token: seg });
+      }
+    }
+  }
+  for (const tag of recipe.tags) {
+    for (const seg of kebabSegments(tag)) {
+      if (tokens.has(seg)) {
+        score += 3;
+        matched.push({ source: 'tags', token: seg });
+      }
+    }
+  }
+  for (const seg of kebabSegments(recipe.project)) {
+    if (tokens.has(seg)) {
+      score += 2;
+      matched.push({ source: 'project', token: seg });
+    }
+  }
+  for (const seg of kebabSegments(recipe.slug)) {
+    if (tokens.has(seg)) {
+      score += 2;
+      matched.push({ source: 'slug', token: seg });
+    }
+  }
+
+  return { recipe, score, matched };
+}
+
+/* --------------------------------- i18n ---------------------------------- */
+
+type Lang = 'en' | 'ja';
+
+interface Strings {
+  eyebrow: string;
+  inputLabel: string;
+  inputPlaceholder: string;
+  clear: string;
+  tokenisedAs: string;
+  resultsHeading: string;
+  resultsCount: (n: number, total: number) => string;
+  emptyHeading: string;
+  emptyBody: (galleryHref: string) => React.ReactNode;
+  noInputBody: string;
+  scoreLabel: string;
+  matchedTokensLabel: string;
+  open: string;
+  galleryLink: string;
+  layerName: (layer: 1 | 2 | 3) => string;
+}
+
+const STRINGS: Record<Lang, Strings> = {
+  en: {
+    eyebrow: '// MATCH · ERROR → RECIPE',
+    inputLabel: 'Paste an error message or stack trace',
+    inputPlaceholder:
+      'Traceback (most recent call last):\n  File "foo.py", line 42, in bar\n    df = pd.DataFrame()\nValueError: dtype mismatch on empty Series',
+    clear: 'clear',
+    tokenisedAs: 'tokenised as:',
+    resultsHeading: '// RANKED CANDIDATES',
+    resultsCount: (n, total) =>
+      `${n} candidate${n === 1 ? '' : 's'} (of ${total} recipes)`,
+    emptyHeading: 'No recipes match these tokens.',
+    emptyBody: (galleryHref) => (
+      <>
+        Try a different fragment of the error, or browse the{' '}
+        <a href={galleryHref}>gallery</a>.
+      </>
+    ),
+    noInputBody:
+      'Paste an error or stack trace above — matches update as you type.',
+    scoreLabel: 'score',
+    matchedTokensLabel: 'matched',
+    open: 'Open ↗',
+    galleryLink: './',
+    layerName: (layer) =>
+      layer === 1
+        ? 'L1 · WASM'
+        : layer === 2
+          ? 'L2 · Docker'
+          : 'L3 · Record-replay',
+  },
+  ja: {
+    eyebrow: '// マッチ · エラー → レシピ',
+    inputLabel: 'エラーメッセージまたはスタックトレースを貼り付ける',
+    inputPlaceholder:
+      'Traceback (most recent call last):\n  File "foo.py", line 42, in bar\n    df = pd.DataFrame()\nValueError: dtype mismatch on empty Series',
+    clear: 'クリア',
+    tokenisedAs: 'トークン化:',
+    resultsHeading: '// ランク付き候補',
+    resultsCount: (n, total) =>
+      `${n} 件 (全 ${total} レシピ中)`,
+    emptyHeading: 'このトークンに該当するレシピがない。',
+    emptyBody: (galleryHref) => (
+      <>
+        エラーの別の部分を試すか、
+        <a href={galleryHref}>ギャラリー</a>
+        を参照する。
+      </>
+    ),
+    noInputBody:
+      '上のエリアにエラーまたはスタックを貼り付けると、入力に応じて候補が即座に絞り込まれる。',
+    scoreLabel: 'スコア',
+    matchedTokensLabel: '一致したトークン',
+    open: '開く ↗',
+    galleryLink: './',
+    layerName: (layer) =>
+      layer === 1
+        ? 'L1 · WASM'
+        : layer === 2
+          ? 'L2 · Docker'
+          : 'L3 · 記録再生',
+  },
+};
+
+/* ------------------------------ Components ------------------------------ */
+
+function MatchCard({ lang, score }: { lang: Lang; score: Score }) {
+  const s = STRINGS[lang];
+  const r = score.recipe;
+  const layerAccent =
+    r.layer === 1 ? 'teal' : r.layer === 2 ? 'violet' : 'coral';
+  // Dedupe matched tokens for display while preserving first-seen order.
+  const seen = new Set<string>();
+  const tokens: { token: string; source: string }[] = [];
+  for (const m of score.matched) {
+    const key = `${m.source}:${m.token}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    tokens.push(m);
+  }
+  return (
+    <article className="v-rg__card v-erm__card">
+      <header className="v-rg__card-head">
+        <span
+          className={`v-rg__layer-pill v-rg__layer-pill--${layerAccent}`}
+        >
+          {s.layerName(r.layer)}
+        </span>
+        <span className="v-erm__score">
+          <span className="v-erm__score-key">{s.scoreLabel}</span>{' '}
+          <code>{score.score}</code>
+        </span>
+      </header>
+      <h3 className="v-rg__title">
+        {r.project}
+        {r.issue > 0 ? <span>#{r.issue}</span> : null}
+      </h3>
+      <p className="v-rg__lede">{r.title}</p>
+      <div className="v-erm__matched">
+        <span className="v-erm__matched-key">{s.matchedTokensLabel}:</span>
+        {tokens.map((m, i) => (
+          <span key={i} className={`v-erm__token v-erm__token--${m.source}`}>
+            <span className="v-erm__token-source">{m.source[0]}</span>
+            {m.token}
+          </span>
+        ))}
+      </div>
+      <div className="v-rg__actions">
+        <a
+          className="v-rg__btn v-rg__btn--primary"
+          href={r.page_url}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {s.open}
+        </a>
+      </div>
+    </article>
+  );
+}
+
+/* -------------------------------- Main -------------------------------- */
+
+export function ErrorRecipeMatcher({ lang }: { lang: Lang }) {
+  const s = STRINGS[lang];
+  const [input, setInput] = useState('');
+
+  // Live filter — every keystroke re-scores against `input` directly.
+  // No debounce: 11 recipes × O(token) is sub-millisecond and the matcher
+  // has no other settings (layer/severity toggles etc.) so there is no
+  // submit semantic to wait on. Clear button is the only escape hatch.
+  const tokens = useMemo(() => tokenise(input), [input]);
+  const tokenSet = useMemo(() => new Set(tokens), [tokens]);
+
+  const ranked = useMemo<Score[]>(() => {
+    if (tokens.length === 0) return [];
+    const scored = INDEX.recipes
+      .map((r) => scoreRecipe(r, tokenSet))
+      .filter((s) => s.score > 0);
+    scored.sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      if (a.recipe.layer !== b.recipe.layer) return a.recipe.layer - b.recipe.layer;
+      return a.recipe.slug.localeCompare(b.recipe.slug);
+    });
+    return scored;
+  }, [tokens, tokenSet]);
+
+  const clear = () => setInput('');
+
+  const hasInput = input.trim().length > 0;
+  const hasResults = ranked.length > 0;
+
+  return (
+    <section className="v-erm">
+      <p className="v-erm__eyebrow">{s.eyebrow}</p>
+      <label className="v-erm__field">
+        <span className="v-erm__field-label">{s.inputLabel}</span>
+        <textarea
+          className="v-erm__field-input"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder={s.inputPlaceholder}
+          rows={8}
+          spellCheck={false}
+          autoCapitalize="off"
+          autoCorrect="off"
+        />
+      </label>
+      <div className="v-erm__actions">
+        <button
+          type="button"
+          className="v-erm__btn v-erm__btn--ghost"
+          onClick={clear}
+          disabled={!input}
+        >
+          {s.clear}
+        </button>
+      </div>
+
+      {hasInput && tokens.length > 0 ? (
+        <div className="v-erm__tokens">
+          <span className="v-erm__tokens-label">{s.tokenisedAs}</span>
+          {tokens.map((t) => (
+            <span key={t} className="v-erm__token v-erm__token--input">
+              {t}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {hasInput ? (
+        hasResults ? (
+          <div className="v-erm__results">
+            <header className="v-erm__results-header">
+              <span className="v-erm__results-eyebrow">{s.resultsHeading}</span>
+              <span className="v-erm__results-count">
+                {s.resultsCount(ranked.length, INDEX.recipes.length)}
+              </span>
+            </header>
+            <div className="v-rg__cards">
+              {ranked.map((score) => (
+                <MatchCard key={score.recipe.slug} lang={lang} score={score} />
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="v-erm__empty">
+            <p className="v-erm__empty-heading">{s.emptyHeading}</p>
+            <p className="v-erm__empty-body">{s.emptyBody(s.galleryLink)}</p>
+          </div>
+        )
+      ) : (
+        <p className="v-erm__hint">{s.noInputBody}</p>
+      )}
+    </section>
+  );
+}
+
+export default ErrorRecipeMatcher;

--- a/docs/components/error-recipe-matcher.css
+++ b/docs/components/error-recipe-matcher.css
@@ -1,0 +1,264 @@
+/* Phase 6 S.2 — error → recipe matcher.
+ * Reuses .v-rg__card and .v-rg__title family from recipe-gallery.css.
+ */
+
+.v-erm {
+  margin: 1.25rem 0 2.5rem;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--vh-text);
+}
+
+.v-erm__eyebrow,
+.v-erm__results-eyebrow {
+  display: block;
+  margin: 0 0 0.6rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--vh-accent-teal);
+}
+
+.v-erm__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  margin-bottom: 0.85rem;
+}
+
+.v-erm__field-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--vh-text-muted);
+}
+
+.v-erm__field-input {
+  width: 100%;
+  padding: 0.7rem 0.85rem;
+  background: var(--vh-card-bg);
+  border: 1px solid var(--vh-hairline);
+  border-radius: 6px;
+  color: var(--vh-text);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  resize: vertical;
+  outline: none;
+}
+
+.v-erm__field-input:focus {
+  border-color: var(--vh-accent-teal);
+  background: var(--vh-card-bg-hover);
+}
+
+.v-erm__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.v-erm__btn {
+  padding: 0.5rem 0.95rem;
+  border: 1px solid var(--vh-hairline-strong);
+  border-radius: 6px;
+  background: var(--vh-card-bg);
+  color: var(--vh-text);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 120ms ease;
+}
+
+.v-erm__btn:hover:not(:disabled) {
+  border-color: var(--vh-accent-teal);
+  background: var(--vh-card-bg-hover);
+}
+
+.v-erm__btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.v-erm__btn--primary {
+  border-color: var(--vh-accent-teal);
+  color: var(--vh-accent-teal);
+}
+
+.v-erm__btn--ghost {
+  background: transparent;
+}
+
+/* ---------- Tokens chip strip ---------- */
+
+.v-erm__tokens {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.3rem 0.45rem;
+  margin: 0 0 1.1rem;
+  padding: 0.6rem 0.85rem;
+  background: var(--vh-card-bg);
+  border: 1px solid var(--vh-hairline);
+  border-radius: 6px;
+}
+
+.v-erm__tokens-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--vh-text-muted);
+  margin-right: 0.25rem;
+}
+
+.v-erm__token {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 3px;
+  background: var(--vh-card-bg-hover);
+  color: var(--vh-text);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  border: 1px solid var(--vh-hairline);
+}
+
+.v-erm__token--input {
+  background: rgba(0, 212, 170, 0.08);
+  border-color: rgba(0, 212, 170, 0.25);
+  color: var(--vh-accent-teal-bright);
+}
+
+.v-erm__token--symptom {
+  background: rgba(124, 92, 255, 0.12);
+  color: var(--vh-accent-violet-bright);
+  border-color: rgba(124, 92, 255, 0.25);
+}
+
+.v-erm__token--tags {
+  background: rgba(0, 212, 170, 0.08);
+  color: var(--vh-accent-teal-bright);
+  border-color: rgba(0, 212, 170, 0.25);
+}
+
+.v-erm__token--project,
+.v-erm__token--slug {
+  background: rgba(255, 113, 108, 0.08);
+  color: var(--vh-accent-coral);
+  border-color: rgba(255, 113, 108, 0.25);
+}
+
+.v-erm__token-source {
+  font-size: 0.62rem;
+  opacity: 0.7;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+/* ---------- Results ---------- */
+
+.v-erm__results {
+  margin-top: 1.5rem;
+}
+
+.v-erm__results-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.7rem;
+}
+
+.v-erm__results-count {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--vh-text-dim);
+}
+
+.v-erm__card {
+  border-color: var(--vh-accent-teal);
+  background: var(--vh-card-bg);
+}
+
+.v-erm__score {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+}
+
+.v-erm__score-key {
+  color: var(--vh-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.65rem;
+}
+
+.v-erm__score code {
+  font-family: 'JetBrains Mono', monospace;
+  background: var(--vh-card-bg-hover);
+  color: var(--vh-accent-teal-bright);
+  padding: 0.1rem 0.45rem;
+  border-radius: 3px;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.v-erm__matched {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.3rem 0.45rem;
+  margin: 0.4rem 0;
+}
+
+.v-erm__matched-key {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--vh-text-muted);
+  margin-right: 0.15rem;
+}
+
+/* ---------- Empty / hint states ---------- */
+
+.v-erm__empty {
+  margin-top: 1.5rem;
+  padding: 1.5rem 1.25rem;
+  text-align: center;
+  background: var(--vh-card-bg);
+  border-radius: 8px;
+  border: 1px dashed var(--vh-hairline-strong);
+}
+
+.v-erm__empty-heading {
+  margin: 0 0 0.5rem;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1rem;
+  color: var(--vh-text);
+}
+
+.v-erm__empty-body {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--vh-text-muted);
+}
+
+.v-erm__empty-body a {
+  color: var(--vh-accent-teal);
+  text-decoration: underline;
+}
+
+.v-erm__hint {
+  margin: 1.2rem 0 0;
+  font-size: 0.85rem;
+  color: var(--vh-text-dim);
+  font-style: italic;
+}

--- a/docs/docs/en/repro/_meta.json
+++ b/docs/docs/en/repro/_meta.json
@@ -6,6 +6,11 @@
   },
   {
     "type": "file",
+    "name": "match",
+    "label": "Match an error"
+  },
+  {
+    "type": "file",
     "name": "compare",
     "label": "Branch-fix comparison"
   }

--- a/docs/docs/en/repro/match.mdx
+++ b/docs/docs/en/repro/match.mdx
@@ -1,0 +1,17 @@
+---
+pageType: doc
+title: Match an error
+---
+
+import { Page, PageHero } from '../../../components/PageChrome';
+import { ErrorRecipeMatcher } from '../../../components/ErrorRecipeMatcher';
+
+<Page>
+  <PageHero
+    eyebrow="// MATCH · ERROR → RECIPE"
+    title={<>Paste an error, find a candidate.</>}
+    sub="Mechanical token-overlap match against the recipe catalogue. No LLM, no fuzzy match — exact lowercase tokens against each recipe's symptom, tags, project, and slug. All scoring runs locally."
+  />
+
+  <ErrorRecipeMatcher lang="en" />
+</Page>

--- a/docs/docs/ja/repro/_meta.json
+++ b/docs/docs/ja/repro/_meta.json
@@ -6,6 +6,11 @@
   },
   {
     "type": "file",
+    "name": "match",
+    "label": "エラーからレシピを探す"
+  },
+  {
+    "type": "file",
     "name": "compare",
     "label": "ブランチ修正の比較"
   }

--- a/docs/docs/ja/repro/match.mdx
+++ b/docs/docs/ja/repro/match.mdx
@@ -1,0 +1,17 @@
+---
+pageType: doc
+title: エラーからレシピを探す
+---
+
+import { Page, PageHero } from '../../../components/PageChrome';
+import { ErrorRecipeMatcher } from '../../../components/ErrorRecipeMatcher';
+
+<Page>
+  <PageHero
+    eyebrow="// MATCH · ERROR → RECIPE"
+    title={<>エラーを貼り付けて、候補レシピを探す。</>}
+    sub="レシピカタログに対する機械的なトークンオーバーラップマッチ。LLM 非依存、ファジーマッチ非対応——各レシピの symptom / tags / project / slug に対する正確な小文字トークン一致のみ。スコアリングはすべてローカルで実行される。"
+  />
+
+  <ErrorRecipeMatcher lang="ja" />
+</Page>


### PR DESCRIPTION

Adds `/{,ja/}repro/match`, a paste-and-rank surface for finding
candidate recipes given an error message or stack trace.
Mechanical token-overlap scoring per ADR-0025: lowercase the
input, split on non-alphanumeric runs, drop sub-3-char tokens
and a fixed English+Japanese stopword list, then score each
recipe by token-overlap weight per source field — `symptom`
segment +5, `tags` segment +3, `project`/`slug` segment +2.
Recipes with score 0 are hidden; ties broken by
(layer asc, slug asc) so Layer 1 (instant in-browser) gets a
tiebreaker preference.

No LLM, no fuzzy match, no synonym table in v1
(ADR-0025 §5) — same mechanical-over-judgement posture as the
rest of Phase 6 (AGENTS.md §3.3). Visitors who paste an error
with no overlap to the overlay see the empty-state pointing at
the gallery.

`docs/components/ErrorRecipeMatcher.tsx` reuses the
`recipes.json` data surface S.1 enriched and renders matched
recipes via cards that share `.v-rg__card` styling — the
matcher's surface is a leaner variant of S.1's gallery cards
plus a "matched tokens" strip showing which fragments hit each
recipe (with source-coloured pills: symptom / tags / project /
slug).

`docs/docs/{en,ja}/repro/_meta.json` reorders the sidebar to
Gallery → Match → Compare so the discovery flow reads
left-to-right: browse → narrow by error → compare a fix.

Path A (Layer 1 in-page source-substitution branch-fix) re-defer
from R.3 stays out of S.2 scope per ADR-0023 §4 — it would
introduce a different surface (live source-replacement runtime)
than the matcher's data-only shape.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/149).
* #151
* #150
* __->__ #149
* #148