### PR TITLE
feat(meta): phase 7 opener — first-30-minutes onboarding scope + A6 editorial follow-up

### DIFF
--- a/docs/docs/en/roadmap.mdx
+++ b/docs/docs/en/roadmap.mdx
@@ -75,6 +75,10 @@ import {
           lead: 'Phase 6 — Usability and visual layer. CLOSED 2026-05-02.',
           body: 'Visual redesign + reusable component library landed (Stitch-driven mocks substituting for Claude Design after quota constraints). Full Japanese ⇄ English i18n with symmetric URL trees and translated spec pages. Reproduction comparison: Contract v1 evidence surface, branch-fix verdict capture pipeline, side-by-side comparison page. Faceted recipe gallery + paste-an-error → ranked-candidates matcher. Interactive manifest scaffolder. Vivarium MCP server with four tools (list_recipes, get_recipe, lookup_verdict, match_error). All six sub-streams (V, R, S, M, X, L) shipped at v1 scope; the closure rule (V + R + ≥1 of S/M/X/L) was satisfied four-times-over.',
         },
+        {
+          lead: 'Phase 7 — First-30-minutes onboarding. ACTIVE.',
+          body: 'Turn "primitives are usable" (Phase 6) into "a stranger can pick this up cold". UI brush-up (V′ — information design, layout flow, visual-token revisit, component graduation) and onboarding documentation (D — getting started, integration guide, AI-agent setup, glossary) are co-defined: where the docs hit a wall, the UI is wrong. AI-slop verification (B3) wires the existing R.2 Path A + R.3 comparison + MCP match_error into one end-to-end walkthrough so an AI agent can drive "did my candidate fix actually work?" cold. A-tail clears Phase 6 leftovers: ajv-standalone migration for the verdict + manifest validators, and match_error v2 (synonym table, fuzzy match, language-specific stopwords). Phase closes when V′ + D + B3 ship; the A-tail is optional.',
+        },
       ]}
     />
   </Section>

--- a/docs/docs/en/spec/branch-fix-pipeline.md
+++ b/docs/docs/en/spec/branch-fix-pipeline.md
@@ -94,8 +94,10 @@ visible on the run page:
 | exit code | (e.g.) 0 | (e.g.) 1 |
 
 …followed by a one-line "matches expected" / "does NOT match
-expected" line for the `expected_verdict` assertion. The summary is
-intentionally a stand-in for the R.3 UI until that ships; the
+expected" line for the `expected_verdict` assertion. The Markdown
+summary is the at-a-glance view in the workflow run page; for the
+side-by-side comparison surface, drop the workflow artefact zip on
+the [comparison page](../repro/compare.mdx) (file-drop or paste). The
 artefact is the source of truth either way.
 
 ## What this pipeline does **not** do
@@ -121,6 +123,9 @@ artefact is the source of truth either way.
 
 ## See also
 
