### PR TITLE
feat(docs): phase 7 D — write-your-first-reproduction guide (ja+en)

### DIFF
--- a/docs/docs/en/guide/_meta.json
+++ b/docs/docs/en/guide/_meta.json
@@ -6,8 +6,18 @@
   },
   {
     "type": "file",
+    "name": "integrate-with-your-repo",
+    "label": "Integrate with your own repo"
+  },
+  {
+    "type": "file",
     "name": "fork-your-own",
     "label": "Run on your own fork"
+  },
+  {
+    "type": "file",
+    "name": "write-your-first-reproduction",
+    "label": "Write your first reproduction"
   },
   {
     "type": "file",

--- a/docs/docs/en/guide/write-your-first-reproduction.mdx
+++ b/docs/docs/en/guide/write-your-first-reproduction.mdx
@@ -1,0 +1,272 @@
+---
+pageType: doc
+title: Write your first reproduction
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  NumberedList,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · WRITE A RECIPE"
+    title="Author one Layer 1 recipe that runs in a browser tab."
+    sub="Copy the nearest existing recipe, swap the slug and the reproduction script, and you have a Vivarium-compatible reproduction page running locally. From there, the choice is upstream PR or self-publish on a fork."
+  />
+
+  <Section
+    eyebrow="// 0 · WHAT THIS GUIDE COVERS"
+    heading="A minimal Layer 1 (in-browser WASM) recipe."
+  >
+    <p>
+      Layer 1 pulls the upstream code into the browser via{' '}
+      <a href="https://pyodide.org/">Pyodide</a>,{' '}
+      <a href="https://ruby.wasm.ie/">Ruby.wasm</a>, php-wasm, or the Rust{' '}
+      <code>wasm32-wasip1</code> target, runs the reproduction script the
+      moment the page loads, and returns a verdict. No install, no server —
+      so a Layer 1 recipe is the lowest-cost first contribution to Vivarium.
+    </p>
+    <p>
+      Layer 2 (Docker) and Layer 3 (record-replay) have their own niches in{' '}
+      <a href="/vivarium/en/architecture">architecture</a>, but if you are
+      writing your first recipe, start at Layer 1.
+    </p>
+    <Callout>
+      This guide ends at "I have a working recipe locally." Where to
+      publish it is a separate two-way fork:{' '}
+      <a href="/vivarium/en/guide/fork-your-own">Run on your own fork</a>{' '}
+      or a PR to the upstream repo.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 1 · PICK A BUG"
+    heading="Slug shape: <project>-<issue>."
+  >
+    <p>
+      If the upstream bug has an issue tracker entry, the slug is{' '}
+      <code>&lt;project&gt;-&lt;issue&gt;</code> (e.g.{' '}
+      <code>pandas-56679</code>). Otherwise, a descriptive kebab-case
+      string (e.g. <code>bash-local-shadows-exit</code>) works. The slug is
+      the directory name and also the Manifest v1 <code>slug</code> field.
+    </p>
+    <p>
+      A Layer 1-friendly bug usually has these properties:
+    </p>
+    <ul>
+      <li>No external I/O (no network, no filesystem, no subprocess).</li>
+      <li>The verdict collapses to <strong>one boolean</strong> (e.g. "are these two values equal?").</li>
+      <li>The required libraries ship inside the WASM build of the runtime (Pyodide / Ruby.wasm / php-wasm bundled package list).</li>
+    </ul>
+  </Section>
+
+  <Section
+    eyebrow="// 2 · CLONE AND COPY A TEMPLATE"
+    heading="Copying the closest existing recipe is the shortest path."
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'Pick a clone target.',
+          body: <>For an upstream PR, clone <code>aletheia-works/vivarium</code> directly. To self-publish, follow the <a href="/vivarium/en/guide/fork-your-own">fork guide</a> and clone your fork.</>,
+        },
+        {
+          lead: 'Set up the toolchain via mise.',
+          body: <><code>mise install</code> at the repo root pulls <code>bun</code> and the rest. For Layer 1 specifically, also run <code>bun install</code> from <code>src/layer1_wasm/</code>.</>,
+        },
+        {
+          lead: 'Copy the closest existing recipe.',
+          body: <>Pick one in the same language: Python → <code>src/layer1_wasm/pandas-56679/</code>, Ruby → <code>ruby-21709/</code>, PHP → <code>php-12167/</code>, Rust → <code>regex-779/</code>. Copy the whole directory: <code>cp -r src/layer1_wasm/pandas-56679 src/layer1_wasm/&lt;your-slug&gt;</code>.</>,
+        },
+      ]}
+    />
+  </Section>
+
+  <Section
+    eyebrow="// 3 · EDIT INDEX.HTML"
+    heading="Three swaps: title, heading, lede."
+  >
+    <p>
+      Keep the structure of the copied <code>index.html</code>; replace
+      these three to match the bug:
+    </p>
+    <ul>
+      <li><code>&lt;title&gt;</code> — tab title (e.g. <code>Vivarium · Reproducing &lt;project&gt;#&lt;issue&gt;</code>).</li>
+      <li><code>&lt;h1&gt;</code> — heading. Link to the upstream issue.</li>
+      <li><code>&lt;p class="lede"&gt;</code> — one-to-two-sentence summary.</li>
+    </ul>
+    <p>
+      <strong>Do not touch</strong>:{' '}
+      <code>&lt;meta name="vivarium-contract" content="v1"&gt;</code>, the{' '}
+      <code>#verdict</code> element, or the link to{' '}
+      <code>../_shared/style.css</code>. Those carry Contract v1, and
+      removing any of them breaks machine-readable verdict capture.
+    </p>
+    <Callout>
+      The authoritative spec lives at{' '}
+      <a href="/vivarium/en/spec/contract-v1">Contract v1</a>. The
+      allowed values for <code>data-verdict</code> and the schema for the{' '}
+      <code>__VIVARIUM_RESULT__</code> envelope come from there.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 4 · EDIT REPRO.TS"
+    heading="Swap the reproduction logic; keep the helpers."
+  >
+    <p>
+      The copied <code>repro.ts</code> imports from{' '}
+      <code>../_shared/loader.js</code> and{' '}
+      <code>../_shared/verdict.js</code>. Leave that frame alone and
+      swap only the <strong>reproduction body</strong>. For a Python
+      recipe:
+    </p>
+    <pre><code>{`const REPRO_CODE = \`
+import pandas as pd
+# ↑ minimum code that exercises the upstream bug
+result = {
+  "left": ...,   # value 1
+  "right": ...,  # value 2
+  "mismatch": <left> != <right>,
+}
+result
+\`.trim();
+`}</code></pre>
+    <p>
+      The helpers handle the verdict wiring: if the comparison is{' '}
+      <code>true</code> (bug reproduced), call{' '}
+      <code>setVerdict("reproduced", "...")</code>; otherwise{' '}
+      <code>setVerdict("unreproduced", "...")</code>.{' '}
+      <code>setResult({`{ contract: "v1", bug, runtime, result, timing }`})</code>{' '}
+      writes the <code>__VIVARIUM_RESULT__</code> envelope.
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 5 · RUN IT LOCALLY"
+    heading="bun run build → static server → open in browser."
+  >
+    <pre><code>{`# from src/layer1_wasm/
+bun install
+bun run build         # repro.ts → repro.js
+
+# serve the recipe directory directly
+python -m http.server -d src/layer1_wasm/<your-slug> 8765
+# open http://localhost:8765/ in a browser
+`}</code></pre>
+    <p>
+      The page loads, the upstream library streams in from the CDN, and
+      the verdict badge moves from <code>pending</code> to either{' '}
+      <code>reproduced</code> or <code>unreproduced</code>. In DevTools,
+      check that <code>__VIVARIUM_VERDICT__</code> and{' '}
+      <code>__VIVARIUM_RESULT__</code> agree with the badge — that's
+      the Contract v1 surface.
+    </p>
+    <Callout>
+      Pyodide / Ruby.wasm / php-wasm are all configured to avoid{' '}
+      <code>SharedArrayBuffer</code>, so COOP/COEP headers are not
+      required. A plain static server (<code>python -m http.server</code>,{' '}
+      <code>bunx serve</code>) is enough.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 6 · NATIVE RE-VERIFICATION (OPTIONAL)"
+    heading="Show the same bug reproduces outside the browser."
+  >
+    <p>
+      A reproduction observed via Pyodide / Ruby.wasm is more convincing
+      when it also reproduces on a native CPython / MRI Ruby. For Python,{' '}
+      <a href="https://docs.astral.sh/uv/">uv</a> + PEP 723 inline
+      metadata gives you a single-file companion:
+    </p>
+    <pre><code>{`# /// script
+# requires-python = ">=3.13"
+# dependencies = ["pandas==2.3.3"]
+# ///
+import pandas as pd
+# … same reproduction logic …
+`}</code></pre>
+    <p>
+      <code>mise exec uv -- uv run repro.py</code> spins up an
+      ephemeral venv and runs it. Ruby, PHP, and Rust use the same
+      pattern — existing recipes' <code>repro.rb</code> /{' '}
+      <code>repro.php</code> / <code>Cargo.toml</code> are good
+      starting points.
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 7 · REGENERATE recipes.json"
+    heading="Get your recipe into the gallery."
+  >
+    <p>
+      <code>recipes.json</code>, which the gallery (<code>/repro/</code>)
+      and the MCP server consume, is generated from{' '}
+      <code>src/layer*/</code> at build time. To regenerate locally:
+    </p>
+    <pre><code>{`mise run recipes:index
+# or
+cd docs && bun run generate-index
+`}</code></pre>
+    <p>
+      Check that <code>docs/public/api/recipes.json</code> contains your
+      slug. With the docs site running locally, the new recipe shows up
+      as a card on the gallery:
+    </p>
+    <pre><code>{`cd docs && bun run dev
+# http://localhost:3000/vivarium/en/repro/`}</code></pre>
+  </Section>
+
+  <Section
+    eyebrow="// 8 · WHERE TO PUBLISH"
+    heading="Upstream PR, fork, or consumer integration."
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'Contribute to the upstream catalogue.',
+          body: <>Open a PR on aletheia-works/vivarium with a Conventional Commit such as <code>feat(layer1): add &lt;slug&gt; reproduction</code>. The CI gate is essentially Contract v1 conformance — anything that turns green is in.</>,
+        },
+        {
+          lead: 'Self-publish on your fork.',
+          body: <>Push the recipe to your own <code>vivarium</code> fork's main, enable deploy via the <a href="/vivarium/en/guide/fork-your-own">fork guide</a>, and the recipe appears at <code>&lt;you&gt;.github.io/vivarium/</code>. Sharing is just sharing the URL.</>,
+        },
+        {
+          lead: 'Track an existing recipe from your project repo.',
+          body: <>If you only want to <em>watch</em> a recipe (no new authoring), you don't need this guide — see <a href="/vivarium/en/guide/integrate-with-your-repo">Integrate with your own repo</a>, which uses Manifest v1 plus the reusable consumer-workflow.</>,
+        },
+      ]}
+    />
+  </Section>
+
+  <Callout>
+    If a step in this guide fails, that's a bug in this guide — file an
+    issue with the step number. Where readers stall sets the priority for
+    the next docs revision.
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      Read the glossary{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="The terms used here — slug, verdict, contract, layer — are pinned to fixed meanings in the glossary."
+  primary={{ label: 'Glossary →', href: '/vivarium/en/guide/glossary' }}
+  ghost={{ label: 'Contract v1 spec', href: '/vivarium/en/spec/contract-v1' }}
+/>
+
+<BottomNote
+  text="VIVARIUM IS PART OF ALETHEIA-WORKS · SEE SOURCE ON GITHUB →"
+  href="https://github.com/aletheia-works/vivarium"
+/>

--- a/docs/docs/ja/guide/_meta.json
+++ b/docs/docs/ja/guide/_meta.json
@@ -6,8 +6,18 @@
   },
   {
     "type": "file",
+    "name": "integrate-with-your-repo",
+    "label": "自分のリポジトリに統合する"
+  },
+  {
+    "type": "file",
     "name": "fork-your-own",
     "label": "自分のフォークで動かす"
+  },
+  {
+    "type": "file",
+    "name": "write-your-first-reproduction",
+    "label": "はじめての再現を書く"
   },
   {
     "type": "file",

--- a/docs/docs/ja/guide/write-your-first-reproduction.mdx
+++ b/docs/docs/ja/guide/write-your-first-reproduction.mdx
@@ -1,0 +1,265 @@
+---
+pageType: doc
+title: はじめての再現を書く
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  NumberedList,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · 再現を書く"
+    title="ブラウザだけで動く Layer 1 レシピを 1 つ書く。"
+    sub="既存レシピをコピーしてスラッグと再現スクリプトを差し替えるだけで、Vivarium 互換の再現ページが手元で動く。完成したらアップストリームへ PR を送るか、自分のフォークに置き続けるかを選べる。"
+  />
+
+  <Section
+    eyebrow="// 0 · このガイドが対象にするもの"
+    heading="Layer 1（ブラウザ内 WASM）の最小レシピ。"
+  >
+    <p>
+      Layer 1 は <a href="https://pyodide.org/">Pyodide</a>、
+      <a href="https://ruby.wasm.ie/">Ruby.wasm</a>、php-wasm、
+      Rust の <code>wasm32-wasip1</code> ターゲットなどで上流コードを
+      ブラウザに持ち込み、ページが開いた瞬間に再現スクリプトを走らせて
+      verdict を返す層です。インストール不要・サーバー不要なので、
+      Vivarium に最初に追加するレシピとして最もコストが低いです。
+    </p>
+    <p>
+      Layer 2（Docker）と Layer 3（record-replay）はそれぞれ
+      <a href="/vivarium/ja/architecture">アーキテクチャ</a>{' '}
+      に役割が書かれていますが、書き始めるならまず Layer 1 一択です。
+    </p>
+    <Callout>
+      このガイドは<strong>レシピを書く</strong>ところまでを対象にします。
+      その先「どこに公開するか」は 2 分岐で、{' '}
+      <a href="/vivarium/ja/guide/fork-your-own">自分のフォークで動かす</a>{' '}
+      または上流リポジトリへの PR、のどちらかです。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 1 · 再現したいバグを決める"
+    heading="スラッグは <project>-<issue> 形式。"
+  >
+    <p>
+      上流 Issue がある場合は <code>&lt;project&gt;-&lt;issue&gt;</code>
+      （例: <code>pandas-56679</code>）が標準。
+      ない場合は説明的なケバブケース（例: <code>bash-local-shadows-exit</code>）。
+      これがディレクトリ名でもあり、Manifest v1 の <code>slug</code> でもあります。
+    </p>
+    <p>
+      バグを選ぶときは、Layer 1 で完結するか確認するのがコツです:
+    </p>
+    <ul>
+      <li>外部 I/O（ネットワーク、ファイル、サブプロセス）を踏まない。</li>
+      <li>verdict が <strong>1 つの真偽値</strong>に落ちる（例: 「2 つの値が等しいか」）。</li>
+      <li>必要なライブラリが対象ランタイムの WASM ビルドに乗っている（Pyodide / Ruby.wasm / php-wasm の同梱パッケージ一覧）。</li>
+    </ul>
+  </Section>
+
+  <Section
+    eyebrow="// 2 · クローンして雛形をコピーする"
+    heading="一番近い既存レシピを丸ごとコピーするのが最短。"
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'リポジトリを用意する。',
+          body: <>アップストリームに PR したいなら <code>aletheia-works/vivarium</code> を直接クローン、自分のフォークに置きたいなら <a href="/vivarium/ja/guide/fork-your-own">フォーク手順</a> でフォークしてからクローンします。</>,
+        },
+        {
+          lead: 'mise でツールを揃える。',
+          body: <><code>mise install</code> でリポジトリ直下から <code>bun</code> など必要なツールが入ります。Layer 1 用には <code>cd src/layer1_wasm</code> 配下で <code>bun install</code> も走らせてください。</>,
+        },
+        {
+          lead: '一番近い既存レシピをコピーする。',
+          body: <>言語が同じレシピを丸ごとコピーするのが楽です。Python なら <code>src/layer1_wasm/pandas-56679/</code>、Ruby なら <code>ruby-21709/</code>、PHP なら <code>php-12167/</code>、Rust なら <code>regex-779/</code>。<code>cp -r src/layer1_wasm/pandas-56679 src/layer1_wasm/&lt;あなたの slug&gt;</code> でディレクトリごと複製。</>,
+        },
+      ]}
+    />
+  </Section>
+
+  <Section
+    eyebrow="// 3 · index.html を書き換える"
+    heading="差し替えるのは title、見出し、lede の 3 か所。"
+  >
+    <p>
+      コピーした <code>index.html</code> の構造はそのまま使い、以下を上流バグに合わせて差し替えます:
+    </p>
+    <ul>
+      <li><code>&lt;title&gt;</code> — タブに出るタイトル（例: <code>Vivarium · Reproducing &lt;project&gt;#&lt;issue&gt;</code>）。</li>
+      <li><code>&lt;h1&gt;</code> — 見出し。上流 Issue へのリンクを含めます。</li>
+      <li><code>&lt;p class="lede"&gt;</code> — 1〜2 文でバグを説明する lede。</li>
+    </ul>
+    <p>
+      <strong>触ってはいけないもの</strong>: <code>&lt;meta name="vivarium-contract" content="v1"&gt;</code>、
+      <code>#verdict</code> 要素、<code>../_shared/style.css</code> へのリンク。
+      これらが Contract v1 を構成しているので、外すと verdict が機械的に読めなくなります。
+    </p>
+    <Callout>
+      Contract v1 の正典は{' '}
+      <a href="/vivarium/ja/spec/contract-v1">Contract v1</a> にあります。
+      <code>data-verdict</code> の取りうる値、<code>__VIVARIUM_RESULT__</code>{' '}
+      envelope のスキーマは spec ページが正です。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 4 · repro.ts を書き換える"
+    heading="再現ロジックだけ差し替える。helper はそのまま。"
+  >
+    <p>
+      コピー元の <code>repro.ts</code> は <code>../_shared/loader.js</code> と{' '}
+      <code>../_shared/verdict.js</code> を import している部分が共通骨格です。
+      ここはそのまま残して、<strong>再現コード本体だけ</strong>差し替えます。
+      Python レシピなら以下のような形:
+    </p>
+    <pre><code>{`const REPRO_CODE = \`
+import pandas as pd
+# ↑ 上流バグを表す最小コード
+result = {
+  "left": ...,   # 比較する値 1
+  "right": ...,  # 比較する値 2
+  "mismatch": <left> != <right>,
+}
+result
+\`.trim();
+`}</code></pre>
+    <p>
+      verdict 設定は helper が面倒を見ます: 比較が <code>true</code>（バグが再現した）なら
+      <code>setVerdict("reproduced", "...")</code>、そうでなければ
+      <code>setVerdict("unreproduced", "...")</code>。
+      <code>setResult({`{ contract: "v1", bug, runtime, result, timing }`})</code>{' '}
+      で <code>__VIVARIUM_RESULT__</code> envelope も書き出されます。
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 5 · ローカルで動かす"
+    heading="bun run build → 静的サーバ → ブラウザで開く。"
+  >
+    <pre><code>{`# src/layer1_wasm/ から
+bun install
+bun run build         # repro.ts → repro.js を生成
+
+# レシピディレクトリを直接サーブ
+python -m http.server -d src/layer1_wasm/<あなたの slug> 8765
+# ブラウザで http://localhost:8765/ を開く
+`}</code></pre>
+    <p>
+      ページが開き、上流ライブラリが CDN からロードされ、
+      verdict バッジが <code>pending</code> →{' '}
+      <code>reproduced</code> / <code>unreproduced</code> のどちらかに落ちます。
+      DevTools コンソールで <code>__VIVARIUM_VERDICT__</code> と
+      <code>__VIVARIUM_RESULT__</code> も同じ値が入っていれば、
+      Contract v1 上は OK です。
+    </p>
+    <Callout>
+      Pyodide / Ruby.wasm / php-wasm はいずれも <code>SharedArrayBuffer</code>{' '}
+      を使わない構成にしてあるので、COOP/COEP ヘッダは不要です。
+      普通の静的サーバ（<code>python -m http.server</code> や{' '}
+      <code>bunx serve</code>）で動きます。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 6 · ネイティブ再検証（任意）"
+    heading="ブラウザ外でも同じバグが出ることを 1 行で確かめる。"
+  >
+    <p>
+      Pyodide / Ruby.wasm 経由で観測できたバグが、本物の CPython /
+      MRI Ruby でも同じく再現することを示すと、レシピの説得力が上がります。
+      Python なら <a href="https://docs.astral.sh/uv/">uv</a> +{' '}
+      PEP 723 inline metadata で 1 ファイル完結に書けます:
+    </p>
+    <pre><code>{`# /// script
+# requires-python = ">=3.13"
+# dependencies = ["pandas==2.3.3"]
+# ///
+import pandas as pd
+# … 同じ再現ロジック …
+`}</code></pre>
+    <p>
+      <code>mise exec uv -- uv run repro.py</code> で ephemeral venv
+      が組まれて走ります。Ruby、PHP、Rust も同様で、既存レシピの
+      <code>repro.rb</code> / <code>repro.php</code> / <code>Cargo.toml</code>{' '}
+      が雛形になります。
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 7 · recipes.json を再生成"
+    heading="ギャラリーに自分のレシピを並べる。"
+  >
+    <p>
+      ギャラリー（<code>/repro/</code>）と MCP サーバが読む
+      <code>recipes.json</code> は、ビルド時に
+      <code>src/layer*/</code> をスキャンして自動生成されます。
+      手元での確認用には:
+    </p>
+    <pre><code>{`mise run recipes:index
+# あるいは
+cd docs && bun run generate-index
+`}</code></pre>
+    <p>
+      生成された <code>docs/public/api/recipes.json</code> に
+      自分のスラッグが入っていれば成功です。
+      docs サイトをローカルで動かすと、ギャラリーにカードが現れます:
+    </p>
+    <pre><code>{`cd docs && bun run dev
+# http://localhost:3000/vivarium/ja/repro/`}</code></pre>
+  </Section>
+
+  <Section
+    eyebrow="// 8 · どこに公開するか"
+    heading="上流 PR か、自分のフォークか。"
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'アップストリーム カタログに contribute する。',
+          body: <>aletheia-works/vivarium 上で <code>feat(layer1): add &lt;slug&gt; reproduction</code> のような Conventional Commits で PR を立てます。レビュー基準は既存レシピを見れば分かりますが、最低限 Contract v1 に従っていれば CI が緑になります。</>,
+        },
+        {
+          lead: '自分のフォークに置く。',
+          body: <>レシピを自分の <code>vivarium</code> フォークの main に push し、<a href="/vivarium/ja/guide/fork-your-own">フォーク手順</a> の deploy 設定を有効化すると、自分の <code>&lt;you&gt;.github.io/vivarium/</code> に並びます。共有は URL を渡すだけ。</>,
+        },
+        {
+          lead: '自分のリポジトリに統合する。',
+          body: <>自分のプロジェクトリポジトリ側で「このレシピを CI で監視する」だけしたい場合は、レシピを書く必要はありません。<a href="/vivarium/ja/guide/integrate-with-your-repo">自分のリポジトリに統合する</a> に Manifest v1 と consumer-workflow.yml を使う最短手順があります。</>,
+        },
+      ]}
+    />
+  </Section>
+
+  <Callout>
+    手順のどこかで詰まったら、それは write-your-first-reproduction
+    のバグです。詰まったステップ番号を Issue に残してください。
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      用語集を読む{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="ここで出てきた slug / verdict / contract / Layer といった単語は、用語集に固定的な意味でまとめてあります。"
+  primary={{ label: '用語集 →', href: '/vivarium/ja/guide/glossary' }}
+  ghost={{ label: 'Contract v1 仕様', href: '/vivarium/ja/spec/contract-v1' }}
+/>
+
+<BottomNote
+  text="VIVARIUM は ALETHEIA-WORKS の一部 · GitHub でソースを見る →"
+  href="https://github.com/aletheia-works/vivarium"
+/>


### PR DESCRIPTION

Adds the fourth onboarding page in the Phase 7 D sub-stream
(ADR-0028 D-2): a step-by-step procedure for authoring a Layer 1
recipe, from "pick the bug" through "regenerate recipes.json,"
ending at the upstream-PR / fork / consumer-integration fork.

Why:
- D so far covers landing (getting-started), terminology
  (glossary), self-publishing infra (fork-your-own), and consumer
  declaration (integrate-with-your-repo). The "I want to *author* a
  reproduction" path was scattered across each Layer 1 recipe's own
  README and the Contract v1 spec — no single procedural entry
  point existed.
- ADR-0028 D-2 explicitly calls for "clone, scaffold a Layer 1
  recipe directory, see it appear in the gallery." This page is
  that walkthrough.

Wiring:
- New page in ja+en under guide/write-your-first-reproduction.
- _meta.json updated in both locales (slot 4: between
  fork-your-own and glossary — the natural reading order is
  publish-infra (fork) → authoring (this page) → vocabulary
  (glossary)).

Verified: docs build clean, both pages emitted to
doc_build/{,ja/}guide/write-your-first-reproduction.html.

Out of scope (deferred to subsequent PRs):
- D-4 ("Use Vivarium from your AI agent") — still blocked on
  unpublished MCP server.
- D-5 ("Compare branch fix") — gated on B3 R.2 Path A.
- V′ visual polish.
- B3 end-to-end walkthrough.
