### PR TITLE
feat(docs): phase 7 D — integrate-with-your-repo guide (ja+en)

### DIFF
--- a/docs/docs/en/guide/_meta.json
+++ b/docs/docs/en/guide/_meta.json
@@ -6,6 +6,11 @@
   },
   {
     "type": "file",
+    "name": "integrate-with-your-repo",
+    "label": "Integrate with your own repo"
+  },
+  {
+    "type": "file",
     "name": "fork-your-own",
     "label": "Run on your own fork"
   },

--- a/docs/docs/en/guide/getting-started.mdx
+++ b/docs/docs/en/guide/getting-started.mdx
@@ -154,7 +154,7 @@ import {
         },
         {
           lead: 'Declare a Vivarium reproduction in your repo.',
-          body: 'Start with the Manifest v1 spec (/spec/manifest-v1) and the interactive scaffolder (/spec/manifest-create).',
+          body: 'The "Integrate with your own repo" guide (/guide/integrate-with-your-repo) walks through it end-to-end. Authoritative spec: Manifest v1 (/spec/manifest-v1).',
         },
         {
           lead: 'Drive Vivarium from an AI agent.',

--- a/docs/docs/en/guide/integrate-with-your-repo.mdx
+++ b/docs/docs/en/guide/integrate-with-your-repo.mdx
@@ -1,0 +1,240 @@
+---
+pageType: doc
+title: Integrate with your own repo
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  NumberedList,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · INTEGRATION"
+    title="Declare and verify a Vivarium reproduction in your own repo."
+    sub="No fork required. Drop one file at the root of your project repo and add one CI job, and you have declared 'we host a reproduction for this bug.' Upstream-fix detection rides on the same wiring."
+  />
+
+  <Section
+    eyebrow="// 0 · WHAT YOU GET"
+    heading="A Vivarium verdict signal in your own CI."
+  >
+    <p>
+      In this flow your project repo (not a fork of Vivarium — your normal
+      product or library repo) gains exactly two additions:
+    </p>
+    <ul>
+      <li>
+        <code>.vivarium/manifest.toml</code> — a declaration that says
+        "Vivarium-compatible reproduction lives here"
+        (spec: <a href="/vivarium/en/spec/manifest-v1">Manifest v1</a>).
+      </li>
+      <li>
+        <code>.github/workflows/check-bug.yml</code> — a one-job CI workflow
+        that <code>uses:</code> the
+        {' '}<a href="/vivarium/en/spec/consumer-workflow">reusable verdict workflow</a>.
+      </li>
+    </ul>
+    <p>
+      That's enough to make "is this upstream bug still reproducing?" a green /
+      red signal in your own CI, on every PR or on a daily schedule. The day
+      upstream ships a fix, the workflow turns red — and that red is your
+      "we no longer need to track this bug" signal.
+    </p>
+    <Callout>
+      You don't copy any Vivarium source. The reusable workflow is maintained
+      org-side, so you only carry the <code>uses:</code> link — Vivarium-side
+      improvements ride along automatically.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 1 · PICK A BUG TO TRACK"
+    heading="If it's already in the catalogue, just note one slug."
+  >
+    <p>
+      If the upstream bug is already in the Vivarium catalogue, jot down its
+      slug (<code>&lt;project&gt;-&lt;issue&gt;</code> shape) and you're done
+      with this step. For example:
+    </p>
+    <ul>
+      <li><code>bash-local-shadows-exit</code> (Layer 2 / bash)</li>
+      <li><code>pandas-56679</code> (Layer 1 / pandas)</li>
+    </ul>
+    <p>
+      The faceted{' '}<a href="/vivarium/en/repro/">recipe gallery</a>{' '}
+      is the way to browse. If you have a concrete error message in hand, the{' '}
+      <a href="/vivarium/en/repro/match">error → recipe matcher</a>{' '}
+      ranks candidates for you.
+    </p>
+    <Callout>
+      If the upstream bug isn't in the catalogue yet, you're in the "build a
+      new recipe" path instead, which is documented in{' '}
+      <a href="/vivarium/en/guide/fork-your-own">Run on your own fork</a>.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 2 · DROP A MANIFEST"
+    heading="Generate it from a form, copy it into your repo."
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'Generate via the scaffolder.',
+          body: <>An interactive form lives at <a href="/vivarium/en/spec/manifest-create">Create a manifest</a>. Fill in slug, layer, bug.project, bug.issue, bug.upstream_url, hit "Generate," and the TOML pops out.</>,
+        },
+        {
+          lead: 'Drop it at the repo root.',
+          body: <>Save the generated TOML as <code>.vivarium/manifest.toml</code> (create the <code>.vivarium</code> directory at the repo root). Both the directory and filename are fixed; nothing recognises the file at any other path.</>,
+        },
+        {
+          lead: 'Wire schema completion (optional).',
+          body: <>The first line of the TOML should be <code>{`#:schema https://aletheia-works.github.io/vivarium/spec/manifest.schema.json`}</code> (the scaffolder writes it for you). Editors with a TOML language server (Taplo, Tombi) pick this up automatically and give you completion plus inline validation.</>,
+        },
+      ]}
+    />
+    <Callout>
+      Hand-writing the manifest is fine — the scaffolder is just there to spit
+      out the canonical shape. The authoritative spec is{' '}
+      <a href="/vivarium/en/spec/manifest-v1">Manifest v1</a>, and
+      <code>verdict.schema.json</code> is published, so CI-side validation is
+      possible too.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 3 · ADD A VERDICT JOB"
+    heading="Layer 2 / 3: just `uses:` the reusable workflow."
+  >
+    <p>
+      Save the following at <code>.github/workflows/check-bug.yml</code>{' '}
+      (replacing <code>slug:</code> with the one you noted in step 1):
+    </p>
+    <pre><code>{`name: vivarium-check
+on:
+  pull_request:
+  schedule:
+    - cron: '17 4 * * *'  # once a day at 04:17 UTC
+
+jobs:
+  bash-issue:
+    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    with:
+      slug: bash-local-shadows-exit
+`}</code></pre>
+    <p>
+      That pulls{' '}
+      <code>ghcr.io/aletheia-works/vivarium-bash-local-shadows-exit:latest</code>,
+      runs the recipe, captures a Contract v1 <code>verdict.json</code>,
+      validates it against the published JSON Schema, and asserts the captured
+      verdict matches <code>expected_verdict</code> (default{' '}
+      <code>"reproduced"</code>). Anything else turns the job red.
+    </p>
+    <p>
+      Tracking several bugs is a matter of stacking jobs:
+    </p>
+    <pre><code>{`jobs:
+  bash-issue:
+    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    with:
+      slug: bash-local-shadows-exit
+  pandas-issue:
+    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    with:
+      slug: pandas-56679
+`}</code></pre>
+    <Callout>
+      Layer 1 (in-browser WASM) recipes can't be verified through this reusable
+      workflow because their verdict is set live in DOM / JavaScript. The
+      Vivarium gallery's own Playwright suite is the canonical regression check
+      for Layer 1. You can still <em>declare</em> a Layer 1 manifest by
+      pointing <code>page_url</code> at the live page; the gallery side handles
+      verification.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 4 · VERIFY"
+    heading="Green = the bug still reproduces today."
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'Push to a branch and open a PR.',
+          body: 'One commit holding both files (manifest plus check-bug.yml) is enough. A minimal commit message such as feat(ci): subscribe to bash-local-shadows-exit verdict is fine.',
+        },
+        {
+          lead: 'Check the Actions tab for vivarium-check.',
+          body: 'First run takes 1–2 minutes due to the GHCR image pull. On completion, the job artifact verdict-<slug>-<run_id> contains a JSON document that conforms to verdict.schema.json.',
+        },
+        {
+          lead: 'Keep the cron line.',
+          body: 'Even one run a day is enough — the day the upstream project ships a fix that no longer reproduces, your CI turns red, and that red is the upstream-fix detection signal.',
+        },
+      ]}
+    />
+    <Callout>
+      <strong>Red means "fixed," not "broken."</strong> The verdict semantics
+      flip the test-mindset direction; the glossary{' '}
+      <a href="/vivarium/en/guide/glossary#verdict">verdict</a> entry and the{' '}
+      <a href="/vivarium/en/spec/contract-v1#verdict-semantics">Contract v1</a>{' '}
+      page nail this down.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 5 · WHERE TO GO NEXT"
+    heading="Lines that branch out from this surface."
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'Verify a candidate fix actually flips the verdict.',
+          body: <>The comparison surface lets you put the post-fix verdict next to the pre-fix one: <a href="/vivarium/en/repro/compare">Compare reproductions</a>. It's the page built for AI-generated patches — a reproduced → unreproduced flip is exactly the "the fix worked" signal.</>,
+        },
+        {
+          lead: 'Pin to a specific image tag.',
+          body: <>The reusable workflow takes an <code>image:</code> input that overrides the default. A git-sha-tagged image, a private fork build — anything in GHCR — is fair game. Reference: the input table in <a href="/vivarium/en/spec/consumer-workflow">consumer workflow</a>.</>,
+        },
+        {
+          lead: 'Declare without scheduled checks.',
+          body: <>Drop the cron line and add <code>workflow_dispatch:</code> for manual-only runs. A reasonable shape for slow-moving upstream bugs that don't reward daily polling.</>,
+        },
+        {
+          lead: 'The bug isn\'t in the catalogue yet.',
+          body: <>Then you're writing a new recipe, not consuming one. <a href="/vivarium/en/guide/fork-your-own">Run on your own fork</a> covers that flow. Layer 1 is fully self-contained inside a fork.</>,
+        },
+      ]}
+    />
+  </Section>
+
+  <Callout>
+    If a step in this guide didn't work, that's a bug in this guide — file an
+    issue with the exact step where you got stuck. Where readers get stuck
+    sets the priority for the next docs revision.
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      Read the glossary{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="The terms used here — manifest, verdict, layer, slug — are pinned to fixed meanings in the glossary."
+  primary={{ label: 'Glossary →', href: '/vivarium/en/guide/glossary' }}
+  ghost={{ label: 'Manifest v1 spec', href: '/vivarium/en/spec/manifest-v1' }}
+/>
+
+<BottomNote
+  text="VIVARIUM IS PART OF ALETHEIA-WORKS · SEE SOURCE ON GITHUB →"
+  href="https://github.com/aletheia-works/vivarium"
+/>

--- a/docs/docs/ja/guide/_meta.json
+++ b/docs/docs/ja/guide/_meta.json
@@ -6,6 +6,11 @@
   },
   {
     "type": "file",
+    "name": "integrate-with-your-repo",
+    "label": "自分のリポジトリに統合する"
+  },
+  {
+    "type": "file",
     "name": "fork-your-own",
     "label": "自分のフォークで動かす"
   },