+- [Comparison page](../repro/compare.mdx) — the R.3 side-by-side UI
+  that consumes this pipeline's artefact bundle (file-drop, URL
+  params, or JSON paste).
 - [Contract v1](./contract-v1.md) — the verdict surface this
   pipeline emits and consumes.
 - [`verdict.schema.json`](https://github.com/aletheia-works/vivarium/blob/main/docs/public/spec/verdict.schema.json) —

--- a/docs/docs/en/spec/recipes-index-v1.md
+++ b/docs/docs/en/spec/recipes-index-v1.md
@@ -59,6 +59,10 @@ URL: <https://aletheia-works.github.io/vivarium/api/recipes.json>
 | `page_url` | URI | ✅ | Live reproduction page (Layer 1: WASM page; Layer 2 / 3: docker-run instructions page). |
 | `verdict_url` | URI | ⏳ | Layer 2 / 3 only — deployed `verdict.json` snapshot. Layer 1 verdicts are produced live in-page and have no static snapshot. |
 | `source_url` | URI | ✅ | GitHub link to the recipe directory. |
+| `language` | string | ⏳ | Optional. Primary implementation language, lowercase (e.g. `"python"`, `"rust"`, `"shell"`). Sourced from the [`docs/data/recipe-facets.json`](https://github.com/aletheia-works/vivarium/blob/main/docs/data/recipe-facets.json) overlay (per ADR-0024). Added in the 2026-05-03 revision. |
+| `symptom` | string (kebab-case) | ⏳ | Optional. Short symptom slug used by the error → recipe matcher (e.g. `"dtype-mismatch"`, `"ordering-non-transitive"`). Sourced from the facet overlay. Added 2026-05-03. |
+| `severity` | string | ⏳ | Optional. Free-form severity bucket (e.g. `"bug"`, `"regression"`, `"spec-violation"`, `"footgun"`). Sourced from the facet overlay. Added 2026-05-03. |
+| `tags` | array of strings | ⏳ | Optional. Free-form tag list scored by the matcher (e.g. `["sqlite3", "pragma", "foreign-keys"]`). Sourced from the facet overlay. Added 2026-05-03. |
 
 ## Versioning
 
@@ -66,13 +70,19 @@ The version is carried as `index = "v1"` on the top-level object. Per
 [ADR-0018](https://github.com/aletheia-works/vivarium/blob/main/_context/decisions/0018-contract-v1-evidence-extension.md)
 (private memo)'s minor-revision policy:
 
-- **Optional additive fields** (e.g. a future `language` field once Phase 6
-  stream S.1 lands frontmatter tags) ship as same-`v1` revisions; consumers
-  feature-detect them.
+- **Optional additive fields** ship as same-`v1` revisions; consumers
+  feature-detect them. Phase 6 stream S.1 added `language`, `symptom`,
+  `severity`, and `tags` under this rule (see revision history below).
 - **Breaking changes** (renamed fields, type changes, optional → required)
   require a v2 schema sibling and a separate ADR.
 
 There is no current v2.
+
+## Revision history
+
+| Date | Change | Reference |
+|---|---|---|
+| 2026-05-03 | Added optional `language`, `symptom`, `severity`, `tags` fields to recipe entries. Sourced from a centralised facet overlay (`docs/data/recipe-facets.json`), not per-recipe frontmatter. Backwards-compatible — v1 consumers ignore. | [ADR-0024](https://github.com/aletheia-works/vivarium/blob/main/_context/decisions/0024-phase6-s1-faceted-gallery.md) (private memo) |
 
 ## Generation
 
@@ -86,10 +96,14 @@ issue number; first dash-segment otherwise, with a small override map for
 recipes whose slug shape diverges).
 
 The output is tracked in git so PRs that add a recipe also show the index
-update in the diff. Phase 6 stream S.1 will replace the slug-derived
-heuristic with explicit per-recipe frontmatter, at which point the
-`project` and (eventually) `language` fields become first-class
-per-recipe declarations rather than slug-derived guesses.
+update in the diff. The optional facet fields (`language`, `symptom`,
+`severity`, `tags`) are merged in from
+[`docs/data/recipe-facets.json`](https://github.com/aletheia-works/vivarium/blob/main/docs/data/recipe-facets.json),
+a centralised overlay maintained by hand and reviewed in PR diff. The
+`project` field stays slug-derived in v1 — Phase 6 stream S.1 (per
+ADR-0024) deliberately rejected per-recipe frontmatter in favour of
+the centralised overlay, since the recipe count fits comfortably in a
+single reviewable file at this scale.
 
 ## Conformance
 

--- a/docs/docs/ja/roadmap.mdx
+++ b/docs/docs/ja/roadmap.mdx
@@ -74,6 +74,10 @@ import {
           lead: 'Phase 6 — ユーザビリティとビジュアルレイヤー。2026-05-02 CLOSED。',
           body: 'ビジュアルリデザイン + 再利用可能コンポーネントライブラリ出荷（Claude Design の利用枠制限を回避するため Stitch 駆動のモックで代替）。対称 URL ツリーと翻訳済み仕様ページを伴う完全な日本語 ⇄ 英語 i18n。再現比較: Contract v1 evidence サーフェス、branch-fix verdict キャプチャパイプライン、横並び比較ページ。ファセット付きレシピギャラリー + エラーを貼り付けると候補レシピがランク順に出るマッチャー。対話的なマニフェストスキャフォルダー。Vivarium MCP サーバには 4 つのツール（list_recipes、get_recipe、lookup_verdict、match_error）。6 つすべてのサブストリーム（V, R, S, M, X, L）が v1 スコープで出荷され、クローズルール（V + R + S/M/X/L のうち少なくとも 1 つ）は 4 重に充足された。',
         },
+        {
+          lead: 'Phase 7 — はじめの 30 分のオンボーディング。ACTIVE。',
+          body: 'Phase 6 の「プリミティブは使える」状態を「初見の人が冷めた状態から拾える」状態へ引き上げる。UI ブラッシュアップ（V′ — 情報設計、レイアウト動線、ビジュアルトークン磨き込み、コンポーネント graduation）とオンボーディングドキュメント（D — getting started、統合ガイド、AI エージェント設定、用語集）は表裏一体: ドキュメントが壁に当たるところは UI が間違っている証拠。AI-slop 検証（B3）は既存の R.2 Path A + R.3 比較ページ + MCP match_error を一本のエンドツーエンドウォークスルーに繋ぎ、AI エージェントが「自分の候補修正は本当に機能しているのか?」を冷めた状態から駆動できるようにする。A-tail は Phase 6 の残作業を片付ける: verdict + manifest validator の ajv-standalone マイグレ、および match_error v2（同義語テーブル、ファジーマッチ、言語別 stopword）。V′ + D + B3 が出荷したらクローズ。A-tail は optional。',
+        },
       ]}
     />
   </Section>

--- a/docs/docs/ja/spec/branch-fix-pipeline.md
+++ b/docs/docs/ja/spec/branch-fix-pipeline.md
@@ -88,7 +88,9 @@ R.3 比較ページ UI はこのバンドル構造を正確に消費する。
 | exit code | （例）0 | （例）1 |
 
 続いて `expected_verdict` アサーションの「期待通り」/ 「期待と不一致」を
-1 行で記述する。このサマリーは R.3 UI がリリースされるまでの代替品であり、
+1 行で記述する。Markdown サマリーはワークフロー実行ページ上の at-a-glance
+ビューだ。サイドバイサイド比較サーフェスが必要なら、ワークフローのアーティファクト
+zip を [比較ページ](../repro/compare.mdx) に file-drop または paste で渡す。
 どちらにしてもアーティファクトが真実のソースだ。
 
 ## このパイプラインがしないこと
@@ -113,6 +115,9 @@ R.3 比較ページ UI はこのバンドル構造を正確に消費する。
 
 ## 関連情報
 
+- [比較ページ](../repro/compare.mdx) — このパイプラインのアーティファクトバンドルを
+  消費する R.3 のサイドバイサイド UI（file-drop、URL パラメータ、JSON paste の
+  3 経路）。
 - [Contract v1](./contract-v1.md) — このパイプラインが出力・消費する verdict サーフェス。
 - [`verdict.schema.json`](https://github.com/aletheia-works/vivarium/blob/main/docs/public/spec/verdict.schema.json) —
   バンドルの両エントリが検証に使用するスキーマ。

--- a/docs/docs/ja/spec/recipes-index-v1.md
+++ b/docs/docs/ja/spec/recipes-index-v1.md
@@ -58,6 +58,10 @@ URL: <https://aletheia-works.github.io/vivarium/api/recipes.json>
 | `page_url` | URI | ✅ | ライブ再現ページ（Layer 1: WASM ページ。Layer 2 / 3: docker-run 手順ページ）。 |
 | `verdict_url` | URI | ⏳ | Layer 2 / 3 のみ——デプロイ済みの `verdict.json` スナップショット。Layer 1 の verdict はページ内でライブ生成されるため静的スナップショットを持たない。 |
 | `source_url` | URI | ✅ | レシピディレクトリへの GitHub リンク。 |
+| `language` | 文字列 | ⏳ | オプション。主要な実装言語の小文字表記（例: `"python"`、`"rust"`、`"shell"`）。[`docs/data/recipe-facets.json`](https://github.com/aletheia-works/vivarium/blob/main/docs/data/recipe-facets.json) のオーバーレイから供給される（ADR-0024 に準拠）。2026-05-03 リビジョンで追加。 |
+| `symptom` | 文字列（ケバブケース） | ⏳ | オプション。エラー → レシピマッチャーが利用する短い症状スラッグ（例: `"dtype-mismatch"`、`"ordering-non-transitive"`）。ファセットオーバーレイから供給。2026-05-03 追加。 |
+| `severity` | 文字列 | ⏳ | オプション。自由形式の重大度バケット（例: `"bug"`、`"regression"`、`"spec-violation"`、`"footgun"`）。ファセットオーバーレイから供給。2026-05-03 追加。 |
+| `tags` | 文字列の配列 | ⏳ | オプション。マッチャーがスコア計算に使う自由形式タグリスト（例: `["sqlite3", "pragma", "foreign-keys"]`）。ファセットオーバーレイから供給。2026-05-03 追加。 |
 
 ## バージョニング
 
@@ -65,13 +69,20 @@ URL: <https://aletheia-works.github.io/vivarium/api/recipes.json>
 [ADR-0018](https://github.com/aletheia-works/vivarium/blob/main/_context/decisions/0018-contract-v1-evidence-extension.md)
 （プライベートメモ）のマイナーリビジョンポリシーに従い:
 
-- **オプションの追加的フィールド**（例: Phase 6 ストリーム S.1 でフロントマタータグが
-  着地した後の将来の `language` フィールド）は v1 リビジョンとして出荷。
-  コンシューマーはフィーチャーデテクトする。
+- **オプションの追加的フィールド**は v1 リビジョンとして出荷される。
+  コンシューマーはフィーチャーデテクトする。Phase 6 ストリーム S.1 は
+  このルールに従って `language` / `symptom` / `severity` / `tags` を追加した
+  （下記リビジョン履歴を参照）。
 - **破壊的変更**（フィールド名変更、型変更、オプション → 必須）には
   v2 スキーマの兄弟ファイルと別の ADR が必要。
 
 現在 v2 は存在しない。
+
+## リビジョン履歴
+
+| 日付 | 変更内容 | 参照 |
+|---|---|---|
+| 2026-05-03 | レシピエントリにオプションの `language` / `symptom` / `severity` / `tags` フィールドを追加。レシピごとのフロントマタではなく、集中型ファセットオーバーレイ（`docs/data/recipe-facets.json`）から供給される。後方互換 — v1 コンシューマーは無視できる。 | [ADR-0024](https://github.com/aletheia-works/vivarium/blob/main/_context/decisions/0024-phase6-s1-faceted-gallery.md)（プライベートメモ） |
 
 ## 生成方法
 
@@ -84,9 +95,12 @@ slug パターン（末尾に Issue 番号を持つ slug の場合は `<project>
 `project` / `issue` を導出する。
 
 出力は git でトラッキングされるため、レシピを追加する PR の diff にインデックス更新も表示される。
-Phase 6 ストリーム S.1 では slug 由来のヒューリスティックをレシピごとの明示的なフロントマタに
-置き換える。その時点で `project`（やがては `language`）フィールドは
-slug 由来の推測ではなくレシピごとの第一級の宣言になる。
+オプションのファセットフィールド（`language` / `symptom` / `severity` / `tags`）は
+[`docs/data/recipe-facets.json`](https://github.com/aletheia-works/vivarium/blob/main/docs/data/recipe-facets.json)
+から merge される。これは手作業で維持され PR 差分でレビューされる集中型オーバーレイだ。
+v1 では `project` フィールドは引き続き slug 由来のままにしている — Phase 6 ストリーム S.1
+（ADR-0024）はあえてレシピごとのフロントマタを採用せず、現状のレシピ数なら 1 つのレビュー可能な
+ファイルに収まる集中型オーバーレイの方を選択した。
 
 ## コンフォーマンス
 

--- a/docs/public/api/recipes.schema.json
+++ b/docs/public/api/recipes.schema.json
@@ -48,7 +48,7 @@
         "project": {
           "type": "string",
           "minLength": 1,
-          "description": "Upstream project name (e.g. 'pandas', 'bash', 'pthread'). Heuristically derived from the slug pattern in v1; will be replaced by frontmatter-driven values when Phase 6 stream S.1 ships."
+          "description": "Upstream project name (e.g. 'pandas', 'bash', 'pthread'). Heuristically derived from the slug pattern in v1; per Phase 6 ADR-0024 (private memo) the slug-derived heuristic is retained — facet fields land via a centralised overlay (docs/data/recipe-facets.json) instead of per-recipe frontmatter."
         },
         "issue": {
           "type": "integer",
@@ -74,6 +74,29 @@
           "type": "string",
           "format": "uri",
           "description": "GitHub link to the recipe directory in this repository, useful for human navigation from a programmatic catalogue lookup."
+        },
+        "language": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional. Primary implementation language, lowercase (e.g. 'python', 'rust', 'shell'). Sourced from docs/data/recipe-facets.json per Phase 6 ADR-0024 (private memo). Added in the 2026-05-03 v1 revision; backwards-compatible, v1 consumers ignore."
+        },
+        "symptom": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional. Short symptom slug (kebab-case) used by the error → recipe matcher (e.g. 'dtype-mismatch', 'ordering-non-transitive'). Sourced from the facet overlay. Added 2026-05-03; backwards-compatible."
+        },
+        "severity": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional. Free-form severity bucket (e.g. 'bug', 'regression', 'spec-violation', 'footgun'). Sourced from the facet overlay. Added 2026-05-03; backwards-compatible."
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Optional. Free-form tag list scored by the matcher (e.g. ['sqlite3', 'pragma', 'foreign-keys']). Sourced from the facet overlay. Added 2026-05-03; backwards-compatible."
         }
       }
     }

--- a/infra/github/main.tf
+++ b/infra/github/main.tf
@@ -365,6 +365,10 @@ locals {
       state       = "closed"
       due_date    = "2026-05-02"
     }
+    "Phase 7 — First-30-minutes onboarding" = {
+      description = "Turn the Phase 6 surface from 'primitives are usable' into 'a stranger can pick this up cold'. UI brush-up (V′) + onboarding documentation (D) co-defined; AI-slop verification flow (B3) wires R.2 Path A + R.3 + MCP into one walkthrough; A-tail clears Phase 6 deferred items (ajv-standalone migration, match_error v2). Closes when V′ + D + B3 ship; A-tail items are optional. EN+JA same-PR is the i18n default."
+      state       = "open"
+    }
   }
 }
 


### PR DESCRIPTION

Phase 7 opens with the first-30-minutes-for-a-stranger framing (per
ADR-0028, private memo): UI brush-up (V′) and onboarding documentation
(D) co-defined with each other, AI-slop verification end-to-end (B3)
wiring R.2 Path A + R.3 + MCP match_error into one walkthrough, plus
the Phase 6 A-tail (ajv-standalone migration A3, match_error v2 A5).

Changes in this commit:

- infra/github/main.tf: add `Phase 7 — First-30-minutes onboarding`
  milestone with state="open". Becomes the canonical planning surface
  once `tofu apply` runs.
- docs/docs/{en,ja}/roadmap.mdx: add Phase 7 ACTIVE section continuing
  the existing per-phase narrative.
- A6 (Phase 6 deferred items, opener-PR bundled per ADR-0028):
  - docs/docs/{en,ja}/spec/recipes-index-v1.md: document the optional
    `language` / `symptom` / `severity` / `tags` fields that ADR-0024
    added (sourced from docs/data/recipe-facets.json overlay). Add a
    revision-history footer.
  - docs/public/api/recipes.schema.json: bring the schema into
    alignment with what recipes.json actually carries — the four
    optional facet fields were missing from the schema even though
    they have shipped in the data since Phase 6 S.1.
  - docs/docs/{en,ja}/spec/branch-fix-pipeline.md: replace the
    "stand-in until R.3 ships" line with a relative link to the
    live ../repro/compare.mdx page.

Local validation: `mise run ci:docs` (rspress build, EN+JA both
locales) passes. No dead-link warnings under checkDeadLinks.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/155).
* __->__ #155
* #152
* #154
* #151
* #150