### PR TITLE
feat(docs): phase 7 D-4 — use-from-ai-agent guide (ja+en)

### DIFF
--- a/docs/docs/en/guide/_meta.json
+++ b/docs/docs/en/guide/_meta.json
@@ -11,6 +11,11 @@
   },
   {
     "type": "file",
+    "name": "use-from-ai-agent",
+    "label": "Use from your AI agent"
+  },
+  {
+    "type": "file",
     "name": "fork-your-own",
     "label": "Run on your own fork"
   },

--- a/docs/docs/en/guide/getting-started.mdx
+++ b/docs/docs/en/guide/getting-started.mdx
@@ -158,7 +158,7 @@ import {
         },
         {
           lead: 'Drive Vivarium from an AI agent.',
-          body: 'The MCP server lives in packages/mcp-server/ with four tools — list_recipes, get_recipe, lookup_verdict, match_error. The first JSR / npm publish has not happened yet, so today the install path is local-clone + bun run build, then point your MCP client at dist/index.js. See packages/mcp-server/README.md.',
+          body: 'The "Use Vivarium from your AI agent" guide (/guide/use-from-ai-agent) walks through Claude Code / Cursor / Cline / Continue setup with sample prompts for the four tools (list_recipes, get_recipe, lookup_verdict, match_error). First JSR / npm publish is intentionally on hold; the working path today is local-clone.',
         },
         {
           lead: 'Understand why this project exists.',

--- a/docs/docs/en/guide/use-from-ai-agent.mdx
+++ b/docs/docs/en/guide/use-from-ai-agent.mdx
@@ -1,0 +1,246 @@
+---
+pageType: doc
+title: Use Vivarium from your AI agent
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  NumberedList,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · AI AGENT"
+    title="Drive the Vivarium MCP server from Claude Code, Cursor, or Cline."
+    sub="Vivarium ships an MCP (Model Context Protocol) server with four tools that let an agent search and read the entire catalogue programmatically. No HTML scraping of the docs site required."
+  />
+
+  <Section
+    eyebrow="// 0 · WHAT THIS GUIDE COVERS"
+    heading="Wiring an AI agent to Vivarium's catalogue via MCP."
+  >
+    <p>
+      The Vivarium MCP server (<code>@aletheia-works/vivarium-mcp</code>)
+      speaks{' '}
+      <a href="https://modelcontextprotocol.io">Model Context Protocol</a>{' '}
+      over stdio and exposes four tools:{' '}
+      <code>list_recipes</code>, <code>get_recipe</code>,{' '}
+      <code>lookup_verdict</code>, and <code>match_error</code>. An agent
+      can browse the catalogue, fetch metadata for a given recipe, and
+      pull deployed Layer 2 / 3 verdict snapshots through them.
+    </p>
+    <Callout>
+      <strong>The first JSR / npm publish is intentionally on hold</strong>.
+      Vivarium overall and the MCP server's feature surface are both
+      judged not yet finished — pushing v1 now would crystallise an
+      interface still under iteration. The maintainer will announce
+      timing separately. Until then, the working install path is{' '}
+      <strong>local clone</strong>.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 1 · BUILD LOCALLY"
+    heading="clone → bun install → bun run build."
+  >
+    <pre><code>{`git clone https://github.com/aletheia-works/vivarium.git
+cd vivarium/packages/mcp-server
+bun install
+bun run build
+# → produces dist/index.js (the entry point your client will spawn)
+`}</code></pre>
+    <p>
+      Note the <strong>absolute path</strong> to <code>dist/index.js</code>.
+      The MCP client config will spawn it via <code>node</code>.
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 2 · REGISTER WITH YOUR MCP CLIENT"
+    heading="Same shape everywhere: command + args."
+  >
+    <p>
+      Every MCP client takes essentially the same JSON snippet — a{' '}
+      <code>command</code> and an <code>args</code> array:
+    </p>
+    <pre><code>{`{
+  "mcpServers": {
+    "vivarium": {
+      "command": "node",
+      "args": ["/abs/path/to/vivarium/packages/mcp-server/dist/index.js"]
+    }
+  }
+}
+`}</code></pre>
+    <p>
+      What differs is where you put it:
+    </p>
+    <NumberedList
+      items={[
+        {
+          lead: 'Claude Code (CLI).',
+          body: <><code>claude mcp add vivarium node /abs/path/to/...dist/index.js</code> registers it interactively. Equivalent: drop the JSON above into the <code>mcpServers</code> key of <code>~/.claude.json</code>.</>,
+        },
+        {
+          lead: 'Cursor.',
+          body: <>Drop the JSON into <code>~/.cursor/mcp.json</code> (or <code>.cursor/mcp.json</code> at the project root for project-scoped registration).</>,
+        },
+        {
+          lead: 'Cline (VS Code extension).',
+          body: <>VS Code → Cline sidebar → <code>MCP Servers</code> → <code>Configure MCP Servers</code> opens a JSON editor. Add the snippet there.</>,
+        },
+        {
+          lead: 'Continue.',
+          body: <>Translate the command + args into the YAML <code>mcpServers</code> section of <code>~/.continue/config.yaml</code> — same fields, just YAML syntax.</>,
+        },
+      ]}
+    />
+    <Callout>
+      The authoritative client list is at{' '}
+      <a href="https://modelcontextprotocol.io/clients">modelcontextprotocol.io/clients</a>.
+      Per-client config paths drift over time; consult upstream when
+      anything looks off.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 3 · TOOLS"
+    heading="All four go through the same stdio transport."
+  >
+    <ul>
+      <li>
+        <strong><code>list_recipes(layer?, project?, q?)</code></strong> —
+        filtered enumeration of the catalogue. <code>layer</code> is
+        the integer 1/2/3, <code>project</code> matches the upstream
+        project (e.g. <code>"pandas"</code>), <code>q</code> is a
+        substring search across slug, project, and title.
+      </li>
+      <li>
+        <strong><code>get_recipe(slug)</code></strong> — full metadata
+        for one recipe (title, project, issue, page URL, verdict
+        snapshot URL, GitHub source URL). Returns{' '}
+        <code>{`{ found: false, error }`}</code> on unknown slug.
+      </li>
+      <li>
+        <strong><code>lookup_verdict(slug)</code></strong> — Layer 1
+        returns <code>{`{ kind: "live", page_url, note }`}</code> (the
+        verdict is computed in-browser at view time). Layer 2 / 3 returns{' '}
+        <code>{`{ kind: "snapshot", snapshot: { verdict, exit_code, image_digest, stdout, stderr_tail, ... } }`}</code>.
+      </li>
+      <li>
+        <strong><code>match_error(text, limit?)</code></strong> — score
+        the catalogue against a pasted error message or stack trace by
+        mechanical token overlap. No LLM, no fuzzy matching — exact
+        token hits against symptom / tags / project / slug, weighted
+        per source.
+      </li>
+    </ul>
+  </Section>
+
+  <Section
+    eyebrow="// 4 · SAMPLE PROMPTS"
+    heading="Three patterns that come up most."
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'Paste an error, find candidate recipes.',
+          body: <>"<em>Use <code>match_error</code> to find Vivarium recipes matching this stack trace, top 5: ...paste...</em>" → the agent calls <code>match_error</code> and shows ranked hits. Drill into one with <code>get_recipe</code>.</>,
+        },
+        {
+          lead: 'Check whether something still reproduces today.',
+          body: <>"<em>What does <code>lookup_verdict</code> say about <code>pandas-56679</code>?</em>" → Layer 1 returns a <code>kind: "live"</code> URL the agent can offer for a browser visit; Layer 2 / 3 returns the snapshot's verdict / exit code directly.</>,
+        },
+        {
+          lead: 'Filter by layer or project.',
+          body: <>"<em>Use <code>list_recipes</code> to enumerate all Layer 2 recipes</em>" → calls with <code>{`{ layer: 2 }`}</code> and returns only the Docker layer.</>,
+        },
+      ]}
+    />
+    <Callout>
+      The <code>match_error</code> scoring is bit-identical to the{' '}
+      <a href="/vivarium/en/repro/match">error → recipe matcher</a>{' '}
+      page. MCP and UI return the same ranked candidates.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 5 · COMMON SNAGS"
+    heading="Most setups stall on one of these."
+  >
+    <ul>
+      <li>
+        <strong>No <code>dist/index.js</code>.</strong> Means{' '}
+        <code>bun run build</code> wasn't run. Run{' '}
+        <code>bun install &amp;&amp; bun run build</code> in{' '}
+        <code>packages/mcp-server/</code> once.
+      </li>
+      <li>
+        <strong>Some clients can't expand the home-directory shortcut or
+        relative paths.</strong>{' '}
+        Use a fully-qualified absolute path —{' '}
+        <code>/Users/&lt;you&gt;/code/vivarium/.../dist/index.js</code>,
+        not <code>$HOME/code/vivarium/...</code>.
+      </li>
+      <li>
+        <strong>Recipes seem stale.</strong> The server caches{' '}
+        <code>https://aletheia-works.github.io/vivarium/api/recipes.json</code>{' '}
+        with a 5-minute TTL and falls back to a build-time snapshot
+        offline. Restart the MCP server to force a refetch.
+      </li>
+      <li>
+        <strong>"Layer 1 verdict isn't a snapshot."</strong> By design
+        — Layer 1's site of truth is the browser at view time
+        (<a href="/vivarium/en/spec/contract-v1">Contract v1</a>). The
+        agent should treat <code>kind: "live"</code> as "open this URL
+        for the human to verify."
+      </li>
+    </ul>
+  </Section>
+
+  <Section
+    eyebrow="// 6 · WHAT'S NEXT"
+    heading="Lines branching out from this surface."
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'Pair with consumer-side CI.',
+          body: <><a href="/vivarium/en/guide/integrate-with-your-repo">Integrate with your own repo</a> sets up the verdict-watch side from your own CI. The two sides — agent + CI — close the loop.</>,
+        },
+        {
+          lead: 'Verify a branch fix end-to-end (planned in B3).',
+          body: <>Confirming "did my candidate fix flip reproduced → unreproduced?" through the agent in one shot is what Phase 7's B3 sub-stream (ADR-0028) is meant to wire up. For now the <a href="/vivarium/en/repro/compare">comparison page</a> is the manual surface; B3 will let the agent drive it.</>,
+        },
+      ]}
+    />
+  </Section>
+
+  <Callout>
+    If a step here didn't work, that's a bug in this guide — file an
+    issue with your client name, OS, and the step number you got stuck on.
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      Integrate with your own repo{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="With the agent side wired, adding the consumer-CI side closes the other half of the loop."
+  primary={{ label: 'Integrate guide →', href: '/vivarium/en/guide/integrate-with-your-repo' }}
+  ghost={{ label: 'Glossary', href: '/vivarium/en/guide/glossary' }}
+/>
+
+<BottomNote
+  text="VIVARIUM IS PART OF ALETHEIA-WORKS · SEE SOURCE ON GITHUB →"
+  href="https://github.com/aletheia-works/vivarium"
+/>

--- a/docs/docs/ja/guide/_meta.json
+++ b/docs/docs/ja/guide/_meta.json
@@ -11,6 +11,11 @@
   },
   {
     "type": "file",
+    "name": "use-from-ai-agent",
+    "label": "AI エージェントから使う"
+  },
+  {
+    "type": "file",
     "name": "fork-your-own",
     "label": "自分のフォークで動かす"
   },

