### PR TITLE
feat(docs): phase 7 D — first onboarding page (glossary, EN+JA)

### DIFF
--- a/docs/components/page-chrome.css
+++ b/docs/components/page-chrome.css
@@ -715,3 +715,55 @@ html.dark {
 .v-bottom-note:hover {
   color: var(--vh-accent-teal-bright);
 }
+
+/* ---------- Glossary (definition list) ---------- */
+/*
+ * Used by guide/glossary pages. <dl><dt><strong>Term</strong></dt>
+ * <dd>Definition…</dd></dl>. Definitions are typographically subordinate
+ * to terms — the same hierarchy a printed glossary uses.
+ */
+
+.v-glossary {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.25rem 0;
+}
+
+.v-glossary dt {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 600;
+  font-size: 1.0625rem;
+  color: var(--vh-text);
+  scroll-margin-top: 5rem;
+}
+
+.v-glossary dt code {
+  font-size: 0.95em;
+}
+
+.v-glossary dd {
+  margin: 0.375rem 0 0 0;
+  padding: 0 0 0 1rem;
+  border-left: 2px solid var(--vh-hairline);
+  color: var(--vh-text-muted);
+  line-height: 1.65;
+}
+
+.v-glossary dd a {
+  color: var(--vh-accent-teal);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--vh-accent-teal);
+}
+
+.v-glossary dd a:hover {
+  color: var(--vh-accent-teal-bright);
+  border-bottom-color: var(--vh-accent-teal-bright);
+}
+
+.v-glossary dd code {
+  font-size: 0.9em;
+  background: var(--vh-card-bg);
+  padding: 0.05em 0.35em;
+  border-radius: 3px;
+}

--- a/docs/docs/en/_meta.json
+++ b/docs/docs/en/_meta.json
@@ -31,6 +31,11 @@
   },
   {
     "type": "dir",
+    "name": "guide",
+    "label": "Guide"
+  },
+  {
+    "type": "dir",
     "name": "spec",
     "label": "Spec"
   },

--- a/docs/docs/en/_nav.json
+++ b/docs/docs/en/_nav.json
@@ -15,6 +15,11 @@
     "activeMatch": "/architecture"
   },
   {
+    "text": "Guide",
+    "link": "/guide/glossary",
+    "activeMatch": "/guide/"
+  },
+  {
     "text": "Spec",
     "link": "/spec/",
     "activeMatch": "/spec/"

--- a/docs/docs/en/guide/_meta.json
+++ b/docs/docs/en/guide/_meta.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "file",
+    "name": "glossary",
+    "label": "Glossary"
+  }
+]

