### PR TITLE
fix(ci): pass create_phase_milestones=true to upstream tofu apply

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -33,4 +33,10 @@ jobs:
     uses: aletheia-works/.github/.github/workflows/terraform-apply.yml@ffd7b8b9619fe8da13233a21c920b4d56b126f28 # main
     with:
       working_directory: infra/github
+      # Phase milestones are upstream-only context (variables.tf comment).
+      # The caller-side `if: github.repository_owner == 'aletheia-works'`
+      # already gates this whole job to upstream, so opting in here is
+      # safe — fork applies never run this workflow.
+      tfvar_assignments: |
+        create_phase_milestones=true
     secrets: inherit


### PR DESCRIPTION

Restores the eight Phase 0–7 milestones that disappeared from the
GitHub repository after #166 merged.

Background:
- #166 added the create_phase_milestones variable (default false) to
  gate phase milestone creation off for fork users.
- The upstream caller .github/workflows/terraform-apply.yml does not
  pass any tfvars, so on the post-#166 apply the variable resolved
  to its default `false`, the for_each set went empty, and OpenTofu
  destroyed all eight milestones (Phase 0 through Phase 7).
- Issues and PRs that were attached to those milestones have lost
  the assignment. Their timeline events still record the historical
  attachment (verified via gh api .../timeline), so reattachment is
  recoverable as a follow-up.

Fix:
- Pass create_phase_milestones=true via the reusable workflow's
  tfvar_assignments input, scoped to the upstream caller only. The
  outer `if: github.repository_owner == 'aletheia-works'` already
  prevents fork applies from running this workflow, so the opt-in
  is safe.
- Variable definition (variables.tf) and gate logic (main.tf) keep
  the fork-friendly default of false from #166. Only the upstream
  caller flips it on.

Effect on merge:
- This file change matches the workflow's own paths filter, so the
  apply workflow re-runs immediately on merge to main.
- OpenTofu sees the same eight `local.milestones` entries and
  recreates them with identical titles, descriptions, due dates,
  and open/closed states. Phase 7 stays open, Phases 0–6 stay
  closed.

Issue/PR re-attachment to recreated milestones is a follow-up
(traversing each PR/Issue's timeline events to find the last
"milestoned" event before deletion).
