### PR TITLE
feat(infra,docs): fork-friendly deploy and a fork-your-own guide

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -62,12 +62,16 @@ concurrency:
 
 jobs:
   build:
-    # Skip on forks. The push trigger fires in any fork that has Actions
-    # enabled, but a fork's main has no Pages site to deploy to (and
-    # would fail at the `actions/deploy-pages` step on GHCR push without
-    # the org's GITHUB_TOKEN scope). The same fork-skip pattern is used
-    # by terraform-apply.yml and terraform-state-backup.yml.
-    if: github.repository_owner == 'aletheia-works'
+    # Runs unconditionally on the upstream `aletheia-works/vivarium` repo.
+    # Forks skip the build by default (the push trigger fires in every
+    # fork with Actions enabled, but most forks do not want Pages to
+    # deploy from this workflow). A fork user who DOES want their own
+    # `<owner>.github.io/<repo>/` site can opt in by setting a single
+    # repository variable: Settings → Secrets and variables → Actions
+    # → Variables → New repository variable, name `VIVARIUM_FORK_DEPLOY`,
+    # value `true`. Layer 2 image build/push remains gated below to
+    # `aletheia-works` only — fork deploys ship Layer 1 only.
+    if: github.repository_owner == 'aletheia-works' || vars.VIVARIUM_FORK_DEPLOY == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -148,6 +152,11 @@ jobs:
         # default `GITHUB_TOKEN`; the workflow's `packages: write`
         # permission lets us push to `ghcr.io/aletheia-works/*` without
         # a separately-rotated PAT.
+        #
+        # Fork users (running with VIVARIUM_FORK_DEPLOY=true) skip this
+        # step — fork deploys ship Layer 1 only because the GITHUB_TOKEN
+        # has no GHCR push scope into `ghcr.io/aletheia-works/*`.
+        if: github.repository_owner == 'aletheia-works'
         working-directory: ${{ github.workspace }}
         run: |
           set -euo pipefail
@@ -170,6 +179,10 @@ jobs:
         # alongside the rest of the directory.
         #
         # Skipped silently if no Layer 2 reproductions exist.
+        #
+        # Fork users (running with VIVARIUM_FORK_DEPLOY=true) skip this
+        # step — Layer 2 deploy stays upstream-only.
+        if: github.repository_owner == 'aletheia-works'
         working-directory: ${{ github.workspace }}
         env:
           IMAGE_OWNER: aletheia-works
@@ -274,7 +287,10 @@ jobs:
             exit 0
           fi
           mkdir -p "$dest"
-          pages_prefix="https://aletheia-works.github.io/vivarium/repro/"
+          # Derived from the runtime context so fork deploys
+          # (VIVARIUM_FORK_DEPLOY=true) bundle correctly under the
+          # fork's own `<owner>.github.io/<repo>/repro/` URL.
+          pages_prefix="https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY##*/}/repro/"
           # Stage shared scaffolding (`_shared/`, `_assets/`, ...) under
           # each Layer 1 project's directory so recipes' `../_shared/...`
           # refs resolve to `/repro/<project>/_shared/...`.
@@ -366,7 +382,10 @@ jobs:
           fi
           shopt -s nullglob
           mkdir -p "$dest"
-          pages_prefix="https://aletheia-works.github.io/vivarium/repro/"
+          # Derived from the runtime context so fork deploys
+          # (VIVARIUM_FORK_DEPLOY=true) bundle correctly under the
+          # fork's own `<owner>.github.io/<repo>/repro/` URL.
+          pages_prefix="https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY##*/}/repro/"
           # Stage shared scaffolding under each Layer 2 project.
           layer2_projects="$(jq -r '.recipes[] | select(.layer == 2) | .project' \
             docs/public/api/recipes.json | sort -u)"
@@ -378,6 +397,16 @@ jobs:
               echo "Staging Layer 2 shared module: ${shared_name} → ${dest}/${project}/${shared_name}"
               cp -R "${shared%/}" "$dest/$project/$shared_name"
             done
