### PR TITLE
feat(ci): test-mcp workflow + ci:mcp local task for PR-time MCP test runs

### DIFF
--- a/.github/workflows/test-mcp.yml
+++ b/.github/workflows/test-mcp.yml
@@ -1,0 +1,55 @@
+name: Test MCP
+
+# Verifies that the @aletheia-works/vivarium-mcp package's test suite
+# (`bun test` against `packages/mcp-server/tests/*.test.ts`) still
+# passes on every PR that touches the MCP server. Without this, MCP
+# regressions would only surface at tag-push time via
+# `publish-mcp.yml`, by which point a broken release is already
+# happening.
+#
+# Tooling: single-tool job (bun only). Uses `oven-sh/setup-bun`
+# directly rather than the local setup-mise composite — there is
+# nothing here that needs the rest of mise.toml.
+#
+# Fork-PR safe: uses `pull_request` (NOT `pull_request_target`), so
+# the workflow runs on the fork's code with the fork's GITHUB_TOKEN.
+# No secrets are needed (test runs are read-only and produce no
+# external side effects), so no permissions or credentials need to
+# be elevated.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/mcp-server/**'
+      - '.github/workflows/test-mcp.yml'
+
+permissions:
+  contents: read
+
+# Only keep the most recent test run per PR. If a new commit
+# supersedes an earlier one, cancel the stale run to save Actions
+# minutes.
+concurrency:
+  group: test-mcp-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test MCP server
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/mcp-server
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install + test
+        run: |
+          bun install --frozen-lockfile
+          bun run test

--- a/mise.toml
+++ b/mise.toml
@@ -281,10 +281,18 @@ bunx playwright install --with-deps chromium
 bun run test
 '''
 
+[tasks."ci:mcp"]
+description = "Local equivalent of test-mcp.yml"
+dir = "packages/mcp-server"
+run = '''
+bun install --frozen-lockfile
+bun run test
+'''
+
 [tasks."ci:commitlint"]
 description = "Lint the most recent commit message against Conventional Commits"
 run = "bunx commitlint --from HEAD~1 --to HEAD --verbose"
 
 [tasks."ci:all"]
-description = "Run all local CI tasks (docs + repro + commitlint)"
-depends = ["ci:docs", "ci:repro", "ci:commitlint"]
+description = "Run all local CI tasks (docs + mcp + repro + commitlint)"
+depends = ["ci:docs", "ci:mcp", "ci:repro", "ci:commitlint"]


### PR DESCRIPTION

Adds `.github/workflows/test-mcp.yml`, a `pull_request`-triggered
workflow that runs the `@aletheia-works/vivarium-mcp` test suite
(`bun test` against `packages/mcp-server/tests/*.test.ts`) on every
PR that touches `packages/mcp-server/**` or the workflow itself.

Without this, MCP regressions only surfaced at tag-push time via
`publish-mcp.yml`, by which point a broken release is already in
flight. PR-time CI shifts the signal left.

Fork-PR safe by construction: uses `pull_request` (not
`pull_request_target`), `permissions: contents: read`, no secrets,
single-tool job (`oven-sh/setup-bun` + `bun install/test`). Fork
contributors get the same CI gate as in-repo PRs.

`mise.toml` gains `[tasks."ci:mcp"]` mirroring the workflow's
shell, and `[tasks."ci:all"]` is updated to depend on it. This
follows the AGENTS.md §4.14 "convergence in both directions"
rule — the canonical local entry point matches CI line-for-line.

Future packages with their own test suites get their own
`test-<package>.yml` workflow + `ci:<package>` mise task following
the same pattern (test-docs-build.yml ↔ ci:docs, repro-regression.yml
↔ ci:repro, test-mcp.yml ↔ ci:mcp, etc.).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/154).
* __->__ #154
* #150