--- a/docs/docs/ja/guide/getting-started.mdx
+++ b/docs/docs/ja/guide/getting-started.mdx
@@ -150,7 +150,7 @@ import {
         },
         {
           lead: '自分のリポジトリに Vivarium 再現を宣言したい。',
-          body: 'spec の Manifest v1 (/spec/manifest-v1) と、対話的なスキャフォールダ (/spec/manifest-create) から始める。',
+          body: 'ガイドの「自分のリポジトリに統合する」(/guide/integrate-with-your-repo) が手順を一通り通す。仕様の正典は Manifest v1 (/spec/manifest-v1)。',
         },
         {
           lead: 'AI エージェントから呼びたい。',

--- a/docs/docs/ja/guide/integrate-with-your-repo.mdx
+++ b/docs/docs/ja/guide/integrate-with-your-repo.mdx
@@ -1,0 +1,236 @@
+---
+pageType: doc
+title: 自分のリポジトリに統合する
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  NumberedList,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · 統合"
+    title="自分のリポジトリで Vivarium 再現を宣言・検証する。"
+    sub="Vivarium 本体をフォークしなくても、自分のリポジトリのルートに 1 ファイルを置き、CI ジョブを 1 つ足すだけで「私たちはこのバグの再現をホストしている」と宣言できる。アップストリーム修正の到達も同じ仕組みで自動検知される。"
+  />
+
+  <Section
+    eyebrow="// 0 · 何が手に入るか"
+    heading="自分のリポジトリの CI に Vivarium verdict が乗る。"
+  >
+    <p>
+      この統合パスでは、自分のリポジトリ（フォークではなく、ふつうのプロジェクトリポジトリ）
+      に 2 つだけ追加します:
+    </p>
+    <ul>
+      <li>
+        <code>.vivarium/manifest.toml</code> — Vivarium 互換再現の宣言ファイル
+        （仕様: <a href="/vivarium/ja/spec/manifest-v1">Manifest v1</a>）。
+      </li>
+      <li>
+        <code>.github/workflows/check-bug.yml</code> —
+        <a href="/vivarium/ja/spec/consumer-workflow">再利用可能 verdict ワークフロー</a>
+        を <code>uses:</code> で呼ぶだけのジョブ。
+      </li>
+    </ul>
+    <p>
+      これだけで、対象のアップストリームバグが今でも再現するかどうかが、
+      自分の CI の green / red シグナルとして毎日（あるいは毎 PR で）勝手に検証されます。
+      アップストリームが修正を出荷した瞬間、CI が赤くなり、その瞬間が
+      「このバグはもう追跡しなくてよい」のシグナルになります。
+    </p>
+    <Callout>
+      Vivarium 本体のソースをコピーしません。再利用可能ワークフローが組織側で
+      保守されているので、こちらは <code>uses:</code> のリンクだけ持っておけば、
+      Vivarium 側の改善が自動で乗ります。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 1 · 検証したいバグを選ぶ"
+    heading="既存のレシピなら、すぐ使えるスラッグを 1 つ控える。"
+  >
+    <p>
+      Vivarium カタログにすでに存在するバグなら、
+      そのスラッグ（<code>&lt;project&gt;-&lt;issue&gt;</code> 形式）を控えるだけで進めます。
+      たとえば:
+    </p>
+    <ul>
+      <li><code>bash-local-shadows-exit</code>（Layer 2 / bash）</li>
+      <li><code>pandas-56679</code>（Layer 1 / pandas）</li>
+    </ul>
+    <p>
+      <a href="/vivarium/ja/repro/">再現一覧</a> でファセット検索ができます。
+      自分が追跡しているエラーメッセージを起点にしたい場合は{' '}
+      <a href="/vivarium/ja/repro/match">エラーからレシピを探す</a> を使えば
+      候補がスコア順で出ます。
+    </p>
+    <Callout>
+      アップストリームでまだ再現が無いバグの場合は、自分のフォークでレシピ自体を作る
+      ルートになります。手順は{' '}
+      <a href="/vivarium/ja/guide/fork-your-own">自分のフォークで動かす</a>{' '}
+      に分けてあります。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 2 · manifest.toml を作る"
+    heading="フォームに入れて生成、リポジトリにコピー。"
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'スキャフォールダで生成。',
+          body: <>対話的に埋められるフォームが <a href="/vivarium/ja/spec/manifest-create">マニフェスト作成</a> にあります。slug、layer、bug.project、bug.issue、bug.upstream_url を埋めて「生成」を押すと TOML がそのまま出ます。</>,
+        },
+        {
+          lead: 'リポジトリのルートに配置。',
+          body: <>生成された TOML を <code>.vivarium/manifest.toml</code>（リポジトリのルート直下に <code>.vivarium</code> ディレクトリを作る）として保存します。ファイル名・パス共に固定で、それ以外の場所では認識されません。</>,
+        },
+        {
+          lead: 'スキーマ補完を効かせる（任意）。',
+          body: <>TOML の先頭行に <code>{`#:schema https://aletheia-works.github.io/vivarium/spec/manifest.schema.json`}</code> が入っているはずです（スキャフォールダが付けます）。Taplo / Tombi など TOML LSP のあるエディタは、これだけで補完と検証が効きます。</>,
+        },
+      ]}
+    />
+    <Callout>
+      手書きしてもよく、スキャフォールダはあくまで<strong>典型形を出す道具</strong>
+      です。仕様の正典は <a href="/vivarium/ja/spec/manifest-v1">Manifest v1</a>{' '}
+      で、<code>verdict.schema.json</code> も公開済みなので CI でも検証できます。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 3 · CI に verdict ジョブを 1 つ追加する"
+    heading="Layer 2 / 3 は再利用可能ワークフローを uses: するだけ。"
+  >
+    <p>
+      <code>.github/workflows/check-bug.yml</code> として以下を保存します
+      （<code>slug:</code> は手順 1 で控えたものに置き換えてください）:
+    </p>
+    <pre><code>{`name: vivarium-check
+on:
+  pull_request:
+  schedule:
+    - cron: '17 4 * * *'  # 毎日 1 回、UTC 04:17
+
+jobs:
+  bash-issue:
+    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    with:
+      slug: bash-local-shadows-exit
+`}</code></pre>
+    <p>
+      これで <code>ghcr.io/aletheia-works/vivarium-bash-local-shadows-exit:latest</code>{' '}
+      がプルされ、レシピが実行され、Contract v1 準拠の <code>verdict.json</code>{' '}
+      がキャプチャされ、JSON Schema で検証されます。
+      verdict が <code>expected_verdict</code>（デフォルト <code>"reproduced"</code>）と
+      一致しなければジョブが赤くなります。
+    </p>
+    <p>
+      追跡したいバグが複数ある場合は、ジョブを並べるだけ:
+    </p>
+    <pre><code>{`jobs:
+  bash-issue:
+    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    with:
+      slug: bash-local-shadows-exit
+  pandas-issue:
+    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    with:
+      slug: pandas-56679
+`}</code></pre>
+    <Callout>
+      Layer 1（ブラウザ内 WASM）の再現は、verdict が DOM / JavaScript ライブで決まるため、
+      この再利用可能ワークフローでは検証できません。Layer 1 のリグレッション検知は
+      Vivarium 本体の Playwright スイートが既に正式な仕組みとして担当しています。
+      Layer 1 をマニフェストで宣言するだけは可能で、その場合
+      <code>page_url</code> を貼り、検証はサイト側に任せる運用になります。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 4 · 動作確認"
+    heading="緑が出れば「再現は今でも本物」。"
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'ブランチを作って push する。',
+          body: '上の 2 ファイル（manifest と check-bug.yml）を 1 commit にして PR を立てます。最低限のコミットメッセージは feat(ci): subscribe to bash-local-shadows-exit verdict のような形で十分です。',
+        },
+        {
+          lead: 'Actions タブで vivarium-check を確認。',
+          body: '初回は GHCR からのイメージプルがあるので 1〜2 分かかります。完了するとジョブのアーティファクトに verdict-<slug>-<run_id> が出ます。中身が verdict.schema.json に従う JSON です。',
+        },
+        {
+          lead: 'スケジューラの cron 行を残す。',
+          body: '毎日 1 回でも回しておくと、アップストリームが修正を出荷した日に CI が赤くなり、Slack / メール / GitHub の通知でその瞬間が分かります。これがアップストリーム修正検知シグナルそのものです。',
+        },
+      ]}
+    />
+    <Callout>
+      <strong>赤くなったら「壊れた」ではなく「修正された」</strong>。verdict セマンティクスが
+      テスト的な感覚と逆向きである点は、用語集の{' '}
+      <a href="/vivarium/ja/guide/glossary#verdict">verdict</a> と{' '}
+      <a href="/vivarium/ja/spec/contract-v1#verdict-セマンティクス">Contract v1</a>{' '}
+      で改めて固定しています。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 5 · 次の選択肢"
+    heading="この surface から続く線。"
+  >
+    <NumberedList
+      items={[
+        {
+          lead: '修正候補が本当に効いているか確かめたい。',
+          body: <>ブランチで書いた fix を当てた後の verdict と、当てる前の verdict を横並びで比較する surface があります: <a href="/vivarium/ja/repro/compare">再現を比較する</a>。AI エージェントが書いたパッチの検証用に作られたページで、reproduced → unreproduced への反転がそのまま「修正は効いた」のシグナルになります。</>,
+        },
+        {
+          lead: '特定のイメージタグにピン留めしたい。',
+          body: <>再利用可能ワークフローの <code>image:</code> インプットでオーバーライドできます。git-sha 付きタグや、自分のフォークで Build した GHCR イメージを差し込めます。仕様: <a href="/vivarium/ja/spec/consumer-workflow">consumer workflow</a> のインプット表。</>,
+        },
+        {
+          lead: '宣言だけして CI 検証は手動で回したい。',
+          body: <>cron 行を消して <code>workflow_dispatch:</code> を足せば、Actions タブから手動実行のみになります。低頻度のレシピ（年単位で動かない上流）に向いた運用です。</>,
+        },
+        {
+          lead: 'カタログに無いバグを追加したい。',
+          body: <>レシピ自体を新しく書く話なので、<a href="/vivarium/ja/guide/fork-your-own">自分のフォークで動かす</a> の手順から入ります。Layer 1 だけならフォーク内で完結します。</>,
+        },
+      ]}
+    />
+  </Section>
+
+  <Callout>
+    この手順がうまく動かなかった箇所は、それは integrate ガイドのバグです。
+    具体的にどのステップで詰まったかを Issue に残してください——
+    どこで詰まるかが、次のドキュメント版の優先順位を決めます。
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      用語集を読む{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="manifest / verdict / Layer / slug などここで出てきた用語は、用語集に固定的な意味でまとめてあります。"
+  primary={{ label: '用語集 →', href: '/vivarium/ja/guide/glossary' }}
+  ghost={{ label: 'マニフェスト v1 仕様', href: '/vivarium/ja/spec/manifest-v1' }}
+/>
+
+<BottomNote
+  text="VIVARIUM は ALETHEIA-WORKS の一部 · GitHub でソースを見る →"
+  href="https://github.com/aletheia-works/vivarium"
+/>


### PR DESCRIPTION

Adds the third onboarding page in the Phase 7 D sub-stream
(ADR-0028): a step-by-step procedure for declaring a Vivarium
reproduction in a third-party project repo via
.vivarium/manifest.toml + the reusable consumer-workflow.yml.

Why:
- Phase 7 D pages so far cover landing (getting-started),
  vocabulary (glossary), and self-publishing (fork-your-own).
  The "I have a project repo and want to track an upstream
  bug from my own CI" path was not yet documented as a
  procedural guide — only as scattered references in the
  spec pages.
- Phase 6 M.1 (manifest scaffolder) and Phase 5 reusable
  workflow are both shipped; this page wires them into the
  "first 30 minutes for a stranger" surface ADR-0028 calls
  for, without depending on any unshipped primitive.

Wiring:
- New page in ja+en under guide/integrate-with-your-repo.
- _meta.json updated in both locales (slot 2: between
  getting-started and fork-your-own — the natural reading
  order for someone who already saw a recipe run).
- getting-started.mdx "where to go next" item that pointed
  directly at the spec pages now points at this guide first
  with the spec as the reference link.

Verified: bun run build (docs/) clean, both pages emitted
to doc_build/{,ja/}guide/integrate-with-your-repo.html.

Out of scope:
- D-4 ("Use Vivarium from your AI agent") — blocked on the
  MCP server being published to JSR/npm (no
  mcp-server-v*.*.* tag exists yet). Spawned a separate
  task chip for that.