+            # Layer 2 pages reference `../_shared/style.css` for the
+            # shared chrome (header, code blocks, verdict pill). The
+            # styles physically live under src/layer1_wasm/_shared/ and
+            # are reused by Layer 2 — copy them into each Layer 2
+            # project so the relative path resolves under
+            # `<dest>/<project>/_shared/style.css` after deploy.
+            if [ -d "src/layer1_wasm/_shared" ]; then
+              echo "Staging Layer 1 _shared/ for Layer 2 project: ${dest}/${project}/_shared"
+              cp -R "src/layer1_wasm/_shared" "$dest/$project/_shared"
+            fi
           done
           # Bundle each individual Layer 2 recipe.
           for entry in src/layer2_docker/*/; do
@@ -403,6 +432,31 @@ jobs:
             echo "Bundling Layer 2 reproduction: ${slug} → ${dest}/${rel}/"
             mkdir -p "$dest/$rel"
             cp -R "${entry}." "$dest/$rel/"
+            # Legacy slug-only URL `/repro/<slug>/` redirect. Before the
+            # hierarchical-URL move, Layer 2 pages were published at
+            # `<pages-base>/repro/<slug>/`; existing links in the wild
+            # need a meta-refresh to the new
+            # `<project>/<issue_path>/` location.
+            if [ "$rel" != "$slug" ]; then
+              mkdir -p "$dest/$slug"
+              cat > "$dest/$slug/index.html" <<HTML
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8" />
+              <title>Vivarium · moved to /repro/${rel}/</title>
+              <meta http-equiv="refresh" content="0; url=../${rel}/" />
+              <link rel="canonical" href="../${rel}/" />
+              <meta name="robots" content="noindex" />
+            </head>
+            <body>
+              <p>This reproduction has moved to
+                <a href="../${rel}/">/repro/${rel}/</a>.
+                Updating in a moment…</p>
+            </body>
+          </html>
+          HTML
+            fi
           done
           ls -la "$dest" || true
 

--- a/docs/components/ReproCompare.tsx
+++ b/docs/components/ReproCompare.tsx
@@ -543,7 +543,20 @@ export function VerdictCompareLayout({
 
 /* ------------------------------ Drop / load ------------------------------ */
 
-const PAGES_BASE = 'https://aletheia-works.github.io/vivarium/repro';
+// Resolves the deployed Pages base for the *current* host (so fork
+// deploys at <user>.github.io/<repo>/ work without rebuild). Looks up
+// the URL path up to the `/repro` segment from window.location and
+// reuses the same origin. Falls back to upstream during SSR / pre-hydrate.
+function resolvePagesBase(): string {
+  if (typeof window === 'undefined') {
+    return 'https://aletheia-works.github.io/vivarium/repro';
+  }
+  const { origin, pathname } = window.location;
+  const idx = pathname.indexOf('/repro');
+  return idx >= 0 ? `${origin}${pathname.slice(0, idx)}/repro` : `${origin}/repro`;
+}
+
+const PAGES_BASE = resolvePagesBase();
 
 async function readZipEntries(
   file: File,

--- a/docs/docs/en/guide/_meta.json
+++ b/docs/docs/en/guide/_meta.json
@@ -6,6 +6,11 @@
   },
   {
     "type": "file",
+    "name": "fork-your-own",
+    "label": "Run on your own fork"
+  },
+  {
+    "type": "file",
     "name": "glossary",
     "label": "Glossary"
   }

