### PR TITLE
feat(mcp): phase 6 X.2 — match_error tool

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,8 +1,13 @@
-// MCP server wiring — registers the three v1 tools (list_recipes,
-// get_recipe, lookup_verdict) and connects a stdio transport.
+// MCP server wiring — registers the v1 tools and connects a stdio
+// transport.
 //
-// See ADR-0019 §3 for the tool surface decision and §1 for the
-// stdio-transport choice.
+// Tool surface:
+//   list_recipes / get_recipe / lookup_verdict — ADR-0019 §3 (X.1, v0.1).
+//   match_error                                 — Phase 6 X.2, mirrors the
+//                                                 docs S.2 matcher
+//                                                 (ADR-0025 §Neutral).
+//
+// See ADR-0019 §1 for the stdio-transport choice.
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -21,6 +26,11 @@ import {
   LOOKUP_VERDICT_TOOL,
   lookupVerdict,
 } from './tools/lookup_verdict.js';
+import {
+  MATCH_ERROR_TOOL,
+  matchError,
+  type MatchErrorArgs,
+} from './tools/match_error.js';
 
 const SERVER_NAME = 'vivarium-mcp';
 // Keep in sync with package.json + jsr.json. Updated by the publish
@@ -35,7 +45,12 @@ export function createServer(): Server {
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: [LIST_RECIPES_TOOL, GET_RECIPE_TOOL, LOOKUP_VERDICT_TOOL],
+    tools: [
+      LIST_RECIPES_TOOL,
+      GET_RECIPE_TOOL,
+      LOOKUP_VERDICT_TOOL,
+      MATCH_ERROR_TOOL,
+    ],
   }));
 
   server.setRequestHandler(CallToolRequestSchema, async (req) => {
@@ -53,6 +68,9 @@ export function createServer(): Server {
           break;
         case 'lookup_verdict':
           payload = await lookupVerdict(args as { slug: string });
+          break;
+        case 'match_error':
+          payload = await matchError(args as unknown as MatchErrorArgs);
           break;
         default:
           return {

--- a/packages/mcp-server/src/tools/match_error.ts
+++ b/packages/mcp-server/src/tools/match_error.ts
@@ -1,0 +1,180 @@
+// Phase 6 X.2 — match_error tool.
+//
+// Server-side mirror of the docs-site error → recipe matcher (Phase 6 S.2,
+// ADR-0025). The scoring rule is bit-identical:
+//   symptom segment match → +5
+//   tag segment match     → +3
+//   project / slug match  → +2
+// Recipes with score 0 are dropped. Ties broken by (layer asc, slug asc).
+//
+// ADR-0025 §Neutral named this lift explicitly:
+//   "A future X.2 ... could expose this matcher to agents. The scoring
+//    rule is identical, so an X.2 implementation would lift the function
+//    from ErrorRecipeMatcher.tsx into the MCP server."
+//
+// The lift is mechanical — no LLM, no fuzzy match, no synonym table.
+// AGENTS.md §3.3's mechanical-over-judgement rule carries through.
+
+import { getCatalogue } from '../catalogue.js';
+import type { RecipeEntry } from '../types.js';
+
+export interface MatchErrorArgs {
+  text: string;
+  limit?: number;
+}
+
+interface MatchedToken {
+  source: 'symptom' | 'tags' | 'project' | 'slug';
+  token: string;
+}
+
+interface ScoredRecipe {
+  recipe: RecipeEntry;
+  score: number;
+  matched: MatchedToken[];
+}
+
+export interface MatchErrorResult {
+  ok: true;
+  query_token_count: number;
+  total_recipes: number;
+  matches: ScoredRecipe[];
+}
+
+const MAX_INPUT_BYTES = 16 * 1024;
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+
+const STOPWORDS: ReadonlySet<string> = new Set([
+  'the', 'and', 'for', 'with', 'from', 'that', 'this', 'have',
+  'has', 'are', 'was', 'were', 'will', 'not', 'but', 'all',
+  'error', 'errors', 'exception', 'failed', 'failure', 'trace',
+  'traceback', 'stack', 'line', 'file', 'most', 'recent', 'call',
+  'です', 'ます', 'した', 'する', 'これ', 'それ', 'その', 'この',
+  'エラー', '例外', '失敗', 'スタック',
+]);
+
+function tokenise(input: string): string[] {
+  let trimmed = input;
+  if (trimmed.length > MAX_INPUT_BYTES) {
+    trimmed = trimmed.slice(trimmed.length - MAX_INPUT_BYTES);
+  }
+  const lower = trimmed.toLowerCase();
+  const raw = lower.split(/[^a-z0-9_]+/);
+  const tokens: string[] = [];
+  const seen = new Set<string>();
+  for (const t of raw) {
+    if (t.length < 3) continue;
+    if (STOPWORDS.has(t)) continue;
+    if (seen.has(t)) continue;
+    seen.add(t);
+    tokens.push(t);
+  }
+  return tokens;
+}
+
+function kebabSegments(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length >= 3 && !STOPWORDS.has(t));
+}
+
+function scoreRecipe(
+  recipe: RecipeEntry,
+  tokens: ReadonlySet<string>,
+): ScoredRecipe {
+  const matched: MatchedToken[] = [];
+  let score = 0;
+
+  if (recipe.symptom) {
+    for (const seg of kebabSegments(recipe.symptom)) {
+      if (tokens.has(seg)) {
+        score += 5;
+        matched.push({ source: 'symptom', token: seg });
+      }
+    }
+  }
+  for (const tag of recipe.tags ?? []) {
+    for (const seg of kebabSegments(tag)) {
+      if (tokens.has(seg)) {
+        score += 3;
+        matched.push({ source: 'tags', token: seg });
+      }
+    }
+  }
+  for (const seg of kebabSegments(recipe.project)) {
+    if (tokens.has(seg)) {
+      score += 2;
+      matched.push({ source: 'project', token: seg });
+    }
+  }
+  for (const seg of kebabSegments(recipe.slug)) {
+    if (tokens.has(seg)) {
+      score += 2;
+      matched.push({ source: 'slug', token: seg });
+    }
+  }
+
+  return { recipe, score, matched };
+}
+
+export async function matchError(
+  args: MatchErrorArgs,
+): Promise<MatchErrorResult | { ok: false; error: string }> {
+  const text = (args.text ?? '').trim();
+  if (!text) {
+    return { ok: false, error: 'missing required argument: text' };
+  }
+  const limit = Math.min(
+    Math.max(1, args.limit ?? DEFAULT_LIMIT),
+    MAX_LIMIT,
+  );
+
+  const tokens = tokenise(text);
+  const tokenSet = new Set(tokens);
+
+  const { recipes } = await getCatalogue();
+  const scored = recipes
+    .map((r) => scoreRecipe(r, tokenSet))
+    .filter((s) => s.score > 0);
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    if (a.recipe.layer !== b.recipe.layer)
+      return a.recipe.layer - b.recipe.layer;
+    return a.recipe.slug.localeCompare(b.recipe.slug);
+  });
+
+  return {
+    ok: true,
+    query_token_count: tokens.length,
+    total_recipes: recipes.length,
+    matches: scored.slice(0, limit),
+  };
+}
+
+export const MATCH_ERROR_TOOL = {
+  name: 'match_error',
+  description:
+    "Find Vivarium recipes that match a pasted error message or stack trace by mechanical token overlap (no LLM, no fuzzy match). The text is tokenised, lowercase-compared against each recipe's symptom (weight 5 per segment), tags (3), project (2), and slug (2). Recipes with score > 0 are returned in descending score order; ties broken by (layer asc, slug asc). Returns the recipe entry plus the matched tokens for each candidate so agents can show which fragments hit. Pair with `get_recipe` to drill into a specific result, or `list_recipes` for unfiltered browsing.",
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      text: {
+        type: 'string' as const,
+        description:
+          'Error message, stack trace, or any free-text fragment to match against the catalogue. Tokenised on non-alphanumeric runs after lowercasing; tokens shorter than 3 chars and a fixed English+Japanese stopword list are dropped. Input longer than 16 KB is truncated from the front.',
+      },
+      limit: {
+        type: 'integer' as const,
+        minimum: 1,
+        maximum: 50,
+        default: 10,
+        description:
+          'Maximum number of matches to return. Defaults to 10; capped at 50.',
+      },
+    },
+    required: ['text'],
+  },
+} as const;

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -22,6 +22,13 @@ export interface RecipeEntry {
   page_url: string;
   verdict_url?: string;
   source_url: string;
+  // Facet overlay added by ADR-0024 §2; always emitted by the generator
+  // but optional here so consumers reading older bundled snapshots (with
+  // no overlay merge) keep working.
+  language?: string;
+  symptom?: string;
+  severity?: string;
+  tags?: string[];
 }
 
 export interface RecipesIndex {

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -8,6 +8,7 @@ import { _resetCacheForTesting, INDEX_URL } from '../src/catalogue.ts';
 import { getRecipe } from '../src/tools/get_recipe.ts';
 import { listRecipes } from '../src/tools/list_recipes.ts';
 import { lookupVerdict } from '../src/tools/lookup_verdict.ts';
+import { matchError } from '../src/tools/match_error.ts';
 
 const FIXTURE_INDEX = {
   index: 'v1',
@@ -21,6 +22,10 @@ const FIXTURE_INDEX = {
       title: 'pandas-dev/pandas#56679',
       page_url: 'https://example.invalid/repro/pandas-56679/',
       source_url: 'https://example.invalid/src/pandas-56679',
+      language: 'python',
+      symptom: 'dtype-mismatch',
+      severity: 'regression',
+      tags: ['empty-series', 'empty-dataframe', 'type-inference'],
     },
     {
       slug: 'bash-local-shadows-exit',
@@ -31,6 +36,10 @@ const FIXTURE_INDEX = {
       page_url: 'https://example.invalid/repro/bash-local-shadows-exit/',
       verdict_url: 'https://example.invalid/repro/bash-local-shadows-exit/verdict.json',
       source_url: 'https://example.invalid/src/bash-local-shadows-exit',
+      language: 'shell',
+      symptom: 'local-shadows-exit-status',
+      severity: 'footgun',
+      tags: ['command-substitution', 'exit-code'],
     },
     {
       slug: 'lost-update',
@@ -41,6 +50,10 @@ const FIXTURE_INDEX = {
       page_url: 'https://example.invalid/repro/lost-update/',
       verdict_url: 'https://example.invalid/repro/lost-update/verdict.json',
       source_url: 'https://example.invalid/src/lost-update',
+      language: 'c',
+      symptom: 'lost-update-data-race',
+      severity: 'datarace',
+      tags: ['rr-replay', 'deterministic'],
     },
   ],
 };
@@ -151,5 +164,64 @@ describe('lookup_verdict', () => {
   it('returns kind=not_found for unknown slug', async () => {
     const r = await lookupVerdict({ slug: 'does-not-exist' });
     assert.equal(r.kind, 'not_found');
+  });
+});
+
+describe('match_error', () => {
+  it('returns the highest-scoring recipe for a relevant error fragment', async () => {
+    const r = await matchError({
+      text: 'ValueError: dtype mismatch on empty Series in pandas DataFrame',
+    });
+    assert.equal('ok' in r && r.ok, true);
+    if ('ok' in r && r.ok) {
+      assert.equal(r.matches[0]!.recipe.slug, 'pandas-56679');
+      assert.ok(r.matches[0]!.score >= 5);
+    }
+  });
+
+  it('orders multiple matches by score descending', async () => {
+    const r = await matchError({
+      text: 'pandas dtype mismatch and bash local exit-code shadows',
+    });
+    if ('ok' in r && r.ok) {
+      assert.ok(r.matches.length >= 2);
+      for (let i = 1; i < r.matches.length; i++) {
+        assert.ok(
+          r.matches[i - 1]!.score >= r.matches[i]!.score,
+          'scores must be non-increasing',
+        );
+      }
+    }
+  });
+
+  it('returns empty matches for fully unrelated text', async () => {
+    const r = await matchError({ text: 'completely unrelated random words' });
+    if ('ok' in r && r.ok) {
+      assert.equal(r.matches.length, 0);
+    }
+  });
+
+  it('returns ok:false on missing text', async () => {
+    const r = await matchError({ text: '' });
+    assert.equal('ok' in r && r.ok, false);
+  });
+
+  it('respects the limit argument', async () => {
+    const r = await matchError({
+      text: 'pandas dtype mismatch bash local exit pthread race',
+      limit: 1,
+    });
+    if ('ok' in r && r.ok) {
+      assert.equal(r.matches.length, 1);
+    }
+  });
+
+  it('exposes the matched tokens per result', async () => {
+    const r = await matchError({ text: 'dtype mismatch' });
+    if ('ok' in r && r.ok && r.matches.length > 0) {
+      const top = r.matches[0]!;
+      const tokens = top.matched.map((m) => m.token);
+      assert.ok(tokens.includes('dtype') || tokens.includes('mismatch'));
+    }
   });
 });

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ESNext"],
+    "types": ["node", "bun"],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,


### PR DESCRIPTION

Adds a fourth tool (`match_error`) to `@aletheia-works/vivarium-mcp`,
exposing the same recipe-matching capability as the docs-side
S.2 page (ADR-0025) over MCP for AI-agent clients (Claude Code,
Cline, Cursor, Continue, etc.). Pre-blessed by ADR-0025 §Neutral
("a future X.2 ... could expose this matcher to agents — the
scoring rule is identical, so an X.2 implementation would lift
the function from ErrorRecipeMatcher.tsx into the MCP server").

The lift is mechanical and bit-identical:
  symptom segment match → +5
  tag segment match     → +3
  project / slug match  → +2
Recipes with score 0 are dropped; ties broken by
(layer asc, slug asc); same 16 KB front-truncation cap and
English+Japanese stopword list as the docs surface.

`packages/mcp-server/src/tools/match_error.ts` carries the
implementation. Inputs: `text` (required, non-empty) and
optional `limit` (1–50, default 10). Output:
`{ ok, query_token_count, total_recipes, matches: [{recipe,
score, matched: [{source, token}]}] }` — agents see both the
ranked candidates and which fragments hit each one, so a
follow-up `get_recipe` call has actionable provenance.

`packages/mcp-server/src/types.ts` extends `RecipeEntry` with
optional `language` / `symptom` / `severity` / `tags` mirroring
the docs S.1 facet overlay (ADR-0024 §2). Per ADR-0019 §4 +
ADR-0018 minor-revision policy, recipes-index v1 stays at the
`"v1"` literal — older bundled snapshots without the overlay
keep working with `tags` defaulting to empty.

`packages/mcp-server/src/server.ts` registers the tool in the
`ListTools` response and dispatches `match_error` calls to the
new module. 6 tests added; total 24/24 passing.

Side fix to `packages/mcp-server/tsconfig.json`: add `types:
["node", "bun"]`. TS 6.0.3 + @types/node 25 doesn't auto-
include node + bun globals when both type packages are
installed, breaking `tsc` build for `fetch` / `console` /
`process` references in pre-existing files (`catalogue.ts`,
`index.ts`). The explicit `types` field was probably always
needed for this combination; the CI matrix at X.1 ship time
must have happened to use a permissive earlier @types/node /
typescript version. Verified build passes again.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/151).
* __->__ #151
* #150