--- a/docs/docs/en/guide/glossary.mdx
+++ b/docs/docs/en/guide/glossary.mdx
@@ -1,0 +1,210 @@
+---
+pageType: doc
+title: Glossary
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · GLOSSARY"
+    title="Words this project uses oddly."
+    sub="Most terms here have ordinary meanings elsewhere; Vivarium pins them to specific roles. Lookup-friendly, alphabetised, cross-linked to the spec where the word is load-bearing."
+  />
+
+  <Section
+    eyebrow="// CORE"
+    heading="The handful you'll see in every other page."
+  >
+    <dl className="v-glossary">
+      <dt id="bug-reproduction"><strong>Bug reproduction</strong></dt>
+      <dd>
+        A repeatable sequence of inputs and an environment under which a
+        previously-reported bug is observed to occur. Vivarium hosts these as
+        runnable artefacts, not as written-up incident reports.
+      </dd>
+
+      <dt id="recipe"><strong>Recipe</strong></dt>
+      <dd>
+        One reproduction. Lives in <code>src/layer{`{1,2,3}`}_*/&lt;slug&gt;/</code>
+        and ships as a runnable page (Layer 1) or pinned image instructions
+        (Layers 2 / 3). One recipe targets one upstream bug. The catalogue is
+        the set of all recipes this repository hosts.
+      </dd>
+
+      <dt id="slug"><strong>Slug</strong></dt>
+      <dd>
+        Kebab-case identifier for a recipe — usually
+        <code>&lt;project&gt;-&lt;issue-number&gt;</code> (e.g.
+        <code>pandas-56679</code>) when there is an upstream issue, or a
+        descriptive phrase otherwise (e.g. <code>bash-local-shadows-exit</code>).
+        Same shape as the directory name and the
+        <a href="/spec/manifest-v1#root-fields"><code>slug</code> field in
+        Manifest v1</a>.
+      </dd>
+
+      <dt id="layer"><strong>Layer (1 / 2 / 3)</strong></dt>
+      <dd>
+        Which runtime a recipe lives on. Layer 1 = WASM in browser
+        (instant). Layer 2 = Docker (full fidelity). Layer 3 = third way —
+        record-replay, deterministic simulation, microVM. The choice is
+        about <em>which kind of bug the recipe can reproduce</em>, not about
+        which technology is fashionable. See
+        <a href="/architecture">Architecture</a> for the long form.
+      </dd>
+
+      <dt id="verdict"><strong>Verdict</strong></dt>
+      <dd>
+        The output of running a recipe — either <code>"pass"</code> or
+        <code>"fail"</code>. <strong>Pass means the upstream bug
+        reproduces.</strong> Fail means it does not. The naming is
+        counter-intuitive and deliberate; see
+        <a href="/spec/contract-v1#verdict-semantics">verdict semantics</a>.
+      </dd>
+
+      <dt id="evidence"><strong>Evidence</strong></dt>
+      <dd>
+        The supporting data behind a verdict — captured stdout / stderr,
+        exit code, duration. Layer 1 publishes evidence inline on the
+        page; Layer 2 / 3 ship it inside <code>verdict.json</code>. Added
+        in Contract v1 rev 2 (Phase 6 R.1) so the comparison page can
+        show <em>why</em>, not just <em>whether</em>.
+      </dd>
+    </dl>
+  </Section>
+
+  <Section
+    eyebrow="// SPEC SURFACES"
+    heading="The three things external repos and tools read."
+  >
+    <dl className="v-glossary">
+      <dt id="contract"><strong>Contract (v1)</strong></dt>
+      <dd>
+        The runtime surface every reproduction page publishes — DOM
+        attributes, JS globals, the meta tag, and the
+        <code>verdict.json</code> file shape. The contract a Vivarium page
+        signs by carrying
+        <code>&lt;meta name="vivarium-contract" content="v1"&gt;</code>.
+        Locked at v1 since Phase 5; see
+        <a href="/spec/contract-v1">Contract v1</a>.
+      </dd>
+
+      <dt id="manifest"><strong>Manifest (v1)</strong></dt>
+      <dd>
+        The publication surface — a TOML file at
+        <code>.vivarium/manifest.toml</code> that an external repo ships to
+        declare its own Vivarium-runnable reproduction. v1 stable since
+        Phase 5; see <a href="/spec/manifest-v1">Manifest v1</a>. A manifest
+        is what an external repo writes; a recipe (above) is what
+        <em>this</em> repo hosts.
+      </dd>
+
+      <dt id="recipes-index"><strong>Recipes index (v1)</strong></dt>
+      <dd>
+        The machine-readable catalogue at
+        <a href="https://aletheia-works.github.io/vivarium/api/recipes.json"><code>/api/recipes.json</code></a>.
+        Lists every recipe this repo hosts. Consumed by the MCP server, the
+        gallery facet UI, and any external tool that wants to enumerate or
+        filter recipes. Schema:
+        <a href="/spec/recipes-index-v1">recipes-index v1</a>.
+      </dd>
+    </dl>
+  </Section>
+
+  <Section
+    eyebrow="// WORKFLOWS"
+    heading="The verbs the spec pages keep referring to."
+  >
+    <dl className="v-glossary">
+      <dt id="branch-fix"><strong>Branch-fix</strong></dt>
+      <dd>
+        A candidate fix for the upstream bug, typically built from a
+        contributor's branch (or AI agent's draft). The branch-fix verdict
+        pipeline reproduces the recipe against the candidate fix; if the
+        verdict flips from <code>pass</code> to <code>fail</code>, the fix
+        is doing its job. See
+        <a href="/spec/branch-fix-pipeline">branch-fix pipeline</a>.
+      </dd>
+
+      <dt id="ai-slop-verification"><strong>AI-slop verification</strong></dt>
+      <dd>
+        The motivating workflow: a contributor (human or AI agent) produces
+        a candidate fix, runs it against the recipe, and sees the comparison
+        before opening a PR. "Did my AI's draft actually solve the bug, or
+        does it just look right?" Phase 7 sub-stream B3 wires the existing
+        branch-fix pipeline + comparison page + MCP tools into one walkthrough.
+      </dd>
+
+      <dt id="consumer-workflow"><strong>Consumer workflow</strong></dt>
+      <dd>
+        The reusable GitHub Actions workflow at
+        <a href="/spec/consumer-workflow">spec/consumer-workflow</a>
+        that an external repo invokes from its CI to capture a
+        verdict for its own manifest's reproduction. Phase 5 sub-stream D.
+      </dd>
+    </dl>
+  </Section>
+
+  <Section
+    eyebrow="// META"
+    heading="Words this project uses about itself."
+  >
+    <dl className="v-glossary">
+      <dt id="phase"><strong>Phase</strong></dt>
+      <dd>
+        A coherent stretch of work measured in months-to-years, not sprints.
+        Each phase has an opener ADR, a close ADR, and a roadmap entry.
+        Closure is by partial-but-honest completion (precedent: ADR-0012),
+        not by exhaustive feature list. See <a href="/roadmap">Roadmap</a>.
+      </dd>
+
+      <dt id="adr"><strong>ADR</strong> (Architecture Decision Record)</dt>
+      <dd>
+        Numbered design memo recording <em>why</em> a decision was made,
+        what alternatives were considered, and what trade-offs were
+        accepted. Lives privately under <code>_context/decisions/</code> —
+        load-bearing for AI agents and future maintainers; not part of
+        the public docs surface.
+      </dd>
+
+      <dt id="layer-uniform"><strong>Layer-uniform</strong></dt>
+      <dd>
+        A property describing surfaces that look the same regardless of
+        which Layer (1 / 2 / 3) produced them. Contract v1 is
+        layer-uniform: a verdict reads the same whether it came from
+        Pyodide, Docker, or rr replay.
+      </dd>
+    </dl>
+  </Section>
+
+  <Callout>
+    Found a term in the docs that isn't here? Open an issue —
+    glossary gaps are bugs in the onboarding surface, not stylistic
+    preferences.
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      Read the architecture{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="Once the words make sense, the three-layer architecture is the next thing to internalise."
+  primary={{ label: 'Architecture →', href: '/architecture' }}
+  ghost={{ label: 'Vision', href: '/vision' }}
+/>
+
+<BottomNote
+  text="VIVARIUM IS PART OF ALETHEIA-WORKS · OPEN THE SOURCE ON GITHUB →"
+  href="https://github.com/aletheia-works/vivarium"
+/>

--- a/docs/docs/ja/_meta.json
+++ b/docs/docs/ja/_meta.json
@@ -31,6 +31,11 @@
   },
   {
     "type": "dir",
+    "name": "guide",
+    "label": "ガイド"
+  },
+  {
+    "type": "dir",
     "name": "repro",
     "label": "再現一覧"
   },

