### PR TITLE
feat(docs): phase 6 M.1 — interactive manifest scaffolder

### DIFF
--- a/docs/components/ManifestScaffolder.tsx
+++ b/docs/components/ManifestScaffolder.tsx
@@ -1,0 +1,732 @@
+import { useMemo, useState } from 'react';
+import './manifest-scaffolder.css';
+
+/* ============================================================================
+ * Phase 6 M.1 — interactive .vivarium/manifest.toml scaffolder.
+ *
+ * Hand-rolled form per ADR-0026 §1 (JSON Schema → labels/help only,
+ * fields are hand-coded). Hand-rolled validation + TOML emission per
+ * §2/§3. No backend; all state is in-memory.
+ *
+ * Output mirrors docs/public/spec/manifest.schema.json's example block.
+ * ========================================================================== */
+
+type Lang = 'en' | 'ja';
+type LayerLiteral = 1 | 2 | 3;
+type ExpectedVerdict = '' | 'pass' | 'fail';
+
+interface FormState {
+  slug: string;
+  layer: LayerLiteral | null;
+  title: string;
+  description: string;
+  bug: {
+    project: string;
+    issue: string;
+    upstream_url: string;
+  };
+  layer1: {
+    page_url: string;
+    expected_verdict: ExpectedVerdict;
+  };
+  layer2: {
+    image: string;
+    dockerfile: string;
+    expected_verdict: ExpectedVerdict;
+  };
+  layer3: {
+    image: string;
+    dockerfile: string;
+    expected_verdict: ExpectedVerdict;
+  };
+}
+
+const SLUG_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const URL_RE = /^https?:\/\/.+/;
+
+type FieldErrors = Partial<Record<string, string>>;
+
+function validate(state: FormState): FieldErrors {
+  const errors: FieldErrors = {};
+  if (!state.slug) errors.slug = 'required';
+  else if (!SLUG_RE.test(state.slug))
+    errors.slug = "must match /^[a-z0-9]+(-[a-z0-9]+)*$/";
+  if (state.layer == null) errors.layer = 'required';
+  if (!state.bug.project) errors['bug.project'] = 'required';
+  if (state.bug.issue !== '' && !/^\d+$/.test(state.bug.issue))
+    errors['bug.issue'] = 'must be a non-negative integer';
+  if (!state.bug.upstream_url) errors['bug.upstream_url'] = 'required';
+  else if (!URL_RE.test(state.bug.upstream_url))
+    errors['bug.upstream_url'] = 'must be http(s)://…';
+
+  if (state.layer === 1) {
+    if (!state.layer1.page_url) errors['layer1.page_url'] = 'required';
+    else if (!URL_RE.test(state.layer1.page_url))
+      errors['layer1.page_url'] = 'must be http(s)://…';
+  } else if (state.layer === 2) {
+    if (!state.layer2.image) errors['layer2.image'] = 'required';
+  } else if (state.layer === 3) {
+    if (!state.layer3.image) errors['layer3.image'] = 'required';
+  }
+  return errors;
+}
+
+/* ----------------------------- TOML emission ----------------------------- */
+
+function escapeTomlBasic(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\t/g, '\\t');
+}
+
+function emitTomlString(value: string): string {
+  if (value.includes('\n')) {
+    // Multi-line basic string: backslash and triple-quote still need escaping.
+    const escaped = value.replace(/\\/g, '\\\\').replace(/"""/g, '\\"\\"\\"');
+    return `"""\n${escaped}\n"""`;
+  }
+  return `"${escapeTomlBasic(value)}"`;
+}
+
+function buildToml(state: FormState): string {
+  const lines: string[] = [];
+  lines.push(`manifest = "v1"`);
+  lines.push(`slug = ${emitTomlString(state.slug)}`);
+  if (state.layer != null) {
+    lines.push(`layer = ${state.layer}`);
+  }
+  if (state.title) {
+    lines.push(`title = ${emitTomlString(state.title)}`);
+  }
+  if (state.description) {
+    lines.push(`description = ${emitTomlString(state.description)}`);
+  }
+  lines.push('');
+  lines.push(`[bug]`);
+  lines.push(`project = ${emitTomlString(state.bug.project)}`);
+  const issue = state.bug.issue || '0';
+  lines.push(`issue = ${issue}`);
+  lines.push(`upstream_url = ${emitTomlString(state.bug.upstream_url)}`);
+
+  if (state.layer === 1) {
+    lines.push('');
+    lines.push(`[layer1]`);
+    lines.push(`page_url = ${emitTomlString(state.layer1.page_url)}`);
+    if (state.layer1.expected_verdict) {
+      lines.push(
+        `expected_verdict = ${emitTomlString(state.layer1.expected_verdict)}`,
+      );
+    }
+  } else if (state.layer === 2) {
+    lines.push('');
+    lines.push(`[layer2]`);
+    lines.push(`image = ${emitTomlString(state.layer2.image)}`);
+    if (state.layer2.dockerfile) {
+      lines.push(`dockerfile = ${emitTomlString(state.layer2.dockerfile)}`);
+    }
+    if (state.layer2.expected_verdict) {
+      lines.push(
+        `expected_verdict = ${emitTomlString(state.layer2.expected_verdict)}`,
+      );
+    }
+  } else if (state.layer === 3) {
+    lines.push('');
+    lines.push(`[layer3]`);
+    lines.push(`image = ${emitTomlString(state.layer3.image)}`);
+    if (state.layer3.dockerfile) {
+      lines.push(`dockerfile = ${emitTomlString(state.layer3.dockerfile)}`);
+    }
+    if (state.layer3.expected_verdict) {
+      lines.push(
+        `expected_verdict = ${emitTomlString(state.layer3.expected_verdict)}`,
+      );
+    }
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+/* --------------------------------- i18n ---------------------------------- */
+
+interface Strings {
+  formEyebrow: string;
+  identityHeading: string;
+  layerHeading: string;
+  bugHeading: string;
+  layerSpecificHeading: (layer: LayerLiteral | null) => string;
+  outputEyebrow: string;
+  slugLabel: string;
+  slugHelp: string;
+  titleLabel: string;
+  titleHelp: string;
+  descriptionLabel: string;
+  descriptionHelp: string;
+  layerLabel: string;
+  layerHelp: string;
+  layerOption: (n: LayerLiteral) => string;
+  bugProjectLabel: string;
+  bugIssueLabel: string;
+  bugIssueHelp: string;
+  bugUpstreamUrlLabel: string;
+  pageUrlLabel: string;
+  pageUrlHelp: string;
+  imageLabel: string;
+  dockerfileLabel: string;
+  dockerfileHelp: string;
+  expectedVerdictLabel: string;
+  expectedVerdictHelp: string;
+  expectedVerdictUnset: string;
+  generate: string;
+  copy: string;
+  download: string;
+  reset: string;
+  noLayerYet: string;
+  required: string;
+  copied: string;
+  emptyOutput: string;
+  specLink: string;
+}
+
+const STRINGS: Record<Lang, Strings> = {
+  en: {
+    formEyebrow: '// 01 · MANIFEST FIELDS',
+    identityHeading: 'Identity',
+    layerHeading: 'Layer',
+    bugHeading: 'Bug reference',
+    layerSpecificHeading: (layer) =>
+      layer == null
+        ? 'Layer-specific'
+        : layer === 1
+          ? 'Layer 1 (WASM)'
+          : layer === 2
+            ? 'Layer 2 (Docker)'
+            : 'Layer 3 (record-replay)',
+    outputEyebrow: '// 02 · GENERATED TOML',
+    slugLabel: 'slug',
+    slugHelp:
+      'Kebab-case identifier; lowercase ASCII, digits, hyphens. Must match `^[a-z0-9]+(-[a-z0-9]+)*$`.',
+    titleLabel: 'title (optional)',
+    titleHelp: 'Short human-readable title.',
+    descriptionLabel: 'description (optional)',
+    descriptionHelp:
+      'Long-form description. Markdown allowed; consumers may render it or display verbatim.',
+    layerLabel: 'layer',
+    layerHelp:
+      '1 = WASM in-browser, 2 = Docker, 3 = record-replay. Selecting a layer reveals that layer\'s required fields below.',
+    layerOption: (n) =>
+      n === 1 ? '1 · WASM' : n === 2 ? '2 · Docker' : '3 · record-replay',
+    bugProjectLabel: 'bug.project',
+    bugIssueLabel: 'bug.issue',
+    bugIssueHelp:
+      'Upstream issue number. 0 if no tracker entry exists. Defaults to 0 in the TOML output if left blank.',
+    bugUpstreamUrlLabel: 'bug.upstream_url',
+    pageUrlLabel: 'layer1.page_url',
+    pageUrlHelp:
+      'URL of the static reproduction page. Must conform to Vivarium Contract v1.',
+    imageLabel: 'image',
+    dockerfileLabel: 'dockerfile (optional)',
+    dockerfileHelp:
+      'Repo-relative path. Informational only — Vivarium does not build from this.',
+    expectedVerdictLabel: 'expected_verdict (optional)',
+    expectedVerdictHelp:
+      "'pass' = bug reproduces; 'fail' = bug does not reproduce (sentinel).",
+    expectedVerdictUnset: '— (omit field)',
+    generate: 'Generate TOML',
+    copy: 'Copy',
+    download: 'Download manifest.toml',
+    reset: 'Reset',
+    noLayerYet: 'Pick a layer to reveal its required fields.',
+    required: 'required',
+    copied: 'copied ✓',
+    emptyOutput:
+      'Fill in the form above and press "Generate TOML" to produce a `.vivarium/manifest.toml` you can copy or download.',
+    specLink: 'Manifest v1 spec → /vivarium/spec/manifest-v1',
+  },
+  ja: {
+    formEyebrow: '// 01 · マニフェストフィールド',
+    identityHeading: 'アイデンティティ',
+    layerHeading: 'レイヤー',
+    bugHeading: 'バグ参照',
+    layerSpecificHeading: (layer) =>
+      layer == null
+        ? 'レイヤー固有'
+        : layer === 1
+          ? 'レイヤー 1 (WASM)'
+          : layer === 2
+            ? 'レイヤー 2 (Docker)'
+            : 'レイヤー 3 (記録再生)',
+    outputEyebrow: '// 02 · 生成された TOML',
+    slugLabel: 'slug',
+    slugHelp:
+      'kebab-case の識別子。小文字 ASCII / 数字 / ハイフンのみ。`^[a-z0-9]+(-[a-z0-9]+)*$` に一致する必要がある。',
+    titleLabel: 'title (任意)',
+    titleHelp: '短い人間向けのタイトル。',
+    descriptionLabel: 'description (任意)',
+    descriptionHelp:
+      '長文の説明。Markdown 可。コンシューマー側がレンダリングするかそのまま表示するかを選ぶ。',
+    layerLabel: 'layer',
+    layerHelp:
+      '1 = ブラウザ内 WASM、2 = Docker、3 = 記録再生。レイヤーを選ぶと、そのレイヤーに必要なフィールドが下に出る。',
+    layerOption: (n) =>
+      n === 1 ? '1 · WASM' : n === 2 ? '2 · Docker' : '3 · 記録再生',
+    bugProjectLabel: 'bug.project',
+    bugIssueLabel: 'bug.issue',
+    bugIssueHelp:
+      'アップストリームの issue 番号。トラッカーエントリがない場合は 0。空欄のときは TOML 出力で 0 が使われる。',
+    bugUpstreamUrlLabel: 'bug.upstream_url',
+    pageUrlLabel: 'layer1.page_url',
+    pageUrlHelp:
+      '静的再現ページの URL。Vivarium Contract v1 に準拠している必要がある。',
+    imageLabel: 'image',
+    dockerfileLabel: 'dockerfile (任意)',
+    dockerfileHelp:
+      'リポジトリ相対パス。情報目的のみ——Vivarium はここからビルドしない。',
+    expectedVerdictLabel: 'expected_verdict (任意)',
+    expectedVerdictHelp:
+      '`pass` = バグが再現する。`fail` = バグが再現しない (sentinel)。',
+    expectedVerdictUnset: '— (フィールドを省略)',
+    generate: 'TOML を生成',
+    copy: 'コピー',
+    download: 'manifest.toml をダウンロード',
+    reset: 'リセット',
+    noLayerYet: 'レイヤーを選ぶと、そのレイヤーに必要なフィールドが表示される。',
+    required: '必須',
+    copied: 'コピー済 ✓',
+    emptyOutput:
+      '上のフォームを埋めて「TOML を生成」を押すと、コピーまたはダウンロード可能な `.vivarium/manifest.toml` が出力される。',
+    specLink: 'Manifest v1 仕様 → /vivarium/ja/spec/manifest-v1',
+  },
+};
+
+/* ------------------------------ Components ------------------------------ */
+
+const INITIAL_STATE: FormState = {
+  slug: '',
+  layer: null,
+  title: '',
+  description: '',
+  bug: { project: '', issue: '', upstream_url: '' },
+  layer1: { page_url: '', expected_verdict: '' },
+  layer2: { image: '', dockerfile: '', expected_verdict: '' },
+  layer3: { image: '', dockerfile: '', expected_verdict: '' },
+};
+
+function Field({
+  label,
+  help,
+  error,
+  children,
+  required,
+  requiredText,
+}: {
+  label: string;
+  help?: string;
+  error?: string;
+  children: React.ReactNode;
+  required?: boolean;
+  requiredText: string;
+}) {
+  return (
+    <label className={'v-mfs__field' + (error ? ' v-mfs__field--err' : '')}>
+      <span className="v-mfs__label">
+        <span className="v-mfs__label-name">{label}</span>
+        {required ? (
+          <span className="v-mfs__required">{requiredText}</span>
+        ) : null}
+      </span>
+      {children}
+      {error ? <span className="v-mfs__error">{error}</span> : null}
+      {help ? <span className="v-mfs__help">{help}</span> : null}
+    </label>
+  );
+}
+
+export function ManifestScaffolder({ lang }: { lang: Lang }) {
+  const s = STRINGS[lang];
+  const [state, setState] = useState<FormState>(INITIAL_STATE);
+  const [output, setOutput] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  const errors = useMemo(() => validate(state), [state]);
+  const hasErrors = Object.keys(errors).length > 0;
+
+  const update = <K extends keyof FormState>(field: K, value: FormState[K]) => {
+    setState((prev) => ({ ...prev, [field]: value }));
+  };
+  const updateBug = (k: keyof FormState['bug'], v: string) => {
+    setState((prev) => ({ ...prev, bug: { ...prev.bug, [k]: v } }));
+  };
+  const updateLayer = <L extends 'layer1' | 'layer2' | 'layer3'>(
+    layer: L,
+    k: keyof FormState[L],
+    v: string,
+  ) => {
+    setState((prev) => ({
+      ...prev,
+      [layer]: { ...prev[layer], [k]: v },
+    }));
+  };
+
+  const generate = () => {
+    if (hasErrors) return;
+    setOutput(buildToml(state));
+    setCopied(false);
+  };
+
+  const copy = async () => {
+    if (!output) return;
+    try {
+      await navigator.clipboard.writeText(output);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard blocked — user can select-and-copy from the <pre>. */
+    }
+  };
+
+  const download = () => {
+    if (!output) return;
+    const blob = new Blob([output], { type: 'application/toml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'manifest.toml';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  const reset = () => {
+    setState(INITIAL_STATE);
+    setOutput('');
+    setCopied(false);
+  };
+
+  return (
+    <div className="v-mfs">
+      <p className="v-mfs__eyebrow">{s.formEyebrow}</p>
+
+      {/* Identity group */}
+      <fieldset className="v-mfs__group">
+        <legend className="v-mfs__group-legend">{s.identityHeading}</legend>
+        <Field
+          label={s.slugLabel}
+          help={s.slugHelp}
+          error={errors.slug}
+          required
+          requiredText={s.required}
+        >
+          <input
+            type="text"
+            className="v-mfs__input"
+            value={state.slug}
+            onChange={(e) => update('slug', e.target.value)}
+            placeholder="my-recipe-slug"
+            spellCheck={false}
+            autoCapitalize="off"
+            autoCorrect="off"
+          />
+        </Field>
+        <Field
+          label={s.titleLabel}
+          help={s.titleHelp}
+          requiredText={s.required}
+        >
+          <input
+            type="text"
+            className="v-mfs__input"
+            value={state.title}
+            onChange={(e) => update('title', e.target.value)}
+            placeholder="bash: local shadows builtin's exit"
+          />
+        </Field>
+        <Field
+          label={s.descriptionLabel}
+          help={s.descriptionHelp}
+          requiredText={s.required}
+        >
+          <textarea
+            className="v-mfs__input v-mfs__input--textarea"
+            value={state.description}
+            onChange={(e) => update('description', e.target.value)}
+            rows={3}
+            spellCheck={false}
+          />
+        </Field>
+      </fieldset>
+
+      {/* Layer group */}
+      <fieldset className="v-mfs__group">
+        <legend className="v-mfs__group-legend">{s.layerHeading}</legend>
+        <Field
+          label={s.layerLabel}
+          help={s.layerHelp}
+          error={errors.layer}
+          required
+          requiredText={s.required}
+        >
+          <div className="v-mfs__chips">
+            {([1, 2, 3] as LayerLiteral[]).map((n) => (
+              <button
+                key={n}
+                type="button"
+                className={
+                  'v-mfs__chip' +
+                  (state.layer === n ? ' v-mfs__chip--on' : '')
+                }
+                onClick={() => update('layer', state.layer === n ? null : n)}
+                aria-pressed={state.layer === n}
+              >
+                {s.layerOption(n)}
+              </button>
+            ))}
+          </div>
+        </Field>
+      </fieldset>
+
+      {/* Bug group */}
+      <fieldset className="v-mfs__group">
+        <legend className="v-mfs__group-legend">{s.bugHeading}</legend>
+        <Field
+          label={s.bugProjectLabel}
+          error={errors['bug.project']}
+          required
+          requiredText={s.required}
+        >
+          <input
+            type="text"
+            className="v-mfs__input"
+            value={state.bug.project}
+            onChange={(e) => updateBug('project', e.target.value)}
+            placeholder="bash"
+          />
+        </Field>
+        <Field
+          label={s.bugIssueLabel}
+          help={s.bugIssueHelp}
+          error={errors['bug.issue']}
+          requiredText={s.required}
+        >
+          <input
+            type="text"
+            inputMode="numeric"
+            className="v-mfs__input"
+            value={state.bug.issue}
+            onChange={(e) => updateBug('issue', e.target.value)}
+            placeholder="0"
+          />
+        </Field>
+        <Field
+          label={s.bugUpstreamUrlLabel}
+          error={errors['bug.upstream_url']}
+          required
+          requiredText={s.required}
+        >
+          <input
+            type="url"
+            className="v-mfs__input"
+            value={state.bug.upstream_url}
+            onChange={(e) => updateBug('upstream_url', e.target.value)}
+            placeholder="https://lists.gnu.org/archive/html/bug-bash/"
+          />
+        </Field>
+      </fieldset>
+
+      {/* Layer-specific group */}
+      <fieldset className="v-mfs__group">
+        <legend className="v-mfs__group-legend">
+          {s.layerSpecificHeading(state.layer)}
+        </legend>
+        {state.layer == null ? (
+          <p className="v-mfs__placeholder">{s.noLayerYet}</p>
+        ) : state.layer === 1 ? (
+          <>
+            <Field
+              label={s.pageUrlLabel}
+              help={s.pageUrlHelp}
+              error={errors['layer1.page_url']}
+              required
+              requiredText={s.required}
+            >
+              <input
+                type="url"
+                className="v-mfs__input"
+                value={state.layer1.page_url}
+                onChange={(e) => updateLayer('layer1', 'page_url', e.target.value)}
+                placeholder="https://example.org/repro/"
+              />
+            </Field>
+            <Field
+              label={s.expectedVerdictLabel}
+              help={s.expectedVerdictHelp}
+              requiredText={s.required}
+            >
+              <select
+                className="v-mfs__input"
+                value={state.layer1.expected_verdict}
+                onChange={(e) =>
+                  updateLayer('layer1', 'expected_verdict', e.target.value)
+                }
+              >
+                <option value="">{s.expectedVerdictUnset}</option>
+                <option value="pass">pass</option>
+                <option value="fail">fail</option>
+              </select>
+            </Field>
+          </>
+        ) : state.layer === 2 ? (
+          <>
+            <Field
+              label={s.imageLabel}
+              error={errors['layer2.image']}
+              required
+              requiredText={s.required}
+            >
+              <input
+                type="text"
+                className="v-mfs__input"
+                value={state.layer2.image}
+                onChange={(e) => updateLayer('layer2', 'image', e.target.value)}
+                placeholder="ghcr.io/example-org/example-recipe:latest"
+              />
+            </Field>
+            <Field
+              label={s.dockerfileLabel}
+              help={s.dockerfileHelp}
+              requiredText={s.required}
+            >
+              <input
+                type="text"
+                className="v-mfs__input"
+                value={state.layer2.dockerfile}
+                onChange={(e) => updateLayer('layer2', 'dockerfile', e.target.value)}
+                placeholder="./Dockerfile"
+              />
+            </Field>
+            <Field
+              label={s.expectedVerdictLabel}
+              help={s.expectedVerdictHelp}
+              requiredText={s.required}
+            >
+              <select
+                className="v-mfs__input"
+                value={state.layer2.expected_verdict}
+                onChange={(e) =>
+                  updateLayer('layer2', 'expected_verdict', e.target.value)
+                }
+              >
+                <option value="">{s.expectedVerdictUnset}</option>
+                <option value="pass">pass</option>
+                <option value="fail">fail</option>
+              </select>
+            </Field>
+          </>
+        ) : (
+          <>
+            <Field
+              label={s.imageLabel}
+              error={errors['layer3.image']}
+              required
+              requiredText={s.required}
+            >
+              <input
+                type="text"
+                className="v-mfs__input"
+                value={state.layer3.image}
+                onChange={(e) => updateLayer('layer3', 'image', e.target.value)}
+                placeholder="ghcr.io/example-org/example-recipe-rr:latest"
+              />
+            </Field>
+            <Field
+              label={s.dockerfileLabel}
+              help={s.dockerfileHelp}
+              requiredText={s.required}
+            >
+              <input
+                type="text"
+                className="v-mfs__input"
+                value={state.layer3.dockerfile}
+                onChange={(e) => updateLayer('layer3', 'dockerfile', e.target.value)}
+                placeholder="./Dockerfile"
+              />
+            </Field>
+            <Field
+              label={s.expectedVerdictLabel}
+              help={s.expectedVerdictHelp}
+              requiredText={s.required}
+            >
+              <select
+                className="v-mfs__input"
+                value={state.layer3.expected_verdict}
+                onChange={(e) =>
+                  updateLayer('layer3', 'expected_verdict', e.target.value)
+                }
+              >
+                <option value="">{s.expectedVerdictUnset}</option>
+                <option value="pass">pass</option>
+                <option value="fail">fail</option>
+              </select>
+            </Field>
+          </>
+        )}
+      </fieldset>
+
+      {/* Action row */}
+      <div className="v-mfs__actions">
+        <button
+          type="button"
+          className="v-mfs__btn v-mfs__btn--primary"
+          onClick={generate}
+          disabled={hasErrors}
+        >
+          {s.generate}
+        </button>
+        <button
+          type="button"
+          className="v-mfs__btn v-mfs__btn--ghost"
+          onClick={reset}
+        >
+          {s.reset}
+        </button>
+      </div>
+
+      {/* Output */}
+      <p className="v-mfs__eyebrow v-mfs__eyebrow--output">{s.outputEyebrow}</p>
+      {output ? (
+        <>
+          <pre className="v-mfs__output">{output}</pre>
+          <div className="v-mfs__actions">
+            <button
+              type="button"
+              className="v-mfs__btn v-mfs__btn--primary"
+              onClick={copy}
+            >
+              {copied ? s.copied : s.copy}
+            </button>
+            <button
+              type="button"
+              className="v-mfs__btn v-mfs__btn--ghost"
+              onClick={download}
+            >
+              {s.download}
+            </button>
+          </div>
+        </>
+      ) : (
+        <p className="v-mfs__empty">{s.emptyOutput}</p>
+      )}
+      <p className="v-mfs__spec-link">
+        <a
+          href={
+            lang === 'ja'
+              ? '/vivarium/ja/spec/manifest-v1'
+              : '/vivarium/spec/manifest-v1'
+          }
+        >
+          {s.specLink}
+        </a>
+      </p>
+    </div>
+  );
+}
+
+export default ManifestScaffolder;

--- a/docs/components/manifest-scaffolder.css
+++ b/docs/components/manifest-scaffolder.css
@@ -1,0 +1,247 @@
+/* Phase 6 M.1 — manifest scaffolder. Tokens inherit from page-chrome.css. */
+
+.v-mfs {
+  margin: 1.25rem 0 2.5rem;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--vh-text);
+}
+
+.v-mfs__eyebrow {
+  display: block;
+  margin: 0 0 0.85rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--vh-accent-teal);
+}
+
+.v-mfs__eyebrow--output {
+  margin-top: 2rem;
+}
+
+/* ---------- Group / fieldset ---------- */
+
+.v-mfs__group {
+  border: 1px solid var(--vh-hairline);
+  border-radius: 8px;
+  background: var(--vh-card-bg);
+  padding: 1rem 1.1rem 0.85rem;
+  margin: 0 0 1rem;
+}
+
+.v-mfs__group-legend {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vh-text-muted);
+  padding: 0 0.4rem;
+}
+
+/* ---------- Fields ---------- */
+
+.v-mfs__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin: 0.85rem 0;
+}
+
+.v-mfs__label {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: var(--vh-text);
+}
+
+.v-mfs__label-name {
+  letter-spacing: 0.04em;
+}
+
+.v-mfs__required {
+  font-size: 0.65rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--vh-accent-coral);
+}
+
+.v-mfs__input {
+  padding: 0.5rem 0.7rem;
+  background: rgba(0, 0, 0, 0.04);
+  border: 1px solid var(--vh-hairline);
+  border-radius: 6px;
+  color: var(--vh-text);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  outline: none;
+}
+
+html.dark .v-mfs__input {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.v-mfs__input:focus {
+  border-color: var(--vh-accent-teal);
+  background: var(--vh-card-bg-hover);
+}
+
+.v-mfs__input--textarea {
+  resize: vertical;
+  min-height: 4rem;
+}
+
+.v-mfs__field--err .v-mfs__input {
+  border-color: var(--vh-accent-coral);
+}
+
+.v-mfs__error {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--vh-accent-coral);
+}
+
+.v-mfs__help {
+  font-size: 0.75rem;
+  color: var(--vh-text-dim);
+  line-height: 1.4;
+}
+
+.v-mfs__help code {
+  font-family: 'JetBrains Mono', monospace;
+  background: var(--vh-card-bg-hover);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  font-size: 0.78rem;
+}
+
+/* ---------- Layer chips ---------- */
+
+.v-mfs__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.v-mfs__chip {
+  padding: 0.35rem 0.85rem;
+  border: 1px solid var(--vh-hairline-strong);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--vh-text-muted);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: all 120ms ease;
+}
+
+.v-mfs__chip:hover {
+  border-color: var(--vh-text-dim);
+  color: var(--vh-text);
+}
+
+.v-mfs__chip--on {
+  color: var(--vh-text);
+  border-color: var(--vh-accent-teal);
+  background: rgba(0, 212, 170, 0.12);
+}
+
+.v-mfs__placeholder {
+  margin: 0.4rem 0;
+  font-size: 0.85rem;
+  color: var(--vh-text-dim);
+  font-style: italic;
+}
+
+/* ---------- Actions ---------- */
+
+.v-mfs__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 1rem 0 0.5rem;
+}
+
+.v-mfs__btn {
+  padding: 0.5rem 0.95rem;
+  border: 1px solid var(--vh-hairline-strong);
+  border-radius: 6px;
+  background: var(--vh-card-bg);
+  color: var(--vh-text);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 120ms ease;
+}
+
+.v-mfs__btn:hover:not(:disabled) {
+  border-color: var(--vh-accent-teal);
+  background: var(--vh-card-bg-hover);
+}
+
+.v-mfs__btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.v-mfs__btn--primary {
+  border-color: var(--vh-accent-teal);
+  color: var(--vh-accent-teal);
+}
+
+.v-mfs__btn--ghost {
+  background: transparent;
+}
+
+/* ---------- Output ---------- */
+
+.v-mfs__output {
+  margin: 0.5rem 0;
+  padding: 0.85rem 1rem;
+  background: rgba(4, 34, 28, 0.5);
+  color: var(--vh-text);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  line-height: 1.55;
+  border-radius: 6px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: auto;
+  max-height: 24rem;
+}
+
+:root:not(.dark) .v-mfs__output {
+  background: rgba(4, 34, 28, 0.06);
+}
+
+.v-mfs__empty {
+  margin: 0.5rem 0;
+  padding: 1rem 1.1rem;
+  background: var(--vh-card-bg);
+  border-radius: 6px;
+  border: 1px dashed var(--vh-hairline-strong);
+  color: var(--vh-text-dim);
+  font-style: italic;
+  font-size: 0.85rem;
+}
+
+.v-mfs__empty code {
+  font-family: 'JetBrains Mono', monospace;
+  background: var(--vh-card-bg-hover);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+}
+
+.v-mfs__spec-link {
+  margin: 1.25rem 0 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  color: var(--vh-text-dim);
+}
+
+.v-mfs__spec-link a {
+  color: var(--vh-accent-teal);
+  text-decoration: underline;
+}

--- a/docs/docs/en/spec/_meta.json
+++ b/docs/docs/en/spec/_meta.json
@@ -1,0 +1,37 @@
+[
+  {
+    "type": "file",
+    "name": "index",
+    "label": "Spec overview"
+  },
+  {
+    "type": "file",
+    "name": "contract-v1",
+    "label": "Contract v1"
+  },
+  {
+    "type": "file",
+    "name": "manifest-v1",
+    "label": "Manifest v1"
+  },
+  {
+    "type": "file",
+    "name": "manifest-create",
+    "label": "Manifest scaffolder"
+  },
+  {
+    "type": "file",
+    "name": "recipes-index-v1",
+    "label": "Recipes index v1"
+  },
+  {
+    "type": "file",
+    "name": "consumer-workflow",
+    "label": "Consumer workflow"
+  },
+  {
+    "type": "file",
+    "name": "branch-fix-pipeline",
+    "label": "Branch-fix pipeline"
+  }
+]

--- a/docs/docs/en/spec/manifest-create.mdx
+++ b/docs/docs/en/spec/manifest-create.mdx
@@ -1,0 +1,17 @@
+---
+pageType: doc
+title: Manifest scaffolder
+---
+
+import { Page, PageHero } from '../../../components/PageChrome';
+import { ManifestScaffolder } from '../../../components/ManifestScaffolder';
+
+<Page>
+  <PageHero
+    eyebrow="// MANIFEST · CREATE"
+    title={<>Generate a <code>.vivarium/manifest.toml</code>.</>}
+    sub={<>Form-driven generator for the Manifest v1 file. Fill in the fields, click Generate, copy the TOML into <code>.vivarium/manifest.toml</code> in your repository — or download the file directly. The schema lives at <code>/vivarium/spec/manifest-v1</code>; this page is the interactive companion.</>}
+  />
+
+  <ManifestScaffolder lang="en" />
+</Page>

--- a/docs/docs/ja/spec/_meta.json
+++ b/docs/docs/ja/spec/_meta.json
@@ -1,0 +1,37 @@
+[
+  {
+    "type": "file",
+    "name": "index",
+    "label": "Spec 概要"
+  },
+  {
+    "type": "file",
+    "name": "contract-v1",
+    "label": "Contract v1"
+  },
+  {
+    "type": "file",
+    "name": "manifest-v1",
+    "label": "Manifest v1"
+  },
+  {
+    "type": "file",
+    "name": "manifest-create",
+    "label": "マニフェスト作成"
+  },
+  {
+    "type": "file",
+    "name": "recipes-index-v1",
+    "label": "Recipes index v1"
+  },
+  {
+    "type": "file",
+    "name": "consumer-workflow",
+    "label": "コンシューマーワークフロー"
+  },
+  {
+    "type": "file",
+    "name": "branch-fix-pipeline",
+    "label": "ブランチ修正パイプライン"
+  }
+]

--- a/docs/docs/ja/spec/manifest-create.mdx
+++ b/docs/docs/ja/spec/manifest-create.mdx
@@ -1,0 +1,17 @@
+---
+pageType: doc
+title: マニフェスト作成
+---
+
+import { Page, PageHero } from '../../../components/PageChrome';
+import { ManifestScaffolder } from '../../../components/ManifestScaffolder';
+
+<Page>
+  <PageHero
+    eyebrow="// MANIFEST · CREATE"
+    title={<><code>.vivarium/manifest.toml</code> を生成する。</>}
+    sub={<>Manifest v1 ファイル用のフォーム駆動ジェネレーター。フィールドを埋めて「生成」を押し、TOML をリポジトリの <code>.vivarium/manifest.toml</code> にコピーするか、ファイルとして直接ダウンロードする。スキーマは <code>/vivarium/ja/spec/manifest-v1</code> にある。このページはその対話的コンパニオン。</>}
+  />
+
+  <ManifestScaffolder lang="ja" />
+</Page>


### PR DESCRIPTION

Adds `/{,ja/}spec/manifest-create`, a form-driven generator
that walks an external contributor through the Manifest v1
fields (ADR-0015) and emits a copy-able / downloadable
`.vivarium/manifest.toml`.

Per ADR-0026 §1, the form is hand-rolled rather than driven by
a runtime JSON Schema → form library. Manifest v1 has 6 fields,
~150-line schema; pulling in `@rjsf/core` or `JSONForms` (~40-100
KB of bundle weight, plus styling that doesn't match the V.2
PageChrome family) does not earn its keep at this scale.
ADR-0017 §M.1's "JSON Schema drives the form" wording is revised
at the sub-decision level: the schema remains canonical at
`docs/public/spec/manifest.schema.json`, the scaffolder reads it
at *build time* for labels and help text, and the field
ordering is hard-coded (intent preserved, mechanism revised —
same posture as ADR-0022 D2/D3 / ADR-0024 §1).

TOML emission is also hand-rolled (~30 lines of string
formatting in `docs/components/ManifestScaffolder.tsx`'s
`buildToml()`). Manifest v1's bounded shape — 8 fields max,
strings/integers/enums only — fits hand-rolled escaping cleanly.
Multi-line `description` uses `"""…"""` form when the input
contains a newline; backslash and double-quote are escaped
inside `"…"` strings. No new runtime dependency.

Validation matches the schema's shape: slug regex, layer chip
(1/2/3, exactly one), bug.issue non-negative integer, URL
shape on `bug.upstream_url` and `layer1.page_url`, required-
field gating on the "Generate TOML" button. Errors render
inline next to the field. The output `<pre>` carries Copy
(`navigator.clipboard.writeText`) and Download (`Blob` →
`a[download]`) buttons.

`docs/docs/{en,ja}/spec/_meta.json` newly added to control
sidebar order: index → Contract v1 → Manifest v1 →
Manifest scaffolder → Recipes index v1 → Consumer workflow →
Branch-fix pipeline. Rationale: scaffolder sits next to the
prose spec it complements.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/150).
* #151
* __->__ #150