### PR TITLE
chore(infra): close Phase 6 milestone (V + R + S + M + X + L all shipped)

### DIFF
--- a/docs/docs/en/roadmap.mdx
+++ b/docs/docs/en/roadmap.mdx
@@ -72,8 +72,8 @@ import {
           body: 'Contract v1 published as an external standard with JSON Schema and CI enforcement. Manifest v1 + three reference TOML manifests so external repos can declare a Vivarium-runnable reproduction with a single .vivarium/manifest.toml. Reusable verdict-capture GitHub Actions workflow. Verdict drift detection on the weekly cron. Issue-triage tooling deferred without adoption.',
         },
         {
-          lead: 'Phase 6 — Usability and visual layer. ACTIVE.',
-          body: 'Visual redesign + reusable component library. Branch-fix verdict pipeline so an AI-generated fix can be checked against a recipe before opening a PR. Faceted gallery search. Manifest authoring UX. Vivarium MCP server (already shipped, dual-published to JSR + npm). Japanese ⇄ English i18n. Closure rule: V + R + at least one of S / M / X / L ships.',
+          lead: 'Phase 6 — Usability and visual layer. CLOSED 2026-05-02.',
+          body: 'Visual redesign + reusable component library landed (Stitch-driven mocks substituting for Claude Design after quota constraints). Full Japanese ⇄ English i18n with symmetric URL trees and translated spec pages. Reproduction comparison: Contract v1 evidence surface, branch-fix verdict capture pipeline, side-by-side comparison page. Faceted recipe gallery + paste-an-error → ranked-candidates matcher. Interactive manifest scaffolder. Vivarium MCP server with four tools (list_recipes, get_recipe, lookup_verdict, match_error). All six sub-streams (V, R, S, M, X, L) shipped at v1 scope; the closure rule (V + R + ≥1 of S/M/X/L) was satisfied four-times-over.',
         },
       ]}
     />

--- a/docs/docs/ja/roadmap.mdx
+++ b/docs/docs/ja/roadmap.mdx
@@ -71,8 +71,8 @@ import {
           body: 'Contract v1 を JSON Schema と CI 強制付きの外部標準として公開。Manifest v1 と 3 つのリファレンス TOML マニフェストにより、外部リポジトリが `.vivarium/manifest.toml` 1 ファイルで Vivarium 実行可能な再現を宣言できるようになった。再利用可能な verdict キャプチャ用 GitHub Actions ワークフロー。週次 cron による verdict ドリフト検出。Issue トリアージツールは採用がないため保留。',
         },
         {
-          lead: 'Phase 6 — ユーザビリティとビジュアルレイヤー。ACTIVE。',
-          body: 'ビジュアルリデザイン + 再利用可能コンポーネントライブラリ。AI が生成した修正を PR を開く前にレシピに対して検証できる branch-fix verdict パイプライン。ファセット付きギャラリー検索。マニフェスト作成 UX。Vivarium MCP サーバ（出荷済み、JSR + npm にデュアル公開）。日本語 ⇄ 英語 i18n。クローズルール: V + R + S/M/X/L のうち少なくとも 1 つの出荷。',
+          lead: 'Phase 6 — ユーザビリティとビジュアルレイヤー。2026-05-02 CLOSED。',
+          body: 'ビジュアルリデザイン + 再利用可能コンポーネントライブラリ出荷（Claude Design の利用枠制限を回避するため Stitch 駆動のモックで代替）。対称 URL ツリーと翻訳済み仕様ページを伴う完全な日本語 ⇄ 英語 i18n。再現比較: Contract v1 evidence サーフェス、branch-fix verdict キャプチャパイプライン、横並び比較ページ。ファセット付きレシピギャラリー + エラーを貼り付けると候補レシピがランク順に出るマッチャー。対話的なマニフェストスキャフォルダー。Vivarium MCP サーバには 4 つのツール（list_recipes、get_recipe、lookup_verdict、match_error）。6 つすべてのサブストリーム（V, R, S, M, X, L）が v1 スコープで出荷され、クローズルール（V + R + S/M/X/L のうち少なくとも 1 つ）は 4 重に充足された。',
         },
       ]}
     />

--- a/infra/github/main.tf
+++ b/infra/github/main.tf
@@ -362,7 +362,8 @@ locals {
     }
     "Phase 6 — Usability and visual layer" = {
       description = "Interaction layer above existing primitives: visual redesign (Claude Design mock + component library), reproduction comparison (branch-fix vs original verdict), search & discoverability, manifest authoring UX, MCP server, i18n. Closes when V + R + at least one of S/M/X/L ships."
-      state       = "open"
+      state       = "closed"
+      due_date    = "2026-05-02"
     }
   }
 }


### PR DESCRIPTION

Marks the Phase 6 milestone as closed with due_date 2026-05-02 in
`infra/github/main.tf` (the consolidated location after PR #153)
and updates the public roadmap entry in `docs/docs/{en,ja}/roadmap.mdx`
from "ACTIVE" to "CLOSED 2026-05-02".

What shipped during Phase 6:
- V — visual layer + component library (PR #143; Stitch-driven
  mocks substituted for Claude Design after quota constraints).
- R — Contract v1 rev2 evidence surface (PR #128, R.1) +
  branch-fix verdict capture pipeline (PR #141, R.2) +
  comparison page UI (PR #147, R.3).
- S — faceted recipe gallery (PR #148, S.1) +
  error → recipe matcher (PR #149, S.2).
- M — interactive manifest scaffolder (PR #150, M.1).
- X — Vivarium MCP server v0.1 with three tools (PRs #129/#130,
  X.1) + match_error tool exposing S.2's matching capability over
  MCP (PR #151, X.2).
- L — full Japanese ⇄ English i18n with symmetric URL trees
  (PRs #142 + #143).

The closure rule from the Phase 6 opener was "V + R + at least one
of S/M/X/L". All six sub-streams shipped at v1 scope, four-times-
over satisfying the rule. Per-sub-stream deferrals (V's residual
visual polish, R.2 Path A for Layer 1 source-substitution, ajv-
standalone validators, Pagefind full-text search, MCP match_error
synonym/fuzzy v2, and editorial spec-page footer updates) are
queued for Phase 7 framing rather than blocking this close.

The IaC apply (`tofu apply` against the remote state) propagates
the milestone state change to GitHub.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/152).
* __->__ #152
* #154
* #151
* #150