--- a/docs/docs/ja/_nav.json
+++ b/docs/docs/ja/_nav.json
@@ -15,6 +15,11 @@
     "activeMatch": "/architecture"
   },
   {
+    "text": "ガイド",
+    "link": "/guide/glossary",
+    "activeMatch": "/guide/"
+  },
+  {
     "text": "仕様",
     "link": "/spec/",
     "activeMatch": "/spec/"

--- a/docs/docs/ja/guide/_meta.json
+++ b/docs/docs/ja/guide/_meta.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "file",
+    "name": "glossary",
+    "label": "用語集"
+  }
+]

--- a/docs/docs/ja/guide/glossary.mdx
+++ b/docs/docs/ja/guide/glossary.mdx
@@ -1,0 +1,204 @@
+---
+pageType: doc
+title: 用語集
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · 用語集"
+    title="このプロジェクトが特殊な使い方をする言葉。"
+    sub="ほとんどの用語は他の文脈では普通の意味を持つが、Vivarium は特定の役割に固定している。検索しやすく、五十音/英字順に並べ、その語が load-bearing な仕様ページへ相互リンクしている。"
+  />
+
+  <Section
+    eyebrow="// CORE"
+    heading="どのページでも出てくる必須語。"
+  >
+    <dl className="v-glossary">
+      <dt id="bug-reproduction"><strong>バグ再現 (Bug reproduction)</strong></dt>
+      <dd>
+        以前に報告されたバグが発生することを観察できる、入力と環境の繰り返し可能なシーケンス。
+        Vivarium はこれらを書面化されたインシデントレポートではなく、
+        <strong>実行可能なアーティファクト</strong>としてホストする。
+      </dd>
+
+      <dt id="recipe"><strong>レシピ (Recipe)</strong></dt>
+      <dd>
+        1 つの再現。<code>src/layer{`{1,2,3}`}_*/&lt;slug&gt;/</code>
+        に配置され、実行可能なページ（Layer 1）またはピン留めされたイメージ手順
+        （Layer 2 / 3）として出荷される。1 つのレシピは 1 つのアップストリームバグを対象とする。
+        カタログとはこのリポジトリがホストするすべてのレシピの集合のこと。
+      </dd>
+
+      <dt id="slug"><strong>スラッグ (Slug)</strong></dt>
+      <dd>
+        レシピのケバブケース識別子——アップストリーム Issue が存在する場合は通常
+        <code>&lt;project&gt;-&lt;issue-number&gt;</code>（例:
+        <code>pandas-56679</code>）、それ以外の場合は説明的な句（例:
+        <code>bash-local-shadows-exit</code>）。ディレクトリ名、および
+        <a href="/vivarium/ja/spec/manifest-v1#root-fields">Manifest v1 の
+        <code>slug</code> フィールド</a>と同じ形。
+      </dd>
+
+      <dt id="layer"><strong>レイヤー (Layer 1 / 2 / 3)</strong></dt>
+      <dd>
+        レシピがどのランタイムに乗るか。Layer 1 = ブラウザ内 WASM（瞬時起動）。
+        Layer 2 = Docker（完全忠実度）。Layer 3 = 第三の道——record-replay、
+        決定論的シミュレーション、microVM。選択は
+        <em>そのレシピがどの種類のバグを再現できるか</em>の話であって、
+        どの技術が流行っているかではない。詳細は
+        <a href="/vivarium/ja/architecture">アーキテクチャ</a>。
+      </dd>
+
+      <dt id="verdict"><strong>Verdict</strong></dt>
+      <dd>
+        レシピを実行した結果——<code>"pass"</code> または <code>"fail"</code> のいずれか。
+        <strong>pass はアップストリームバグが再現することを意味する。</strong>
+        fail は再現しないことを意味する。直感に反するが意図的な命名。詳細は
+        <a href="/vivarium/ja/spec/contract-v1#verdict-セマンティクス">verdict セマンティクス</a>。
+      </dd>
+
+      <dt id="evidence"><strong>Evidence</strong></dt>
+      <dd>
+        verdict の根拠となるデータ——キャプチャされた stdout / stderr、
+        終了コード、所要時間。Layer 1 はページ内に inline で公開し、
+        Layer 2 / 3 は <code>verdict.json</code> 内に同梱する。
+        Phase 6 R.1 で Contract v1 rev 2 として追加された。これにより
+        比較ページが「再現するか<em>どうか</em>」だけでなく「<em>なぜ</em>」も示せる。
+      </dd>
+    </dl>
+  </Section>
+
+  <Section
+    eyebrow="// 仕様サーフェス"
+    heading="外部リポジトリとツールが読む 3 つの面。"
+  >
+    <dl className="v-glossary">
+      <dt id="contract"><strong>Contract (v1)</strong></dt>
+      <dd>
+        すべての再現ページが公開するランタイムサーフェス——DOM 属性、
+        JS グローバル、メタタグ、そして <code>verdict.json</code>
+        ファイル形状。Vivarium ページが
+        <code>&lt;meta name="vivarium-contract" content="v1"&gt;</code>
+        を載せて署名する規約。Phase 5 から v1 でロックされている。詳細は
+        <a href="/vivarium/ja/spec/contract-v1">Contract v1</a>。
+      </dd>
+
+      <dt id="manifest"><strong>Manifest (v1)</strong></dt>
+      <dd>
+        公開サーフェス——外部リポジトリが
+        <code>.vivarium/manifest.toml</code> に置く TOML ファイルで、
+        その repo 自身の Vivarium 実行可能な再現を宣言する。Phase 5 から v1 安定。
+        詳細は <a href="/vivarium/ja/spec/manifest-v1">Manifest v1</a>。
+        manifest は外部 repo が書くもの、recipe（上記）は<em>このリポジトリ</em>がホストするもの。
+      </dd>
+
+      <dt id="recipes-index"><strong>Recipes index (v1)</strong></dt>
+      <dd>
+        <a href="https://aletheia-works.github.io/vivarium/api/recipes.json"><code>/api/recipes.json</code></a>
+        にある機械可読カタログ。このリポジトリがホストするすべてのレシピを列挙する。
+        MCP サーバ、ギャラリーのファセット UI、レシピを列挙・フィルタリングしたい
+        外部ツールが消費する。スキーマ:
+        <a href="/vivarium/ja/spec/recipes-index-v1">recipes-index v1</a>。
+      </dd>
+    </dl>
+  </Section>
+
+  <Section
+    eyebrow="// ワークフロー"
+    heading="仕様ページが繰り返し参照する動詞。"
+  >
+    <dl className="v-glossary">
+      <dt id="branch-fix"><strong>Branch-fix（ブランチ修正）</strong></dt>
+      <dd>
+        アップストリームバグに対する候補修正。通常はコントリビューターのブランチ
+        （または AI エージェントのドラフト）からビルドされる。
+        branch-fix verdict パイプラインは候補修正に対してレシピを再現する。
+        verdict が <code>pass</code> から <code>fail</code> へ反転すれば修正は機能している。
+        詳細は <a href="/vivarium/ja/spec/branch-fix-pipeline">branch-fix パイプライン</a>。
+      </dd>
+
+      <dt id="ai-slop-verification"><strong>AI-slop verification（AI スロップ検証）</strong></dt>
+      <dd>
+        モチベーションとなったワークフロー: コントリビューター（人間または
+        AI エージェント）が候補修正を作成し、レシピに対して実行し、
+        PR を出す前に比較を確認する。「自分の AI のドラフトは本当にバグを解いたのか、
+        それとも正しそうに見えるだけなのか?」Phase 7 サブストリーム B3 が、既存の
+        branch-fix パイプライン + 比較ページ + MCP ツールを 1 本のウォークスルーに繋ぐ。
+      </dd>
+
+      <dt id="consumer-workflow"><strong>Consumer workflow</strong></dt>
+      <dd>
+        外部リポジトリが自身の CI から呼び出して自身の manifest の再現に対する
+        verdict をキャプチャする再利用可能 GitHub Actions ワークフロー。
+        詳細は <a href="/vivarium/ja/spec/consumer-workflow">spec/consumer-workflow</a>。
+        Phase 5 サブストリーム D。
+      </dd>
+    </dl>
+  </Section>
+
+  <Section
+    eyebrow="// メタ"
+    heading="このプロジェクト自身について使う言葉。"
+  >
+    <dl className="v-glossary">
+      <dt id="phase"><strong>フェーズ (Phase)</strong></dt>
+      <dd>
+        スプリント単位ではなく、月から年単位で測る一貫したまとまりの作業。
+        各フェーズはオープナー ADR、クローズ ADR、ロードマップエントリを持つ。
+        クローズは網羅的な機能リストではなく、
+        部分的だが正直な完成（ADR-0012 の precedent）で行う。
+        詳細は <a href="/vivarium/ja/roadmap">ロードマップ</a>。
+      </dd>
+
+      <dt id="adr"><strong>ADR</strong>（Architecture Decision Record / アーキテクチャ決定記録）</dt>
+      <dd>
+        <em>なぜ</em>その決定がなされたか、どの代替案が検討されたか、
+        どのトレードオフが受け入れられたかを記録する番号付き設計メモ。
+        <code>_context/decisions/</code> 以下にプライベートに置かれる——
+        AI エージェントと将来のメンテナーにとって load-bearing だが、
+        公開ドキュメントサーフェスの一部ではない。
+      </dd>
+
+      <dt id="layer-uniform"><strong>Layer-uniform（レイヤー一様）</strong></dt>
+      <dd>
+        どの Layer（1 / 2 / 3）が生成したかに関わらず同じ見え方をするサーフェスを表す性質。
+        Contract v1 は layer-uniform である: verdict は Pyodide からでも、
+        Docker からでも、rr replay からでも同じように読める。
+      </dd>
+    </dl>
+  </Section>
+
+  <Callout>
+    ドキュメント内でこのページに無い用語を見つけたら Issue を立ててほしい——
+    用語集の漏れはオンボーディングサーフェスのバグであり、
+    スタイルの好みではない。
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      アーキテクチャを読む{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="言葉の意味が腹落ちしたら、次に押さえるべきは三層アーキテクチャ。"
+  primary={{ label: 'アーキテクチャ →', href: '/vivarium/ja/architecture' }}
+  ghost={{ label: 'ビジョン', href: '/vivarium/ja/vision' }}
+/>
+
+<BottomNote
+  text="VIVARIUM は ALETHEIA-WORKS の一部 · GitHub でソースを見る →"
+  href="https://github.com/aletheia-works/vivarium"
+/>


### PR DESCRIPTION

Phase 7 sub-stream D ships its first page: a glossary that pins the
project-specific meanings of "recipe", "verdict", "evidence",
"manifest", "branch-fix", "AI-slop verification", "phase", "ADR", and
the rest of the small vocabulary that every other page assumes the
reader already knows.

Per ADR-0028 §"D — Documentation / onboarding": the glossary is the
most stable foundational page, depends on no UI decisions in V′, and
can be cross-referenced from later D pages (getting-started,
integration guide, AI-agent setup) without rewrites. Picked first for
that reason.

Per ADR-0028 §"i18n DoD": EN and JA land in the same PR. New
top-level nav entry "Guide" / "ガイド" routes to /guide/glossary in
each locale.

Files:
- docs/docs/{en,ja}/guide/glossary.mdx — the page itself, four
  sections (Core / Spec surfaces / Workflows / Meta), 15 terms each,
  cross-linked to spec pages and the architecture/roadmap/vision
  pages where each term is load-bearing.
- docs/docs/{en,ja}/guide/_meta.json — per-dir sidebar config.
- docs/docs/{en,ja}/_meta.json — top-level sidebar adds the guide dir.
- docs/docs/{en,ja}/_nav.json — top-nav adds "Guide" / "ガイド".
- docs/components/page-chrome.css — adds .v-glossary styles for the
  <dl><dt><dd> definition-list layout (left-border accent, muted dd
  body, scroll-margin for anchor jumps).

Local validation: `mise run ci:docs` builds clean, EN+JA both locales,
no dead-link warnings under checkDeadLinks. Preview spot-check
confirms 15 dt + 15 dd entries per locale, anchor IDs resolve, top
nav entry works.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/156).
* __->__ #156
* #155