### PR TITLE
docs(mcp): mark MCP server install as pre-publish until first tag ships

### DIFF
--- a/docs/docs/en/guide/getting-started.mdx
+++ b/docs/docs/en/guide/getting-started.mdx
@@ -154,11 +154,11 @@ import {
         },
         {
           lead: 'Declare a Vivarium reproduction in your repo.',
-          body: 'Start with the Manifest v1 spec (/spec/manifest-v1) and the interactive scaffolder (/spec/manifest-create).',
+          body: 'The "Integrate with your own repo" guide (/guide/integrate-with-your-repo) walks through it end-to-end. Authoritative spec: Manifest v1 (/spec/manifest-v1).',
         },
         {
           lead: 'Drive Vivarium from an AI agent.',
-          body: 'The MCP server @aletheia-works/vivarium-mcp is on JSR and npm. Four tools — list_recipes, get_recipe, lookup_verdict, match_error.',
+          body: 'The MCP server lives in packages/mcp-server/ with four tools — list_recipes, get_recipe, lookup_verdict, match_error. The first JSR / npm publish has not happened yet, so today the install path is local-clone + bun run build, then point your MCP client at dist/index.js. See packages/mcp-server/README.md.',
         },
         {
           lead: 'Understand why this project exists.',

--- a/docs/docs/ja/guide/getting-started.mdx
+++ b/docs/docs/ja/guide/getting-started.mdx
@@ -150,11 +150,11 @@ import {
         },
         {
           lead: '自分のリポジトリに Vivarium 再現を宣言したい。',
-          body: 'spec の Manifest v1 (/spec/manifest-v1) と、対話的なスキャフォールダ (/spec/manifest-create) から始める。',
+          body: 'ガイドの「自分のリポジトリに統合する」(/guide/integrate-with-your-repo) が手順を一通り通す。仕様の正典は Manifest v1 (/spec/manifest-v1)。',
         },
         {
           lead: 'AI エージェントから呼びたい。',
-          body: 'MCP サーバ @aletheia-works/vivarium-mcp が JSR + npm に出ている。4 つのツール (list_recipes / get_recipe / lookup_verdict / match_error) でレシピを検索・取得できる。',
+          body: 'MCP サーバが packages/mcp-server/ に同梱されており、4 つのツール (list_recipes / get_recipe / lookup_verdict / match_error) でレシピを検索・取得できる。JSR / npm への初回公開は未実施なので、現状はローカルクローン後に bun run build した dist を MCP クライアントに登録する形になる。詳細は packages/mcp-server/README.md。',
         },
         {
           lead: 'なぜこのプロジェクトが存在するか知りたい。',

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -22,11 +22,43 @@ deployed verdict snapshots, without scraping the docs site.
 
 ## Install
 
-### npm (default for `npx`-based MCP launchers)
+> **Status (2026-05-06)**: not yet published to a registry. The
+> `mcp-server-v0.1.0` tag has not been pushed, so the `npx` and
+> `bunx jsr:` snippets below would 404 today. Until the first publish,
+> use the local-clone path. The
+> [`publish-mcp.yml`](https://github.com/aletheia-works/vivarium/blob/main/.github/workflows/publish-mcp.yml)
+> workflow handles dual JSR + npm release on tag push; the snippets
+> in the next two subsections will work once that runs for the first
+> time.
 
-Add the server to your client's MCP configuration. The exact file
-location varies by client (Claude Code: `~/.claude/mcp.json`; Cline:
-its VS Code settings; Cursor: `~/.cursor/mcp.json`). Snippet:
+### Local clone (works today)
+
+```bash
+git clone https://github.com/aletheia-works/vivarium.git
+cd vivarium/packages/mcp-server
+bun install
+bun run build
+```
+
+Then point your MCP client at the built entry point:
+
+```json
+{
+  "mcpServers": {
+    "vivarium": {
+      "command": "node",
+      "args": ["/absolute/path/to/vivarium/packages/mcp-server/dist/index.js"]
+    }
+  }
+}
+```
+
+### npm (post-publish; default for `npx`-based MCP launchers)
+
+Once the server has been published, the configuration becomes a
+single-line `npx` invocation. The exact MCP-config file location
+varies by client (Claude Code: `~/.claude/mcp.json`; Cline: its VS
+Code settings; Cursor: `~/.cursor/mcp.json`). Snippet:
 
 ```json
 {
@@ -39,7 +71,7 @@ its VS Code settings; Cursor: `~/.cursor/mcp.json`). Snippet:
 }
 ```
 
-### JSR (Deno / Bun-native install)
+### JSR (post-publish; Deno / Bun-native install)
 
 For clients with native JSR support (Bun ≥ 1.1, Deno):
 


### PR DESCRIPTION

Three sites claimed @aletheia-works/vivarium-mcp was already on JSR
and npm, but the mcp-server-v0.1.0 tag has never been pushed and
both registries 404 today (verified 2026-05-06):

- npm view @aletheia-works/vivarium-mcp → E404
- https://jsr.io/@aletheia-works/vivarium-mcp/meta.json → 404

Updated each to a local-clone install path, with the npx / bunx
snippets preserved as "post-publish" examples that will start
working once .github/workflows/publish-mcp.yml runs for the first
tag push:

- packages/mcp-server/README.md — added a top-of-Install status
  note and an "Install via local clone" subsection.
- docs/docs/{en,ja}/guide/getting-started.mdx — softened the
  "Drive Vivarium from an AI agent" item to point at the local
  package path and README.

Why now:
- Phase 7 D-4 (the planned "Use Vivarium from your AI agent" page)
  needs accurate install instructions before it can ship. This
  unblocks anyone following getting-started today and clears a
  prerequisite for D-4.

Out of scope:
- Pushing the actual mcp-server-v0.1.0 tag (one-way, irreversible
  publish to public registries — needs human authorisation).
- D-4 itself.