--- a/docs/docs/en/guide/fork-your-own.mdx
+++ b/docs/docs/en/guide/fork-your-own.mdx
@@ -1,0 +1,240 @@
+---
+pageType: doc
+title: Run on your own fork
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  NumberedList,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · YOUR OWN FORK"
+    title="Run Vivarium on your own fork."
+    sub="Fork this repo, add your own bug reproductions, and publish them to your own GitHub Pages site. Without ever opening a PR upstream, you can curate a recipe collection of your own and share the URL."
+  />
+
+  <Section
+    eyebrow="// 0 · WHAT THIS GETS YOU"
+    heading="Your bugs at <user>.github.io/vivarium/."
+  >
+    <p>
+      In this flow you fork <code>aletheia-works/vivarium</code>, add and edit
+      reproduction recipes on your own copy, and publish your fork as your own
+      GitHub Pages site. You're not contributing upstream —{' '}
+      <strong>your fork itself is the destination</strong>.
+    </p>
+    <p>
+      Layer 1 (in-browser WASM) works end-to-end on your fork. Layer 2 / 3
+      (Docker, record-replay) ride on upstream's GHCR images and stay
+      upstream-only; on a fork, <strong>only Layer 1 is deployed</strong>.
+    </p>
+    <Callout>
+      The intended use case is a personal collection of reproductions, not
+      a mirror of upstream. To share, hand out{' '}
+      <code>https://&lt;you&gt;.github.io/vivarium/</code>.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 1 · FORK THE REPO"
+    heading="One click in the GitHub UI."
+  >
+    <p>
+      Hit <strong>Fork</strong> on{' '}
+      <a href="https://github.com/aletheia-works/vivarium">aletheia-works/vivarium</a>{' '}
+      to copy it under your account or org. The repository name can stay as
+      <code>vivarium</code> or be renamed (in which case substitute your name
+      for <code>vivarium</code> below).
+    </p>
+    <p>Then clone it locally:</p>
+    <pre><code>{`git clone https://github.com/<you>/vivarium.git
+cd vivarium`}</code></pre>
+  </Section>
+
+  <Section
+    eyebrow="// 2 · INSTALL THE TOOLCHAIN"
+    heading="mise wires it all up."
+  >
+    <p>
+      The project pins tool versions through{' '}
+      <a href="https://mise.jdx.dev/">mise</a>. From the clone root:
+    </p>
+    <pre><code>{`mise install`}</code></pre>
+    <p>
+      That installs <code>bun</code> (docs and the MCP server),{' '}
+      <code>opentofu</code> (Infrastructure-as-Code for the GitHub repo
+      settings), <code>uv</code> (native Python re-verification), and the
+      Layer 1 native interpreters. A Rust toolchain (<code>rustup</code>) is
+      also needed if you plan to add Rust recipes.
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 3 · ISSUE A FINE-GRAINED PAT"
+    heading="The token OpenTofu uses to read/write your fork's settings."
+  >
+    <p>
+      Create a token at{' '}
+      <a href="https://github.com/settings/personal-access-tokens/new">
+        Settings → Developer settings → Personal access tokens → Fine-grained
+      </a>{' '}
+      scoped to your fork.
+    </p>
+    <ul>
+      <li><strong>Resource owner</strong>: your account or org.</li>
+      <li><strong>Repository access</strong>: just the forked repo.</li>
+      <li><strong>Repository permissions</strong>: Administration (RW), Contents (RW), Metadata (R), Issues (RW), Pull requests (RW), Actions (RW), Workflows (RW), Variables (RW), Webhooks (RW).</li>
+    </ul>
+    <Callout>
+      Never commit token values. <code>terraform.tfvars</code> is in the
+      repo's <code>.gitignore</code> for the same reason.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 4 · APPLY THE OPENTOFU CONFIG"
+    heading="Labels, Pages, branch protection in one go."
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'Create your tfvars.',
+          body: 'cp infra/github/terraform.tfvars.example infra/github/terraform.tfvars and set github_owner = "<you>". Leave create_phase_milestones at its default of false — phase milestones are upstream-only context and forks skip them.',
+        },
+        {
+          lead: 'Export the PAT.',
+          body: 'export GITHUB_TOKEN=github_pat_xxxxxxxx. Disappears when the shell exits.',
+        },
+        {
+          lead: 'Plan, then apply.',
+          body: 'cd infra/github && tofu init && tofu plan, then tofu apply once the diff looks right. Pages, labels, and branch protection roll out on your fork.',
+        },
+      ]}
+    />
+  </Section>
+
+  <Section
+    eyebrow="// 5 · ENABLE PAGES DEPLOY"
+    heading="One repository variable."
+  >
+    <p>
+      The <code>deploy-docs.yml</code> workflow ships{' '}
+      <strong>off by default on forks</strong> — its <code>if</code> guard
+      blocks the build for any owner other than upstream. To opt in on your
+      own fork, add a single repository variable.
+    </p>
+    <NumberedList
+      items={[
+        {
+          lead: 'Open Settings → Secrets and variables → Actions.',
+          body: 'Pick the "Variables" tab (not "Secrets").',
+        },
+        {
+          lead: 'Click "New repository variable".',
+          body: 'Name: VIVARIUM_FORK_DEPLOY, value: true.',
+        },
+        {
+          lead: 'Push or run the workflow manually.',
+          body: 'The deploy fires on the next push to main, or from Actions → Deploy docs to GitHub Pages → Run workflow.',
+        },
+      ]}
+    />
+    <p>
+      Removing the variable later turns the deploy back off. Layer 2
+      (Docker / GHCR) cannot push from a fork's token, so fork deploys{' '}
+      <strong>automatically ship Layer 1 only</strong>.
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 6 · ADD A RECIPE"
+    heading="One directory under src/layer1_wasm/<slug>/."
+  >
+    <p>The minimum unit of a Layer 1 recipe is one directory per upstream bug:</p>
+    <ul>
+      <li><code>src/layer1_wasm/&lt;slug&gt;/index.html</code> — the recipe page skeleton.</li>
+      <li><code>src/layer1_wasm/&lt;slug&gt;/repro.ts</code> — runs the reproduction in Pyodide / Ruby.wasm / php-wasm / Rust and sets the verdict.</li>
+      <li><code>src/layer1_wasm/&lt;slug&gt;/README.md</code> — what the recipe is.</li>
+    </ul>
+    <p>
+      The fastest path is to copy an existing recipe like{' '}
+      <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/pandas-56679"><code>pandas-56679</code></a>{' '}
+      or{' '}
+      <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/regex-779"><code>regex-779</code></a>,
+      change the slug (<code>&lt;project&gt;-&lt;issue&gt;</code> is the convention),
+      and rewrite the reproduction script.
+    </p>
+    <Callout>
+      The contract a recipe satisfies is{' '}
+      <a href="/vivarium/spec/contract-v1">Contract v1</a>. Emit{' '}
+      <code>&lt;meta name="vivarium-contract" content="v1"&gt;</code> and a{' '}
+      <code>#verdict</code> element with{' '}
+      <code>data-verdict="reproduced|unreproduced|pending"</code> and you're
+      conformant.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 7 · PUSH AND VERIFY"
+    heading="Open your Pages URL."
+  >
+    <p>
+      Push the recipe to <code>main</code>; with{' '}
+      <code>VIVARIUM_FORK_DEPLOY=true</code> set, the <code>deploy-docs</code>{' '}
+      workflow runs. Once green, the site is at:
+    </p>
+    <pre><code>{`https://<you>.github.io/vivarium/`}</code></pre>
+    <p>
+      Individual recipes land at{' '}
+      <code>/repro/&lt;project&gt;/&lt;issue&gt;/</code>. The URLs in
+      <code>recipes.json</code> are built from{' '}
+      <code>GITHUB_REPOSITORY_OWNER</code> and <code>GITHUB_REPOSITORY</code>{' '}
+      at deploy time, so a fork lands the right URLs without editing source.
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 8 · SHARE"
+    heading="Hand out the URL."
+  >
+    <p>
+      Drop your fork URL{' '}
+      (<code>https://&lt;you&gt;.github.io/vivarium/</code>) in an issue, PR,
+      or chat — whoever opens it can confirm the reproduction in their browser.
+      Because every recipe satisfies Contract v1, third-party tooling, including
+      AI agents, can read the verdict mechanically.
+    </p>
+  </Section>
+
+  <Callout>
+    If you later want to upstream a recipe you built here, the directory you
+    created on the fork can be PR'd as-is into{' '}
+    <code>aletheia-works/vivarium</code>. The contract is the same; verdicts
+    captured on the fork carry over.
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      Read the glossary{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="The terms that come up while adding recipes (slug, verdict, layer …) are pinned down in the guide's glossary."
+  primary={{ label: 'Glossary →', href: '/vivarium/guide/glossary' }}
+  ghost={{ label: 'Reproductions', href: '/vivarium/repro/' }}
+/>
+
+<BottomNote
+  text="VIVARIUM is part of ALETHEIA-WORKS · See the source on GitHub →"
+  href="https://github.com/aletheia-works/vivarium"
+/>

--- a/docs/docs/ja/guide/_meta.json
+++ b/docs/docs/ja/guide/_meta.json
@@ -6,6 +6,11 @@
   },
   {
     "type": "file",
+    "name": "fork-your-own",
+    "label": "自分のフォークで動かす"
+  },
+  {
+    "type": "file",
     "name": "glossary",
     "label": "用語集"
   }

--- a/docs/docs/ja/guide/fork-your-own.mdx
+++ b/docs/docs/ja/guide/fork-your-own.mdx
@@ -1,0 +1,234 @@
+---
+pageType: doc
+title: 自分のフォークで動かす
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  NumberedList,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · フォーク運用"
+    title="自分のフォークで Vivarium を動かす。"
+    sub="このリポジトリをフォークして、自分のバグ再現を自分の GitHub Pages に公開する手順。アップストリームに PR を投げなくても、自分自身のリポジトリで再現を整え、URL でシェアできる。"
+  />
+
+  <Section
+    eyebrow="// 0 · 何ができるか"
+    heading="自分の <user>.github.io/vivarium/ に自分のバグ再現を並べる。"
+  >
+    <p>
+      この使い方では、ユーザーは <code>aletheia-works/vivarium</code> をフォークし、
+      自分のフォークリポジトリの上で再現レシピを足したり編集したりして、
+      自分の GitHub Pages サイトとして公開します。アップストリームに
+      contribute するのではなく、<strong>自分のフォーク自体が公開先</strong>
+      になります。
+    </p>
+    <p>
+      Layer 1（ブラウザ内 WASM）は完全にあなたのフォーク側で完結します。
+      Layer 2 / 3（Docker・record-replay）はアップストリームの GHCR
+      イメージと統合された配信が前提なので、フォークでは <strong>Layer 1 のみ</strong>
+      が deploy されます。
+    </p>
+    <Callout>
+      アップストリームの再現一覧と並べる予定がない、自分専用の再現置き場として
+      使う運用を想定しています。共有したいときは <code>https://&lt;あなた&gt;.github.io/vivarium/</code>
+      の URL を渡すだけです。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 1 · リポジトリをフォークする"
+    heading="GitHub の UI から 1 クリック。"
+  >
+    <p>
+      <a href="https://github.com/aletheia-works/vivarium">aletheia-works/vivarium</a> 右上の
+      <strong>Fork</strong> ボタンから自分のアカウント（または組織）配下にフォークします。
+      リポジトリ名は <code>vivarium</code> のままでも、別名でも構いません（別名にした場合は
+      この手順書の <code>vivarium</code> 部分を読み替えてください）。
+    </p>
+    <p>
+      その後ローカルにクローンします:
+    </p>
+    <pre><code>{`git clone https://github.com/<あなた>/vivarium.git
+cd vivarium`}</code></pre>
+  </Section>
+
+  <Section
+    eyebrow="// 2 · ツールチェーンを揃える"
+    heading="mise が一括で入れる。"
+  >
+    <p>
+      このプロジェクトは <a href="https://mise.jdx.dev/">mise</a> でツールバージョンを管理しています。
+      クローン直下で:
+    </p>
+    <pre><code>{`mise install`}</code></pre>
+    <p>
+      これで <code>bun</code>（docs/MCP サーバ用）、<code>opentofu</code>（GitHub 設定の
+      Infrastructure-as-Code 用）、<code>uv</code>（Python ネイティブ再検証用）等が揃います。
+      レシピを追加する Layer / 言語によっては Rust ツールチェイン（<code>rustup</code>）も必要です。
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 3 · Fine-grained PAT を発行する"
+    heading="OpenTofu がフォークの設定を読み書きするためのトークン。"
+  >
+    <p>
+      <a href="https://github.com/settings/personal-access-tokens/new">
+      Settings → Developer settings → Personal access tokens → Fine-grained
+      </a>
+      から、自分のフォークリポジトリ宛のトークンを発行します。
+    </p>
+    <ul>
+      <li><strong>Resource owner</strong>: 自分のアカウント（または組織）</li>
+      <li><strong>Repository access</strong>: フォークしたリポジトリのみ</li>
+      <li><strong>Repository permissions</strong>: Administration (RW), Contents (RW), Metadata (R), Issues (RW), Pull requests (RW), Actions (RW), Workflows (RW), Variables (RW), Webhooks (RW)</li>
+    </ul>
+    <Callout>
+      トークン値は<strong>絶対にコミットしない</strong>でください。
+      <code>terraform.tfvars</code> もリポジトリの <code>.gitignore</code> に登録済みです。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 4 · OpenTofu でフォーク側のリポジトリ設定を整える"
+    heading="ラベル、Pages、ブランチ保護を一括反映。"
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'tfvars を作成。',
+          body: 'cp infra/github/terraform.tfvars.example infra/github/terraform.tfvars してから、github_owner = "<あなた>" に書き換えます。create_phase_milestones は false（デフォルト）のままでよく、Phase マイルストーンはアップストリーム専用なのでフォークでは作成されません。',
+        },
+        {
+          lead: 'PAT を環境変数に。',
+          body: 'export GITHUB_TOKEN=github_pat_xxxxxxxx。シェルが閉じれば消えます。',
+        },
+        {
+          lead: 'plan して apply。',
+          body: 'cd infra/github && tofu init && tofu plan の出力を確認した上で tofu apply。Pages の有効化、ラベル、ブランチ保護がフォーク側に反映されます。',
+        },
+      ]}
+    />
+  </Section>
+
+  <Section
+    eyebrow="// 5 · GitHub Pages のデプロイを有効にする"
+    heading="リポジトリ変数を 1 つ足すだけ。"
+  >
+    <p>
+      フォークでは GitHub Pages へのデプロイは<strong>デフォルトで止めて</strong>あります
+      （<code>.github/workflows/deploy-docs.yml</code> の <code>if</code> 条件によるもの）。
+      フォークの所有者として deploy を有効化したい場合は、リポジトリ変数を 1 つ足します。
+    </p>
+    <NumberedList
+      items={[
+        {
+          lead: 'GitHub UI で Settings → Secrets and variables → Actions を開く。',
+          body: '"Variables" タブを選びます（"Secrets" ではありません）。',
+        },
+        {
+          lead: '"New repository variable" をクリック。',
+          body: 'Name: VIVARIUM_FORK_DEPLOY、Value: true。',
+        },
+        {
+          lead: '次の push、または手動実行で deploy が走る。',
+          body: 'Actions タブ → Deploy docs to GitHub Pages → Run workflow から手動でも起動できます。',
+        },
+      ]}
+    />
+    <p>
+      この変数を後で消せば、deploy は再びスキップされます。
+      Layer 2（Docker / GHCR）はフォークの権限ではプッシュできないため、
+      フォーク deploy では<strong>自動的に Layer 1 のみ</strong>がバンドルされます。
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 6 · 自分のレシピを追加する"
+    heading="src/layer1_wasm/<slug>/ にディレクトリを 1 つ。"
+  >
+    <p>
+      Layer 1 レシピの最小単位は、再現したい上流バグごとに 1 つのディレクトリです:
+    </p>
+    <ul>
+      <li><code>src/layer1_wasm/&lt;slug&gt;/index.html</code> — レシピページの骨格</li>
+      <li><code>src/layer1_wasm/&lt;slug&gt;/repro.ts</code> — Pyodide / Ruby.wasm / php-wasm / Rust などで再現スクリプトを実行し、verdict を設定</li>
+      <li><code>src/layer1_wasm/&lt;slug&gt;/README.md</code> — レシピの説明</li>
+    </ul>
+    <p>
+      既存の <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/pandas-56679"><code>pandas-56679</code></a>
+      や <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/regex-779"><code>regex-779</code></a> を雛形にコピーして、
+      上流バグの slug（<code>&lt;project&gt;-&lt;issue&gt;</code> 推奨）と
+      再現スクリプトを書き換えるのが最短です。
+    </p>
+    <Callout>
+      レシピが satisfy するべき仕様は <a href="/vivarium/ja/spec/contract-v1">Contract v1</a>
+      に書かれています。<code>&lt;meta name="vivarium-contract" content="v1"&gt;</code> と
+      <code>data-verdict="reproduced|unreproduced|pending"</code> の <code>#verdict</code>
+      要素を出力すれば、自動的に整合します。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 7 · push して deploy を確認"
+    heading="自分の Pages URL でレシピを開く。"
+  >
+    <p>
+      レシピを <code>main</code> にプッシュすると、<code>VIVARIUM_FORK_DEPLOY=true</code>
+      が設定されたフォークでは <code>deploy-docs</code> ワークフローが走ります。完了後、
+      以下の URL でサイトが見えます:
+    </p>
+    <pre><code>{`https://<あなた>.github.io/vivarium/`}</code></pre>
+    <p>
+      個別レシピは <code>/repro/&lt;project&gt;/&lt;issue&gt;/</code> 以下に配置されます。
+      この URL は <code>recipes.json</code> 生成時に <code>GITHUB_REPOSITORY_OWNER</code> /
+      <code>GITHUB_REPOSITORY</code> から動的に組み立てられるため、フォークでも
+      ハードコード書き換えなしで正しい URL が出力されます。
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 8 · 共有する"
+    heading="URL を渡すだけ。"
+  >
+    <p>
+      自分のフォーク URL（<code>https://&lt;あなた&gt;.github.io/vivarium/</code>）を Issue
+      / PR / 社内チャットで共有すれば、相手はブラウザを開くだけで再現を確認できます。
+      Vivarium のレシピは Contract v1 に従っているので、AI エージェントを含む第三者ツールが
+      verdict を機械的に読むこともできます。
+    </p>
+  </Section>
+
+  <Callout>
+    アップストリームに re-publish したくなったら、自分のフォークで作ったレシピディレクトリを
+    そのまま PR にして <code>aletheia-works/vivarium</code> に投げられます。仕様（Contract v1）
+    が同じなので、フォーク時代の verdict はそのまま意味を持ちます。
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// 次のページ"
+  heading={
+    <>
+      用語集を読む{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="レシピ追加で出てくる用語（slug、verdict、layer など）はガイド配下の用語集にまとめてあります。"
+  primary={{ label: '用語集 →', href: '/vivarium/ja/guide/glossary' }}
+  ghost={{ label: '再現一覧', href: '/vivarium/ja/repro/' }}
+/>
+
+<BottomNote
+  text="VIVARIUM は ALETHEIA-WORKS の一部 · GitHub でソースを見る →"
+  href="https://github.com/aletheia-works/vivarium"
+/>

--- a/docs/scripts/generate-recipes-index.ts
+++ b/docs/scripts/generate-recipes-index.ts
@@ -37,8 +37,15 @@ import { readdir, readFile, stat, mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const PAGES_BASE = 'https://aletheia-works.github.io/vivarium';
-const REPO_BASE = 'https://github.com/aletheia-works/vivarium';
+// Owner and repository name. Resolved from CI-provided env vars when
+// the script runs in GitHub Actions (so a fork's deploy bundles its
+// own URLs); falls back to the upstream values for local dev.
+const OWNER = process.env['GITHUB_REPOSITORY_OWNER'] ?? 'aletheia-works';
+const REPO_NAME =
+  process.env['GITHUB_REPOSITORY']?.split('/')[1] ?? 'vivarium';
+
+const PAGES_BASE = `https://${OWNER}.github.io/${REPO_NAME}`;
+const REPO_BASE = `https://github.com/${OWNER}/${REPO_NAME}`;
 
 type Layer = 1 | 2 | 3;
 

--- a/infra/github/main.tf
+++ b/infra/github/main.tf
@@ -385,7 +385,10 @@ locals {
 }
 
 resource "github_repository_milestone" "phases" {
-  for_each = local.milestones
+  # Phase milestones are upstream-only context. Forks running this
+  # configuration on their own copy of the repository skip them by
+  # default; the upstream tfvars sets `create_phase_milestones = true`.
+  for_each = var.create_phase_milestones ? local.milestones : {}
 
   owner       = var.github_owner
   repository  = github_repository.this.name

--- a/infra/github/terraform.tfvars.example
+++ b/infra/github/terraform.tfvars.example
@@ -12,8 +12,25 @@
 # In GitHub Actions, tfvars are not used — values are injected via
 # environment variables and workflow inputs.
 
+# ─── Required ────────────────────────────────────────────────────────
+#
+# Set this to your own GitHub user or org if you forked the repo.
+# The upstream value is "aletheia-works".
 github_owner = "aletheia-works"
 
-# Defaults are usually fine. Override only when needed:
+
+# ─── Optional ────────────────────────────────────────────────────────
+#
+# Defaults are usually fine. Override only when needed.
+#
 # repository_name        = "vivarium"
 # repository_visibility  = "public"
+#
+# `create_phase_milestones` controls whether the Vivarium Phase 0–N
+# milestone set is materialised on the repository. Phase milestones are
+# upstream context (a roadmap shape this project happens to use); fork
+# users do not need them. Default: false.
+#
+# Upstream `aletheia-works/vivarium` overrides this to `true`:
+#
+# create_phase_milestones = true

--- a/infra/github/variables.tf
+++ b/infra/github/variables.tf
@@ -43,3 +43,15 @@ variable "repository_topics" {
     "open-source",
   ]
 }
+
+# Whether to create the project's Phase 0–N milestones on the
+# repository. The phase taxonomy is upstream-only context;
+# fork users running this configuration on their own copy do
+# not need them. Default: false (fork-friendly). The upstream
+# `aletheia-works/vivarium` repo sets this to `true` in its own
+# terraform.tfvars.
+variable "create_phase_milestones" {
+  description = "Whether to create the Vivarium Phase milestones (upstream only)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION

Add the second supported usage path for this project: fork the repo,
add your own bug reproductions, and publish them to your own GitHub
Pages site — without ever opening a PR upstream. Layer 1 (in-browser
WASM) ships end-to-end on a fork; Layer 2 (Docker / GHCR) stays
upstream-only.

This change set also fixes two pre-existing Layer 2 bundling bugs
that the surface inspection above turned up. Both are deploy-side
fixes; no Layer 2 source HTML was touched.

## OpenTofu — fork-friendly defaults

- variables.tf: new `create_phase_milestones` boolean (default false).
  Phase milestones are upstream-only context; forks skip them.
- main.tf: `github_repository_milestone.phases` for_each gated on
  the new variable.
- terraform.tfvars.example: documents the upstream-vs-fork flow,
  with the `create_phase_milestones = true` line shown as the
  upstream override.

The repo URL itself was already variable (`var.github_owner`), so a
fork user only needs to set their own owner in tfvars.

## deploy-docs.yml — opt-in for fork deploys

- The build job now runs when either `repository_owner == 'aletheia-works'`
  or repository variable `VIVARIUM_FORK_DEPLOY == 'true'`. Fork users
  enable it by adding one Variables-tab entry; no workflow YAML edit,
  no merge conflicts on upstream pulls.
- Layer 2 GHCR login + image build/push gain an inner
  `if: repository_owner == 'aletheia-works'` so fork deploys ship
  Layer 1 only (forks have no GHCR push scope into
  ghcr.io/aletheia-works/*).
- `pages_prefix` is now built from `${GITHUB_REPOSITORY_OWNER}` and
  `${GITHUB_REPOSITORY##*/}`, so the bundling layout matches each
  fork's own `<owner>.github.io/<repo>/repro/` URL.

## Layer 2 bundling fixes

Two bugs surfaced while reviewing the Layer 2 deploy path:

- **Missing styles on every Layer 2 page.** Each
  `src/layer2_docker/<slug>/index.html` references
  `<link rel="stylesheet" href="../_shared/style.css" />` for the
  shared chrome. The styles live under `src/layer1_wasm/_shared/` and
  are reused, but the bundling step only copied the Layer 2-specific
  `_*/` directories under each project — `_shared/style.css` ended up
  404 and pages rendered unstyled. Layer 2 staging now also copies
  `src/layer1_wasm/_shared/` into `<dest>/<project>/_shared/`.
- **404 on legacy slug-only Layer 2 URLs.** When Layer 2 moved to
  `<pages-base>/repro/<project>/<issue_path>/` no redirect was left
  at the previous `<pages-base>/repro/<slug>/` location. Reproduced
  with `/repro/postgres-lost-update/`. Layer 2 bundling now writes a
  meta-refresh redirect at `<dest>/<slug>/index.html` for each
  recipe whose hierarchical URL differs from the slug, mirroring the
  Layer 1 `<dest>/poc/<slug>/` legacy-redirect pattern.

## generate-recipes-index.ts — owner/repo from env

`PAGES_BASE` and `REPO_BASE` resolve from `GITHUB_REPOSITORY_OWNER` and
`GITHUB_REPOSITORY` at runtime (with the upstream values as the local
fallback). A fork's `recipes.json` ends up with the fork's own URLs
without source edits.

## ReproCompare.tsx — runtime PAGES_BASE

The compare-page component derives its lookup base from
`window.location` (the segment of the URL before `/repro`), so the
deployed-snapshot fetch hits the same host the page is served from.
Fork users running their own compare page see their own deployed
snapshots, not upstream's.

## docs/guide — "Run on your own fork"

New tutorial-genre page (ja+en) walking through the eight-step path:
fork → clone → mise install → fine-grained PAT → tofu apply →
opt-in `VIVARIUM_FORK_DEPLOY=true` → push → share. Slotted under the
guide section between `getting-started` and `glossary`.

## Verification

- mise run docs:build succeeds (1.5 MB, all pages including the new
  guide entries generated for both locales).
- preview confirmed for /vivarium/ja/guide/fork-your-own and
  /vivarium/guide/fork-your-own; sidebar reflects the new ordering
  (Overview → First five minutes → Run on your own fork → Glossary).
- deploy-docs.yml round-trips through PyYAML and the Layer 2 heredoc
  terminator sits at column 0 after `run: |` indentation strip —
  matching the Layer 1 pattern that has been live for several releases.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
