### PR TITLE
feat(docs): phase 7 D — getting-started page (ja+en)

### DIFF
--- a/docs/docs/en/_nav.json
+++ b/docs/docs/en/_nav.json
@@ -16,7 +16,7 @@
   },
   {
     "text": "Guide",
-    "link": "/guide/glossary",
+    "link": "/guide/getting-started",
     "activeMatch": "/guide/"
   },
   {

--- a/docs/docs/en/guide/_meta.json
+++ b/docs/docs/en/guide/_meta.json
@@ -1,6 +1,11 @@
 [
   {
     "type": "file",
+    "name": "getting-started",
+    "label": "First five minutes"
+  },
+  {
+    "type": "file",
     "name": "glossary",
     "label": "Glossary"
   }

--- a/docs/docs/en/guide/getting-started.mdx
+++ b/docs/docs/en/guide/getting-started.mdx
@@ -1,0 +1,193 @@
+---
+pageType: doc
+title: First five minutes
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  NumberedList,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · FIRST 5 MINUTES"
+    title="Open the site, run a recipe, read the verdict."
+    sub="The shortest path through Vivarium for someone arriving cold. No install, no account, no terminal — one browser tab."
+  />
+
+  <Section
+    eyebrow="// 0 · WHAT YOU'LL DO"
+    heading="Three steps."
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'Open the gallery.',
+          body: 'Click "Reproductions" in the top nav, or jump straight to /repro/. Layer 1 (in-browser WebAssembly) recipes are listed there.',
+        },
+        {
+          lead: 'Pick a recipe and hit "Open".',
+          body: 'A real upstream bug opens in a dedicated page. Pandas, NumPy, CPython, Ruby, PHP, or Rust regex — any one works.',
+        },
+        {
+          lead: 'Read the verdict.',
+          body: 'The badge at the top settles from pending to either reproduced or unreproduced. "Reproduced = the bug still reproduces". That single sentence is enough to start.',
+        },
+      ]}
+    />
+    <Callout>
+      The verdict literals point in a counter-intuitive direction; the{' '}
+      <a href="/vivarium/guide/glossary#verdict">verdict glossary entry</a>{' '}
+      explains why. A useful mental model: "reproduced is red, unreproduced is green."
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 1 · OPEN THE GALLERY"
+    heading="Every recipe satisfies the same Contract v1."
+  >
+    <p>
+      The <a href="/vivarium/repro/">reproduction gallery</a> lists every
+      recipe. Each card maps to one upstream bug and shows the project,
+      issue number, layer, current verdict, and when that verdict was
+      captured.
+    </p>
+    <p>
+      Facets filter the list: language (python / ruby / php / rust),
+      symptom, severity, tag. To find a recipe by a concrete error
+      message, use{' '}
+      <a href="/vivarium/repro/match">match an error to a recipe</a>{' '}
+      — it scores recipes by lexical overlap and returns ranked candidates.
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 2 · RUN A RECIPE"
+    heading="One click. The browser does the rest."
+  >
+    <p>
+      Walk through it once with <code>pandas-56679</code> as the running
+      example. Hitting "Open" on the card pops a new tab at the recipe's
+      page, <a href="/vivarium/repro/pandas/56679/" target="_blank" rel="noreferrer"><code>/repro/pandas/56679/</code></a>.
+    </p>
+    <p>
+      On load the page fetches Pyodide (CPython compiled to WebAssembly)
+      and pandas from the jsDelivr CDN. The verdict badge sits at{' '}
+      <code>pending</code> with "Loading runtime…" while that happens.
+    </p>
+    <p>
+      Once loaded, the embedded reproduction script runs and the verdict
+      settles. First load takes a few to a few-tens of seconds depending
+      on connection and cache state; subsequent visits hit the CDN cache
+      and open in milliseconds to a second.
+    </p>
+    <Callout>
+      Layer 1 means everything happens inside the browser — you don't
+      need Python or pandas locally. The three-layer model is in{' '}
+      <a href="/vivarium/architecture">architecture</a>.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 3 · READ THE VERDICT"
+    heading="Three values. reproduced / unreproduced / pending."
+  >
+    <p>
+      <code>reproduced</code> means the upstream bug still reproduces.
+      <code>unreproduced</code> means it does not — typically because a
+      newer runtime build resolved the issue, or because the conditions
+      shifted. <code>pending</code> is the in-flight state while the
+      script is running or the runtime is still loading.
+    </p>
+    <p>
+      Open pandas-56679 and the verdict will settle to{' '}
+      <code>reproduced</code> or <code>unreproduced</code> depending on
+      what version of pandas Pyodide currently ships. Underneath the
+      badge you'll see the data the verdict was decided from — the
+      <code>series_dtype</code> vs <code>df_dtype</code> comparison.
+    </p>
+    <Callout>
+      Why "reproduced / unreproduced" instead of "pass / fail": pass and
+      fail flip meaning between teams. Vivarium pins the verb to one
+      thing — <em>did the bug reproduce</em>. Spec:{' '}
+      <a href="/vivarium/spec/contract-v1#verdict-semantics">contract v1 verdict semantics</a>.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 4 · READ THE EVIDENCE"
+    heading="Not just the badge — the basis is on the same page."
+  >
+    <p>
+      Below the verdict badge sits an "Evidence" section bundling the
+      reproduction script's run: stdout, stderr, exit code, duration in
+      milliseconds. Contract v1 revision 2 (added in Phase 6 R.1) made
+      the basis for a verdict readable on-page rather than buried in a
+      separate file.
+    </p>
+    <p>
+      For pandas-56679, that includes the literal <code>series_dtype</code>
+      and <code>df_dtype</code> strings, the boolean for whether they
+      match, and the running pandas / Python versions — all serialised
+      as JSON. That bundle <em>is</em> the evidence.
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 5 · WHERE TO GO NEXT"
+    heading="Entry points by intent."
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'Get the vocabulary straight.',
+          body: 'The glossary (/guide/glossary) pins down every word Vivarium uses with a fixed meaning — recipe, verdict, evidence, Layer 1/2/3, manifest, contract.',
+        },
+        {
+          lead: 'Verify a branch fix.',
+          body: 'The compare page (/repro/compare) accepts before/after verdict bundles and shows whether reproduced flipped to unreproduced. Built for verifying AI-agent-authored patches.',
+        },
+        {
+          lead: 'Declare a Vivarium reproduction in your repo.',
+          body: 'Start with the Manifest v1 spec (/spec/manifest-v1) and the interactive scaffolder (/spec/manifest-create).',
+        },
+        {
+          lead: 'Drive Vivarium from an AI agent.',
+          body: 'The MCP server @aletheia-works/vivarium-mcp is on JSR and npm. Four tools — list_recipes, get_recipe, lookup_verdict, match_error.',
+        },
+        {
+          lead: 'Understand why this project exists.',
+          body: 'Read vision (/vision), architecture (/architecture), and roadmap (/roadmap) in that order to fix the skeleton in your head.',
+        },
+      ]}
+    />
+  </Section>
+
+  <Callout>
+    If any step on this page didn't work, that's a bug in
+    getting-started — not a stylistic preference. Please file an issue.
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      Read the glossary{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="With something running in your head, five minutes on the glossary lets every other doc on this site read faster."
+  primary={{ label: 'Glossary →', href: '/vivarium/guide/glossary' }}
+  ghost={{ label: 'Back to gallery', href: '/vivarium/repro/' }}
+/>
+
+<BottomNote
+  text="VIVARIUM is part of ALETHEIA-WORKS · See the source on GitHub →"
+  href="https://github.com/aletheia-works/vivarium"
+/>

--- a/docs/docs/ja/_nav.json
+++ b/docs/docs/ja/_nav.json
@@ -16,7 +16,7 @@
   },
   {
     "text": "ガイド",
-    "link": "/guide/glossary",
+    "link": "/guide/getting-started",
     "activeMatch": "/guide/"
   },
   {

--- a/docs/docs/ja/guide/_meta.json
+++ b/docs/docs/ja/guide/_meta.json
@@ -1,6 +1,11 @@
 [
   {
     "type": "file",
+    "name": "getting-started",
+    "label": "はじめての 5 分"
+  },
+  {
+    "type": "file",
     "name": "glossary",
     "label": "用語集"
   }

--- a/docs/docs/ja/guide/getting-started.mdx
+++ b/docs/docs/ja/guide/getting-started.mdx
@@ -1,0 +1,189 @@
+---
+pageType: doc
+title: はじめての 5 分
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  NumberedList,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · はじめての 5 分"
+    title="サイトを開いて、レシピを動かして、verdict を読む。"
+    sub="このページは Vivarium をはじめて触る人のための最短ルート。インストール不要、アカウント登録不要、ターミナル不要。ブラウザのタブ 1 枚で完結する。"
+  />
+
+  <Section
+    eyebrow="// 0 · 5 分でやること"
+    heading="3 ステップ。"
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'ギャラリーを開く。',
+          body: 'トップナビの「再現一覧」をクリックする。あるいは直接 /repro/ へ。Layer 1（ブラウザ内 WebAssembly）のレシピが並んでいる。',
+        },
+        {
+          lead: 'レシピを 1 つ選んで「Open」を押す。',
+          body: '本物のアップストリームバグが、別タブの専用ページで開く。pandas、numpy、CPython、Ruby、PHP、Rust regex のどれでもよい。',
+        },
+        {
+          lead: 'verdict を読む。',
+          body: '画面上部のバッジが pending → reproduced か unreproduced のどちらかに落ち着く。「reproduced ＝ バグが今でも再現する」。これだけ覚えれば最低限読める。',
+        },
+      ]}
+    />
+    <Callout>
+      verdict の値リテラルが直感に反する向きを持っている点は、用語集の{' '}
+      <a href="/vivarium/ja/guide/glossary#verdict">verdict</a> に詳しく書いた。
+      「reproduced は赤、unreproduced は緑」のメンタルモデルでよい。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 1 · ギャラリーを開く"
+    heading="どのレシピも同じ Contract v1 を満たす。"
+  >
+    <p>
+      <a href="/vivarium/ja/repro/">再現一覧</a>{' '}
+      にレシピが一覧表示されている。各カードは 1 つのアップストリームバグに対応し、
+      対応プロジェクト、Issue 番号、Layer、現時点の verdict、いつキャプチャされた verdict かを示す。
+    </p>
+    <p>
+      ファセットでフィルタできる: 言語（python / ruby / php / rust）、症状、深刻度、タグ。
+      具体的なエラーメッセージから候補を絞りたい場合は{' '}
+      <a href="/vivarium/ja/repro/match">エラーからレシピを探す</a>{' '}
+      が使える（語句マッチでスコアリングして候補を返す）。
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 2 · レシピを動かす"
+    heading="クリック 1 回。後はブラウザがやる。"
+  >
+    <p>
+      初回は何が起きているのか分かりやすいように、<code>pandas-56679</code> を例に進める。
+      カードの「Open」ボタンを押すと別タブで{' '}
+      <a href="/vivarium/repro/pandas/56679/" target="_blank" rel="noreferrer">
+        /repro/pandas/56679/
+      </a>{' '}
+      が開く。
+    </p>
+    <p>
+      ページが読み込まれると、まず Pyodide（CPython の WebAssembly ビルド）と pandas を
+      jsDelivr CDN からダウンロードする。verdict バッジは <code>pending</code> 状態で
+      「ランタイムを読み込み中」と表示される。
+    </p>
+    <p>
+      ロード完了後、ページに埋め込まれた再現スクリプトが実行され、verdict が確定する。
+      初回ロードは数秒〜十数秒（接続速度とブラウザのキャッシュ状態による）、
+      2 回目以降は CDN キャッシュが効いてミリ秒〜秒で開く。
+    </p>
+    <Callout>
+      Layer 1 はブラウザ完結。ローカルに Python も pandas も入れる必要はない。
+      Vivarium が宣言する 3 層アーキテクチャは{' '}
+      <a href="/vivarium/ja/architecture">アーキテクチャ</a> 参照。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 3 · verdict を読む"
+    heading="reproduced / unreproduced / pending の 3 値だけ。"
+  >
+    <p>
+      <code>reproduced</code> はアップストリームバグが現在も再現することを示す。
+      <code>unreproduced</code> は再現しなかったこと——つまりランタイムの新しいビルドが
+      問題を解消した、あるいは再現条件が変わった——を示す。<code>pending</code> は
+      まだ実行中、もしくは初期化中の中間状態。
+    </p>
+    <p>
+      pandas-56679 を開いて少し待つと、現状（pandas が Pyodide で出荷している版で再現するかどうか）
+      に応じて値が <code>reproduced</code> か <code>unreproduced</code> に落ち着く。
+      verdict バッジの下に、その判定の根拠となった出力——<code>series_dtype</code> と
+      <code>df_dtype</code> の比較結果——も表示される。
+    </p>
+    <Callout>
+      「pass / fail」ではなく「reproduced / unreproduced」を使う理由: テスト用語の{' '}
+      pass / fail はチームによって意味が逆転する。Vivarium の動詞は
+      「<em>バグが再現したか</em>」一本に固定したい。詳細は{' '}
+      <a href="/vivarium/ja/spec/contract-v1#verdict-セマンティクス">contract v1 verdict セマンティクス</a>。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 4 · evidence を読む"
+    heading="バッジだけではなく、その根拠も同じページに。"
+  >
+    <p>
+      verdict バッジの下に「Evidence」セクションがあり、再現スクリプトの実行結果が
+      まとまっている: stdout、stderr、終了コード、所要時間（ms）。Contract v1
+      リビジョン 2（Phase 6 R.1 で追加）により、verdict が出る根拠が
+      ページから直接読める。
+    </p>
+    <p>
+      たとえば pandas-56679 では、<code>series_dtype</code> と <code>df_dtype</code> の
+      文字列値、両者が一致しないかどうかの真偽値、pandas と Python のバージョンが
+      JSON で出力される。これがそのまま<strong>evidence</strong> として記録される。
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 5 · 次に何をするか"
+    heading="目的別の入口。"
+  >
+    <NumberedList
+      items={[
+        {
+          lead: '言葉を整理したい。',
+          body: '用語集 (/guide/glossary) に Vivarium が固定的な意味で使う単語をまとめてある。レシピ、verdict、evidence、Layer 1/2/3、manifest、contract など。',
+        },
+        {
+          lead: 'ブランチ修正が本当に効いているか確かめたい。',
+          body: '比較ページ (/repro/compare) に修正前後の verdict バンドルをドロップすると、reproduced → unreproduced に反転したかが横並びで見える。AI エージェントが書いたパッチの検証用に作られた surface。',
+        },
+        {
+          lead: '自分のリポジトリに Vivarium 再現を宣言したい。',
+          body: 'spec の Manifest v1 (/spec/manifest-v1) と、対話的なスキャフォールダ (/spec/manifest-create) から始める。',
+        },
+        {
+          lead: 'AI エージェントから呼びたい。',
+          body: 'MCP サーバ @aletheia-works/vivarium-mcp が JSR + npm に出ている。4 つのツール (list_recipes / get_recipe / lookup_verdict / match_error) でレシピを検索・取得できる。',
+        },
+        {
+          lead: 'なぜこのプロジェクトが存在するか知りたい。',
+          body: 'ビジョン (/vision)、アーキテクチャ (/architecture)、ロードマップ (/roadmap) を順に読むと骨格がつかめる。',
+        },
+      ]}
+    />
+  </Section>
+
+  <Callout>
+    このページの手順がうまく動かないところがあれば、それは getting-started の
+    バグであり、スタイルの好みではない。Issue を立ててほしい。
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      用語集を読む{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="動くものを見たあとは、Vivarium が固定的な意味で使う言葉を 5 分で押さえると、以後のドキュメントが速く読める。"
+  primary={{ label: '用語集 →', href: '/vivarium/ja/guide/glossary' }}
+  ghost={{ label: 'ギャラリーへ戻る', href: '/vivarium/ja/repro/' }}
+/>
+
+<BottomNote
+  text="VIVARIUM は ALETHEIA-WORKS の一部 · GitHub でソースを見る →"
+  href="https://github.com/aletheia-works/vivarium"
+/>


### PR DESCRIPTION

The "first 5 minutes" entry point for someone arriving cold: open
the gallery, run a Layer 1 recipe, read the verdict. Re-points the
top-nav Guide link from the glossary to this page; glossary stays as
the second entry under guide/.

Per ADR-0028 §D — first of the six tutorial-genre pages this phase
introduces. Forcing-function role for V′: places where this page is
awkward to write are V′ tickets. Drafted while V′ is in flight so the
two streams co-evolve as the ADR intends.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/163).
* #164
* __->__ #163