### PR TITLE
feat(infra): set repo homepage URL to the GitHub Pages site

### DIFF
--- a/infra/github/main.tf
+++ b/infra/github/main.tf
@@ -22,6 +22,18 @@ resource "github_repository" "this" {
   visibility  = var.repository_visibility
   topics      = var.repository_topics
 
+  # About-section homepage URL — mirrors the GitHub UI checkbox
+  # "Use your GitHub Pages website".
+  #
+  # Constructed from var.github_owner + var.repository_name rather than
+  # `github_repository_pages.this.html_url` because the latter creates a
+  # dependency cycle (github_repository_pages.this depends on
+  # github_repository.this.name). The default Pages URL format is
+  # https://{owner}.github.io/{repo}/, identical to what html_url would
+  # return; if a custom domain is later configured on Pages, update this
+  # line at the same time.
+  homepage_url = "https://${var.github_owner}.github.io/${var.repository_name}/"
+
   # Feature toggles
   has_issues      = true
   has_discussions = true


### PR DESCRIPTION

Mirrors the "Use your GitHub Pages website" checkbox in the GitHub
About-section UI by setting `github_repository.this.homepage_url`.

The value is constructed from `var.github_owner` + `var.repository_name`
rather than referencing `github_repository_pages.this.html_url` directly,
because the latter creates a dependency cycle:

  github_repository.this   ← homepage_url ← github_repository_pages.this
  github_repository_pages.this ← repository ← github_repository.this

`tofu validate` confirms the cycle on the direct-reference variant. The
constructed-URL variant produces an identical value to what `html_url`
would return for the default Pages URL format, so the GUI semantics are
preserved. Custom-domain Pages configuration would diverge; the inline
comment flags this for the next maintainer.

`tofu validate` passes on the chosen form. `tofu plan` is the human's
to run with proper credentials per AGENTS.md §2.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