--- a/docs/docs/ja/guide/getting-started.mdx
+++ b/docs/docs/ja/guide/getting-started.mdx
@@ -154,7 +154,7 @@ import {
         },
         {
           lead: 'AI エージェントから呼びたい。',
-          body: 'MCP サーバが packages/mcp-server/ に同梱されており、4 つのツール (list_recipes / get_recipe / lookup_verdict / match_error) でレシピを検索・取得できる。JSR / npm への初回公開は未実施なので、現状はローカルクローン後に bun run build した dist を MCP クライアントに登録する形になる。詳細は packages/mcp-server/README.md。',
+          body: 'ガイドの「AI エージェントから使う」(/guide/use-from-ai-agent) に Claude Code / Cursor / Cline / Continue 向けの設定例と 4 つのツール (list_recipes / get_recipe / lookup_verdict / match_error) のサンプルプロンプトがある。MCP サーバの初公開は意図的に保留中なので、現状はローカルクローン経由で動かす。',
         },
         {
           lead: 'なぜこのプロジェクトが存在するか知りたい。',

--- a/docs/docs/ja/guide/use-from-ai-agent.mdx
+++ b/docs/docs/ja/guide/use-from-ai-agent.mdx
@@ -1,0 +1,239 @@
+---
+pageType: doc
+title: AI エージェントから使う
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  NumberedList,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · AI エージェント"
+    title="Vivarium MCP サーバを Claude Code / Cursor / Cline から呼ぶ。"
+    sub="Vivarium は MCP（Model Context Protocol）サーバを同梱しており、4 つのツールでカタログ全体をエージェントから機械的に検索・取得できる。docs サイトを HTML スクレイプする必要はない。"
+  />
+
+  <Section
+    eyebrow="// 0 · このガイドが対象にするもの"
+    heading="MCP 経由でカタログにアクセスするエージェント設定。"
+  >
+    <p>
+      Vivarium MCP サーバ (<code>@aletheia-works/vivarium-mcp</code>) は{' '}
+      <a href="https://modelcontextprotocol.io">Model Context Protocol</a>{' '}
+      の stdio トランスポート経由で 4 つのツールを提供します:{' '}
+      <code>list_recipes</code>、<code>get_recipe</code>、
+      <code>lookup_verdict</code>、<code>match_error</code>。
+      エージェント側からカタログを検索し、特定レシピのメタデータを取得し、
+      Layer 2 / 3 の verdict スナップショットを読めます。
+    </p>
+    <Callout>
+      <strong>JSR / npm への初回公開は現時点で意図的に保留中</strong>です。
+      Vivarium 全体およびサーバ機能サーフェスがまだ熟していない段階で公開すると、
+      まだ動かしたいインタフェースを v1 として固定してしまうため。
+      公開時期は維持者が別途アナウンスします。それまでは{' '}
+      <strong>ローカルクローン経由</strong>で動かすパスが標準です。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 1 · ローカルでビルドする"
+    heading="clone → bun install → bun run build。"
+  >
+    <pre><code>{`git clone https://github.com/aletheia-works/vivarium.git
+cd vivarium/packages/mcp-server
+bun install
+bun run build
+# → dist/index.js が出来る（クライアントが起動するエントリポイント）
+`}</code></pre>
+    <p>
+      <code>dist/index.js</code> の<strong>絶対パス</strong>を控えておきます。
+      MCP クライアント側の設定で、<code>node</code> 経由でこのファイルを起動する形になります。
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 2 · MCP クライアントに登録する"
+    heading="共通スキーマ: command + args。"
+  >
+    <p>
+      MCP サーバの登録は、どのクライアントでも本質的に「<code>command</code>{' '}
+      と <code>args</code> の組」を JSON で渡す形です:
+    </p>
+    <pre><code>{`{
+  "mcpServers": {
+    "vivarium": {
+      "command": "node",
+      "args": ["/abs/path/to/vivarium/packages/mcp-server/dist/index.js"]
+    }
+  }
+}
+`}</code></pre>
+    <p>
+      この snippet を貼る場所がクライアントごとに違うだけです:
+    </p>
+    <NumberedList
+      items={[
+        {
+          lead: 'Claude Code（CLI）。',
+          body: <><code>claude mcp add vivarium node /abs/path/to/...dist/index.js</code> で対話的に登録できます。あるいは <code>~/.claude.json</code> の <code>mcpServers</code> キーに上の JSON を直接書いても等価です。</>,
+        },
+        {
+          lead: 'Cursor。',
+          body: <><code>~/.cursor/mcp.json</code>（プロジェクト局所なら <code>.cursor/mcp.json</code>）に上の JSON をそのまま置きます。</>,
+        },
+        {
+          lead: 'Cline（VS Code 拡張）。',
+          body: <>VS Code の Cline サイドバー → <code>MCP Servers</code> → <code>Configure MCP Servers</code> から JSON 編集 UI を開き、上のスキーマで追加します。</>,
+        },
+        {
+          lead: 'Continue。',
+          body: <><code>~/.continue/config.yaml</code> の <code>mcpServers</code> セクションで command+args を YAML 形式に転記します（YAML 表記は同じ意味）。</>,
+        },
+      ]}
+    />
+    <Callout>
+      MCP クライアント側の正典のドキュメントは
+      <a href="https://modelcontextprotocol.io/clients">{' '}modelcontextprotocol.io/clients{' '}</a>
+      にあります。各クライアントの設定ファイルパスは更新されることがあるので、
+      迷ったら本家を参照してください。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 3 · ツール一覧"
+    heading="4 つすべて MCP の標準 stdio 経由で呼べる。"
+  >
+    <ul>
+      <li>
+        <strong><code>list_recipes(layer?, project?, q?)</code></strong> —
+        カタログをフィルタして列挙。<code>layer</code> は 1/2/3 の整数、
+        <code>project</code> は上流プロジェクト名（<code>"pandas"</code>等）、
+        <code>q</code> は slug / project / title 横断の部分文字列検索。
+      </li>
+      <li>
+        <strong><code>get_recipe(slug)</code></strong> — 1 つのレシピの全メタデータ
+        （title / project / issue / page URL / verdict snapshot URL / GitHub source URL）。
+        slug が見つからなければ <code>{`{ found: false, error }`}</code>。
+      </li>
+      <li>
+        <strong><code>lookup_verdict(slug)</code></strong> — Layer 1 は{' '}
+        <code>{`{ kind: "live", page_url, note }`}</code>（verdict はブラウザ実行時に出る）、
+        Layer 2 / 3 は <code>{`{ kind: "snapshot", snapshot: { verdict, exit_code, image_digest, stdout, stderr_tail, ... } }`}</code>。
+      </li>
+      <li>
+        <strong><code>match_error(text, limit?)</code></strong> — エラー文字列・スタックトレースから
+        機械的トークンマッチで候補レシピをスコア順で返す。LLM もファジーマッチも使わず、
+        symptom / tags / project / slug への完全一致で重みづけ。
+      </li>
+    </ul>
+  </Section>
+
+  <Section
+    eyebrow="// 4 · サンプルプロンプト"
+    heading="3 つの典型的な使い方。"
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'エラー文を貼って候補レシピを探す。',
+          body: <>「<em>このスタックトレースに合いそうな Vivarium レシピを <code>match_error</code> で 5 件出して: ...貼り付け...</em>」 → エージェントが <code>match_error</code> を呼び、上位を表示。気になったものを <code>get_recipe</code> で詳細取得。</>,
+        },
+        {
+          lead: '今この瞬間に再現するか確認する。',
+          body: <>「<em><code>pandas-56679</code> の現在の verdict を <code>lookup_verdict</code> で見て</em>」→ Layer 1 は <code>kind: "live"</code> なので「ページを開いて確認するURLを返却」、Layer 2 / 3 はスナップショットの数値が直接出る。</>,
+        },
+        {
+          lead: '層・プロジェクトでフィルタして列挙。',
+          body: <>「<em><code>list_recipes</code> で Layer 2 のものだけ全部出して</em>」→ <code>{`{ layer: 2 }`}</code> 引数で呼ばれ、Layer 2 (Docker) レシピだけが返る。</>,
+        },
+      ]}
+    />
+    <Callout>
+      <code>match_error</code> のスコアリングは
+      <a href="/vivarium/ja/repro/match"> 「エラーからレシピを探す」</a>{' '}
+      ページとビット同一です。MCP 経由でも UI 経由でも同じ候補順が出ます。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 5 · 詰まりやすい点"
+    heading="経験上、ここで止まる人が多い。"
+  >
+    <ul>
+      <li>
+        <strong><code>dist/index.js</code> が無い。</strong>
+        <code>bun run build</code> を流していない場合に起きる。
+        <code>packages/mcp-server</code> 直下で <code>bun install &amp;&amp; bun run build</code>{' '}
+        を 1 度走らせる必要があります。
+      </li>
+      <li>
+        <strong>絶対パスでないと一部クライアントが見つけられない。</strong>{' '}
+        ホームディレクトリ短縮表記や相対パスは展開されないことがあります。
+        <code>$HOME/code/vivarium/...</code> ではなく
+        <code>/Users/&lt;you&gt;/code/vivarium/.../dist/index.js</code>{' '}
+        のようにフルパスで書きます。
+      </li>
+      <li>
+        <strong>レシピが古い気がする。</strong> サーバは{' '}
+        <code>https://aletheia-works.github.io/vivarium/api/recipes.json</code>{' '}
+        を 5 分 TTL でキャッシュ、ネット切断時は build-time の snapshot にフォールバック。
+        最新を強制したいときは MCP サーバを再起動するのが早いです。
+      </li>
+      <li>
+        <strong>Layer 1 の verdict が「snapshot じゃない」と言われる。</strong>{' '}
+        Layer 1 はブラウザでの実行が確定の場で、サーバ側にスナップショットを置かない設計
+        （<a href="/vivarium/ja/spec/contract-v1">Contract v1</a>）。
+        エージェントには <code>kind: "live"</code> の page_url を提示して、
+        ブラウザで開いて確認させるのが正規ルートです。
+      </li>
+    </ul>
+  </Section>
+
+  <Section
+    eyebrow="// 6 · この先"
+    heading="MCP 経由で次にできること。"
+  >
+    <NumberedList
+      items={[
+        {
+          lead: '自分のリポジトリの CI と組み合わせる。',
+          body: <><a href="/vivarium/ja/guide/integrate-with-your-repo">自分のリポジトリに統合する</a> でCI 側の verdict 監視が立ち、エージェント側からは MCP でカタログを検索する、という両方向の組み合わせができます。</>,
+        },
+        {
+          lead: 'ブランチ修正を verdict で検証する（B3 で予定）。',
+          body: <>修正候補が本当に reproduced → unreproduced を起こしたかをエージェントから一発で確認するためのフロー（B3、ADR-0028）が Phase 7 で予定されています。今は <a href="/vivarium/ja/repro/compare">比較ページ</a> を手動で使う形ですが、将来は MCP 経由で完結する見込みです。</>,
+        },
+      ]}
+    />
+  </Section>
+
+  <Callout>
+    手順のどこかで詰まったら、それは use-from-ai-agent のバグです。
+    クライアント名・OS・詰まったステップ番号を Issue に残してください。
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      自分のリポジトリに統合する{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="MCP からカタログが見える状態になったら、自分の CI 側でも verdict を監視するともう片側が閉じます。"
+  primary={{ label: '統合ガイド →', href: '/vivarium/ja/guide/integrate-with-your-repo' }}
+  ghost={{ label: '用語集', href: '/vivarium/ja/guide/glossary' }}
+/>
+
+<BottomNote
+  text="VIVARIUM は ALETHEIA-WORKS の一部 · GitHub でソースを見る →"
+  href="https://github.com/aletheia-works/vivarium"
+/>


### PR DESCRIPTION
## Summary

Adds the fifth onboarding page in Phase 7 D (ADR-0028 D-4): a step-by-step procedure for wiring the Vivarium MCP server into Claude Code, Cursor, Cline, and Continue, with the four tools (`list_recipes`, `get_recipe`, `lookup_verdict`, `match_error`) and three sample prompt patterns.

## Why now

The MCP install path was documented as local-clone in #171, so D-4 can ship on truthful instructions instead of an `npx` command that 404s.

D so far covers: landing (#163), vocabulary (#156), recipe author (#170), fork-publish (#166), consumer-CI integration (#168). The agent-driver path was the last gap on the "first 30 minutes" surface that does not depend on B3.

## Truthfulness

- Top-of-page Callout makes the **intentional publish-deferral** posture explicit (per maintainer 2026-05-06: Vivarium overall and the MCP server feature surface are still judged unfinished — premature publish would crystallise an interface still under iteration).
- Common-snags section lists the four real failure modes (missing `dist`, path expansion, stale recipes cache, Layer 1 not-a-snapshot expectation).

## Wiring

- New page in ja+en under `guide/use-from-ai-agent`.
- `_meta.json` updated in both locales (slot 3: between integrate-with-your-repo and fork-your-own — natural reading order is consumer-CI → agent-driver → fork).
- `getting-started.mdx` "where to go next" entry for AI agents now points at this guide first.

## Test plan

- [x] `bun run build` clean in `docs/`
- [x] both pages emit to `doc_build/{,ja/}guide/use-from-ai-agent.html`
- [x] CI test-docs-build green
- [x] reviewer skim for accuracy of MCP client paths

## Out of scope (deferred)

- D-5 ("Compare branch fix") — gated on B3 R.2 Path A
- B3 itself — needs new ADR
- V′ component graduation — needs info-design lead
- A3 / A5 (optional A-tail) — separate PRs to follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)