### PR TITLE
feat(mcp,docs): phase 7 A5 — match_error v2 (synonym + fuzzy + multi-lang stopwords)

### DIFF
--- a/docs/components/ErrorRecipeMatcher.tsx
+++ b/docs/components/ErrorRecipeMatcher.tsx
@@ -3,7 +3,7 @@ import './error-recipe-matcher.css';
 import recipesIndex from '../public/api/recipes.json';
 
 /* ============================================================================
- * Phase 6 S.2 — error → recipe matcher (mechanical, no LLM).
+ * Phase 6 S.2 → Phase 7 A5 — error → recipe matcher (mechanical, no LLM).
  *
  * Mechanical token-overlap scoring per ADR-0025:
  *   symptom segment match → +5
@@ -11,9 +11,19 @@ import recipesIndex from '../public/api/recipes.json';
  *   project / slug match  → +2
  * Recipes with score 0 are hidden. Ties broken by (layer asc, slug asc).
  *
- * No LLM, no fuzzy match, no synonym table. Visitors pasting an error
- * with no overlap to the overlay see the empty-state pointing at the
- * gallery (S.1).
+ * Phase 7 A5 (ADR-0028) extends v1 with three accuracy improvements that
+ * never change the weights above:
+ *   1. Adjacent-pair token expansion — "data type" also tries `datatype`.
+ *   2. Synonym groups — variants of the same concept (e.g. dtype⇄datatype).
+ *   3. Bounded fuzzy match — Levenshtein distance ≤ 1 for tokens of
+ *      length ≥ 6 (typo tolerance).
+ *   4. Multi-language stopwords — German, Spanish, French, Chinese,
+ *      Korean noise tokens drop alongside the English+Japanese set.
+ *
+ * **CRITICAL: keep in sync with `packages/mcp-server/src/tools/match_error.ts`.**
+ * The MCP X.2 server-side mirror is bit-identical with this file by ADR
+ * design. Diverging the scoring would surface as agent-vs-UI disagreement
+ * on identical input.
  * ========================================================================== */
 
 interface RecipeEntry {
@@ -40,35 +50,155 @@ const INDEX = recipesIndex as RecipesIndex;
 
 const MAX_INPUT_BYTES = 16 * 1024;
 
-/* English + Japanese stopwords. Kept short; the goal is to drop noise
- * tokens that would never sit in a recipe's overlay anyway, not to
- * provide full lexical coverage. */
+/* Multi-language stopword set (Phase 7 A5). The goal is dropping the
+ * frequent noise tokens that would never sit in a recipe overlay
+ * anyway, not full lexical coverage of any one language. */
 const STOPWORDS = new Set([
+  // English
   'the', 'and', 'for', 'with', 'from', 'that', 'this', 'have',
   'has', 'are', 'was', 'were', 'will', 'not', 'but', 'all',
   'error', 'errors', 'exception', 'failed', 'failure', 'trace',
   'traceback', 'stack', 'line', 'file', 'most', 'recent', 'call',
+  // Japanese
   'です', 'ます', 'した', 'する', 'これ', 'それ', 'その', 'この',
   'エラー', '例外', '失敗', 'スタック',
+  // German
+  'der', 'die', 'das', 'und', 'mit', 'von', 'für', 'fehler',
+  'ausnahme', 'aufgetreten',
+  // Spanish
+  'que', 'por', 'una', 'los', 'las', 'del', 'con',
+  'excepción', 'fallo',
+  // French
+  'pour', 'avec', 'sur', 'dans', 'erreur',
+  'échec',
+  // Chinese (Simplified + Traditional)
+  '错误', '异常', '失败', '堆栈', '錯誤', '異常', '失敗', '堆疊',
+  // Korean
+  '오류', '예외', '실패', '스택',
 ]);
 
-function tokenise(input: string): string[] {
+/* Synonym groups (Phase 7 A5). Within a group, any token in the
+ * user's input expands the input set to include all members.
+ * Conservative on purpose — false-positive pressure rises with table
+ * size. Add entries only when the mapping is unambiguous. */
+const SYNONYM_GROUPS: ReadonlyArray<readonly string[]> = [
+  ['dtype', 'datatype'],
+  ['nullptr', 'nullpointer', 'nilptr', 'nullpointerexception'],
+  ['segfault', 'sigsegv', 'segmentation'],
+  ['flock', 'filelock'],
+  ['deadlock', 'deadblock'],
+  ['datarace', 'racecondition'],
+  ['exitcode', 'exitstatus', 'returncode'],
+  ['oom', 'outofmemory'],
+  ['encoding', 'utf'],
+  ['mismatch', 'mismatched'],
+];
+
+const SYNONYM_MAP: ReadonlyMap<string, ReadonlyArray<string>> = (() => {
+  const m = new Map<string, ReadonlyArray<string>>();
+  for (const group of SYNONYM_GROUPS) {
+    for (const member of group) {
+      m.set(member, group.filter((g) => g !== member));
+    }
+  }
+  return m;
+})();
+
+/* Bounded fuzzy match (Phase 7 A5). Only tokens of length ≥
+ * FUZZY_MIN_LEN are eligible; only Levenshtein distance ≤ 1 is
+ * accepted. Same scoring weight as exact, but matched tokens
+ * record `via: 'fuzzy'` for client-side rendering. */
+const FUZZY_MIN_LEN = 6;
+
+function withinDistance1(a: string, b: string): boolean {
+  if (a === b) return true;
+  const lenA = a.length;
+  const lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  if (lenA === lenB) {
+    let diffs = 0;
+    for (let i = 0; i < lenA; i++) {
+      if (a[i] !== b[i]) {
+        diffs++;
+        if (diffs > 1) return false;
+      }
+    }
+    return diffs === 1;
+  }
+  const shorter = lenA < lenB ? a : b;
+  const longer = lenA < lenB ? b : a;
+  let i = 0;
+  let j = 0;
+  let diffs = 0;
+  while (i < shorter.length && j < longer.length) {
+    if (shorter[i] !== longer[j]) {
+      diffs++;
+      if (diffs > 1) return false;
+      j++;
+    } else {
+      i++;
+      j++;
+    }
+  }
+  return true;
+}
+
+interface TokenSet {
+  /** Direct tokens after splitting + stopword filter + adjacent-pair join. */
+  direct: ReadonlySet<string>;
+  /** Synonym-expanded tokens: catalogue-side variant → original input token. */
+  synonyms: ReadonlyMap<string, string>;
+  /** Direct tokens of length ≥ FUZZY_MIN_LEN, eligible for fuzzy matching. */
+  fuzzyCandidates: ReadonlyArray<string>;
+  /** Ordered display list (de-duplicated, no synonym/pair additions). */
+  displayOrder: ReadonlyArray<string>;
+}
+
+function tokenise(input: string): TokenSet {
   let trimmed = input;
   if (trimmed.length > MAX_INPUT_BYTES) {
     trimmed = trimmed.slice(trimmed.length - MAX_INPUT_BYTES);
   }
   const lower = trimmed.toLowerCase();
   const raw = lower.split(/[^a-z0-9_]+/);
-  const tokens: string[] = [];
-  const seen = new Set<string>();
+
+  // Stage 1: filter raw tokens (length ≥ 3, not stopword, dedup).
+  const ordered: string[] = [];
+  const seenRaw = new Set<string>();
   for (const t of raw) {
     if (t.length < 3) continue;
     if (STOPWORDS.has(t)) continue;
-    if (seen.has(t)) continue;
-    seen.add(t);
-    tokens.push(t);
+    if (seenRaw.has(t)) continue;
+    seenRaw.add(t);
+    ordered.push(t);
   }
-  return tokens;
+
+  // Stage 2: adjacent-pair expansion. Lets multi-word user input
+  // (e.g. "data type") match single-word catalogue terms (`dtype`)
+  // via the synonym table.
+  const direct = new Set<string>(ordered);
+  for (let i = 0; i < ordered.length - 1; i++) {
+    direct.add(ordered[i]! + ordered[i + 1]!);
+  }
+
+  // Stage 3: synonym expansion.
+  const synonyms = new Map<string, string>();
+  for (const t of direct) {
+    const partners = SYNONYM_MAP.get(t);
+    if (!partners) continue;
+    for (const p of partners) {
+      if (direct.has(p) || synonyms.has(p)) continue;
+      synonyms.set(p, t);
+    }
+  }
+
+  // Stage 4: fuzzy candidate set.
+  const fuzzyCandidates: string[] = [];
+  for (const t of direct) {
+    if (t.length >= FUZZY_MIN_LEN) fuzzyCandidates.push(t);
+  }
+
+  return { direct, synonyms, fuzzyCandidates, displayOrder: ordered };
 }
 
 function kebabSegments(value: string): string[] {
@@ -78,44 +208,67 @@ function kebabSegments(value: string): string[] {
     .filter((t) => t.length >= 3 && !STOPWORDS.has(t));
 }
 
+interface MatchedToken {
+  source: 'symptom' | 'tags' | 'project' | 'slug';
+  token: string;
+  via?: 'synonym' | 'fuzzy';
+  input?: string;
+}
+
 interface Score {
   recipe: RecipeEntry;
   score: number;
-  matched: { source: 'symptom' | 'tags' | 'project' | 'slug'; token: string }[];
+  matched: MatchedToken[];
 }
 
-function scoreRecipe(recipe: RecipeEntry, tokens: Set<string>): Score {
-  const matched: Score['matched'] = [];
+interface SegmentMatch {
+  matched: boolean;
+  via?: 'synonym' | 'fuzzy';
+  input?: string;
+}
+
+function matchSegment(seg: string, tokens: TokenSet): SegmentMatch {
+  if (tokens.direct.has(seg)) return { matched: true };
+  const synonymInput = tokens.synonyms.get(seg);
+  if (synonymInput !== undefined) {
+    return { matched: true, via: 'synonym', input: synonymInput };
+  }
+  if (seg.length >= FUZZY_MIN_LEN) {
+    for (const candidate of tokens.fuzzyCandidates) {
+      if (withinDistance1(seg, candidate)) {
+        return { matched: true, via: 'fuzzy', input: candidate };
+      }
+    }
+  }
+  return { matched: false };
+}
+
+function scoreRecipe(recipe: RecipeEntry, tokens: TokenSet): Score {
+  const matched: MatchedToken[] = [];
   let score = 0;
 
+  const apply = (
+    source: MatchedToken['source'],
+    weight: number,
+    seg: string,
+  ) => {
+    const m = matchSegment(seg, tokens);
+    if (!m.matched) return;
+    score += weight;
+    const entry: MatchedToken = { source, token: seg };
+    if (m.via) entry.via = m.via;
+    if (m.input !== undefined) entry.input = m.input;
+    matched.push(entry);
+  };
+
   if (recipe.symptom) {
-    for (const seg of kebabSegments(recipe.symptom)) {
-      if (tokens.has(seg)) {
-        score += 5;
-        matched.push({ source: 'symptom', token: seg });
-      }
-    }
+    for (const seg of kebabSegments(recipe.symptom)) apply('symptom', 5, seg);
   }
   for (const tag of recipe.tags) {
-    for (const seg of kebabSegments(tag)) {
-      if (tokens.has(seg)) {
-        score += 3;
-        matched.push({ source: 'tags', token: seg });
-      }
-    }
+    for (const seg of kebabSegments(tag)) apply('tags', 3, seg);
   }
-  for (const seg of kebabSegments(recipe.project)) {
-    if (tokens.has(seg)) {
-      score += 2;
-      matched.push({ source: 'project', token: seg });
-    }
-  }
-  for (const seg of kebabSegments(recipe.slug)) {
-    if (tokens.has(seg)) {
-      score += 2;
-      matched.push({ source: 'slug', token: seg });
-    }
-  }
+  for (const seg of kebabSegments(recipe.project)) apply('project', 2, seg);
+  for (const seg of kebabSegments(recipe.slug)) apply('slug', 2, seg);
 
   return { recipe, score, matched };
 }
@@ -215,12 +368,12 @@ function MatchCard({ lang, score }: { lang: Lang; score: Score }) {
     r.layer === 1 ? 'teal' : r.layer === 2 ? 'violet' : 'coral';
   // Dedupe matched tokens for display while preserving first-seen order.
   const seen = new Set<string>();
-  const tokens: { token: string; source: string }[] = [];
+  const displayTokens: MatchedToken[] = [];
   for (const m of score.matched) {
-    const key = `${m.source}:${m.token}`;
+    const key = `${m.source}:${m.token}:${m.via ?? ''}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    tokens.push(m);
+    displayTokens.push(m);
   }
   return (
     <article className="v-rg__card v-erm__card">
@@ -242,12 +395,23 @@ function MatchCard({ lang, score }: { lang: Lang; score: Score }) {
       <p className="v-rg__lede">{r.title}</p>
       <div className="v-erm__matched">
         <span className="v-erm__matched-key">{s.matchedTokensLabel}:</span>
-        {tokens.map((m, i) => (
-          <span key={i} className={`v-erm__token v-erm__token--${m.source}`}>
-            <span className="v-erm__token-source">{m.source[0]}</span>
-            {m.token}
-          </span>
-        ))}
+        {displayTokens.map((m, i) => {
+          const viaMark = m.via === 'fuzzy' ? '~' : m.via === 'synonym' ? '≡' : null;
+          const title = m.via && m.input
+            ? `${m.via} match (input: ${m.input})`
+            : undefined;
+          return (
+            <span
+              key={i}
+              className={`v-erm__token v-erm__token--${m.source}${m.via ? ' v-erm__token--' + m.via : ''}`}
+              title={title}
+            >
+              <span className="v-erm__token-source">{m.source[0]}</span>
+              {m.token}
+              {viaMark ? <span className="v-erm__token-via">{viaMark}</span> : null}
+            </span>
+          );
+        })}
       </div>
       <div className="v-rg__actions">
         <a
@@ -274,12 +438,11 @@ export function ErrorRecipeMatcher({ lang }: { lang: Lang }) {
   // has no other settings (layer/severity toggles etc.) so there is no
   // submit semantic to wait on. Clear button is the only escape hatch.
   const tokens = useMemo(() => tokenise(input), [input]);
-  const tokenSet = useMemo(() => new Set(tokens), [tokens]);
 
   const ranked = useMemo<Score[]>(() => {
-    if (tokens.length === 0) return [];
+    if (tokens.displayOrder.length === 0) return [];
     const scored = INDEX.recipes
-      .map((r) => scoreRecipe(r, tokenSet))
+      .map((r) => scoreRecipe(r, tokens))
       .filter((s) => s.score > 0);
     scored.sort((a, b) => {
       if (b.score !== a.score) return b.score - a.score;
@@ -287,7 +450,7 @@ export function ErrorRecipeMatcher({ lang }: { lang: Lang }) {
       return a.recipe.slug.localeCompare(b.recipe.slug);
     });
     return scored;
-  }, [tokens, tokenSet]);
+  }, [tokens]);
 
   const clear = () => setInput('');
 
@@ -321,10 +484,10 @@ export function ErrorRecipeMatcher({ lang }: { lang: Lang }) {
         </button>
       </div>
 
-      {hasInput && tokens.length > 0 ? (
+      {hasInput && tokens.displayOrder.length > 0 ? (
         <div className="v-erm__tokens">
           <span className="v-erm__tokens-label">{s.tokenisedAs}</span>
-          {tokens.map((t) => (
+          {tokens.displayOrder.map((t) => (
             <span key={t} className="v-erm__token v-erm__token--input">
               {t}
             </span>

--- a/docs/docs/en/repro/match.mdx
+++ b/docs/docs/en/repro/match.mdx
@@ -10,7 +10,7 @@ import { ErrorRecipeMatcher } from '../../../components/ErrorRecipeMatcher';
   <PageHero
     eyebrow="// MATCH · ERROR → RECIPE"
     title={<>Paste an error, find a candidate.</>}
-    sub="Mechanical token-overlap match against the recipe catalogue. No LLM, no fuzzy match — exact lowercase tokens against each recipe's symptom, tags, project, and slug. All scoring runs locally."
+    sub="Mechanical token-overlap match against the recipe catalogue. No LLM — lowercase tokens are scored against each recipe's symptom, tags, project, and slug. Phase 7 A5 adds a synonym table (e.g. dtype⇄datatype), Levenshtein-1 fuzzy match for tokens of length ≥ 6, and multi-language stopwords. All scoring runs locally."
   />
 
   <ErrorRecipeMatcher lang="en" />

--- a/docs/docs/ja/repro/match.mdx
+++ b/docs/docs/ja/repro/match.mdx
@@ -10,7 +10,7 @@ import { ErrorRecipeMatcher } from '../../../components/ErrorRecipeMatcher';
   <PageHero
     eyebrow="// MATCH · ERROR → RECIPE"
     title={<>エラーを貼り付けて、候補レシピを探す。</>}
-    sub="レシピカタログに対する機械的なトークンオーバーラップマッチ。LLM 非依存、ファジーマッチ非対応——各レシピの symptom / tags / project / slug に対する正確な小文字トークン一致のみ。スコアリングはすべてローカルで実行される。"
+    sub="レシピカタログに対する機械的なトークンオーバーラップマッチ。LLM 非依存——各レシピの symptom / tags / project / slug に対する小文字トークン一致をスコア化する。Phase 7 A5 で同義語テーブル（dtype⇄datatype など）、Levenshtein 距離 1 のファジーマッチ（長さ 6 以上のトークン）、多言語ストップワードを追加。スコアリングはすべてローカルで実行される。"
   />
 
   <ErrorRecipeMatcher lang="ja" />

--- a/packages/mcp-server/src/tools/match_error.ts
+++ b/packages/mcp-server/src/tools/match_error.ts
@@ -1,18 +1,32 @@
-// Phase 6 X.2 — match_error tool.
+// Phase 6 X.2 → Phase 7 A5 — match_error tool, v2.
 //
-// Server-side mirror of the docs-site error → recipe matcher (Phase 6 S.2,
-// ADR-0025). The scoring rule is bit-identical:
+// Server-side mirror of the docs-site error → recipe matcher
+// (Phase 6 S.2, ADR-0025). The scoring weights are bit-identical
+// with the docs-site `ErrorRecipeMatcher.tsx`:
 //   symptom segment match → +5
 //   tag segment match     → +3
 //   project / slug match  → +2
 // Recipes with score 0 are dropped. Ties broken by (layer asc, slug asc).
 //
-// ADR-0025 §Neutral named this lift explicitly:
-//   "A future X.2 ... could expose this matcher to agents. The scoring
-//    rule is identical, so an X.2 implementation would lift the function
-//    from ErrorRecipeMatcher.tsx into the MCP server."
+// Phase 7 A5 (ADR-0028) extends v1 with three accuracy improvements,
+// none of which change the weights above:
+//   1. Adjacent-pair token expansion — "data type" also tries `datatype`,
+//      so multi-word user input can hit single-word catalogue terms.
+//   2. Synonym groups — variants of the same concept (e.g. `dtype` ⇄
+//      `datatype`) all expand to the whole group.
+//   3. Bounded fuzzy match — tokens of length ≥ 6 within Levenshtein
+//      distance 1 score the same as exact, so "missmatch" still hits
+//      `mismatch`.
+//   4. Multi-language stopwords — German, Spanish, French, Chinese,
+//      Korean noise tokens drop alongside the existing English+Japanese.
 //
-// The lift is mechanical — no LLM, no fuzzy match, no synonym table.
+// **CRITICAL: keep in sync with `docs/components/ErrorRecipeMatcher.tsx`.**
+// ADR-0025 §Neutral made the docs surface the canonical implementation;
+// X.2 lifted it server-side bit-identical, and A5 keeps both copies
+// updated atomically. Diverging the scoring between MCP and the docs
+// matcher would surface as agent-vs-UI disagreement on identical input.
+//
+// The matcher remains mechanical — no LLM, no semantic embeddings.
 // AGENTS.md §3.3's mechanical-over-judgement rule carries through.
 
 import { getCatalogue } from '../catalogue.js';
@@ -26,6 +40,21 @@ export interface MatchErrorArgs {
 interface MatchedToken {
   source: 'symptom' | 'tags' | 'project' | 'slug';
   token: string;
+  /**
+   * How the token was matched. Omitted (undefined) for direct exact
+   * matches (the v1 case). `synonym` indicates the catalogue token
+   * was reached via a synonym-group expansion of an input token.
+   * `fuzzy` indicates a Levenshtein-distance-1 match (typo-tolerant).
+   * v1 clients ignore this field; v2 clients can render the
+   * provenance.
+   */
+  via?: 'synonym' | 'fuzzy';
+  /**
+   * Original input token that triggered a non-exact match (set when
+   * `via` is `synonym` or `fuzzy`). Lets agents render "you wrote X,
+   * we matched Y."
+   */
+  input?: string;
 }
 
 interface ScoredRecipe {
@@ -45,32 +74,163 @@ const MAX_INPUT_BYTES = 16 * 1024;
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 50;
 
+// Multi-language stopword set (Phase 7 A5). The goal isn't full
+// lexical coverage of any single language — it's dropping the
+// frequent noise tokens that would never sit in a recipe overlay.
+// Anything that sneaks through scores 0 against the catalogue
+// anyway; the worst case is wasted comparison cycles, not wrong
+// matches.
 const STOPWORDS: ReadonlySet<string> = new Set([
+  // English
   'the', 'and', 'for', 'with', 'from', 'that', 'this', 'have',
   'has', 'are', 'was', 'were', 'will', 'not', 'but', 'all',
   'error', 'errors', 'exception', 'failed', 'failure', 'trace',
   'traceback', 'stack', 'line', 'file', 'most', 'recent', 'call',
+  // Japanese
   'です', 'ます', 'した', 'する', 'これ', 'それ', 'その', 'この',
   'エラー', '例外', '失敗', 'スタック',
+  // German
+  'der', 'die', 'das', 'und', 'mit', 'von', 'für', 'fehler',
+  'ausnahme', 'aufgetreten',
+  // Spanish
+  'que', 'por', 'una', 'los', 'las', 'del', 'con',
+  'excepción', 'fallo',
+  // French
+  'pour', 'avec', 'sur', 'dans', 'erreur',
+  'échec',
+  // Chinese (Simplified + Traditional, common particles + error words)
+  '错误', '异常', '失败', '堆栈', '錯誤', '異常', '失敗', '堆疊',
+  // Korean (common particles + error words)
+  '오류', '예외', '실패', '스택',
 ]);
 
-function tokenise(input: string): string[] {
+// Synonym groups (Phase 7 A5). Within a group, any token in the
+// user's input expands the input set to include all members.
+// Variants are stored hyphen-stripped (lowercase, alphanumeric)
+// to match the kebab-segmented catalogue tokens.
+//
+// Conservative on purpose — false-positive pressure rises with
+// table size. Add a group only when there's an unambiguous mapping
+// between a user-input shape and a catalogue overlay token.
+const SYNONYM_GROUPS: ReadonlyArray<readonly string[]> = [
+  ['dtype', 'datatype'],
+  ['nullptr', 'nullpointer', 'nilptr', 'nullpointerexception'],
+  ['segfault', 'sigsegv', 'segmentation'],
+  ['flock', 'filelock'],
+  ['deadlock', 'deadblock'],
+  ['datarace', 'racecondition'],
+  ['exitcode', 'exitstatus', 'returncode'],
+  ['oom', 'outofmemory'],
+  ['encoding', 'utf'],
+  ['mismatch', 'mismatched'],
+];
+
+const SYNONYM_MAP: ReadonlyMap<string, ReadonlyArray<string>> = (() => {
+  const m = new Map<string, ReadonlyArray<string>>();
+  for (const group of SYNONYM_GROUPS) {
+    for (const member of group) {
+      m.set(member, group.filter((g) => g !== member));
+    }
+  }
+  return m;
+})();
+
+// Phase 7 A5: bounded fuzzy match. Only fires for tokens of length
+// ≥ FUZZY_MIN_LEN; only Levenshtein distance ≤ 1 is accepted (single
+// insert / delete / substitute). Same weight as exact, but the
+// MatchedToken records `via: 'fuzzy'` for client-side rendering.
+const FUZZY_MIN_LEN = 6;
+
+function withinDistance1(a: string, b: string): boolean {
+  if (a === b) return true;
+  const lenA = a.length;
+  const lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  if (lenA === lenB) {
+    let diffs = 0;
+    for (let i = 0; i < lenA; i++) {
+      if (a[i] !== b[i]) {
+        diffs++;
+        if (diffs > 1) return false;
+      }
+    }
+    return diffs === 1;
+  }
+  const shorter = lenA < lenB ? a : b;
+  const longer = lenA < lenB ? b : a;
+  let i = 0;
+  let j = 0;
+  let diffs = 0;
+  while (i < shorter.length && j < longer.length) {
+    if (shorter[i] !== longer[j]) {
+      diffs++;
+      if (diffs > 1) return false;
+      j++;
+    } else {
+      i++;
+      j++;
+    }
+  }
+  return true;
+}
+
+interface TokenSet {
+  /** Direct tokens (no synonym/fuzzy provenance). */
+  direct: ReadonlySet<string>;
+  /** Synonym-expanded tokens with their original input tokens. */
+  synonyms: ReadonlyMap<string, string>;
+  /** Long enough for fuzzy matching (length ≥ FUZZY_MIN_LEN). */
+  fuzzyCandidates: ReadonlyArray<string>;
+}
+
+function tokenise(input: string): TokenSet {
   let trimmed = input;
   if (trimmed.length > MAX_INPUT_BYTES) {
     trimmed = trimmed.slice(trimmed.length - MAX_INPUT_BYTES);
   }
   const lower = trimmed.toLowerCase();
   const raw = lower.split(/[^a-z0-9_]+/);
-  const tokens: string[] = [];
-  const seen = new Set<string>();
+
+  // Stage 1: filter raw tokens (length ≥ 3, not stopword, dedup).
+  const ordered: string[] = [];
+  const seenRaw = new Set<string>();
   for (const t of raw) {
     if (t.length < 3) continue;
     if (STOPWORDS.has(t)) continue;
-    if (seen.has(t)) continue;
-    seen.add(t);
-    tokens.push(t);
+    if (seenRaw.has(t)) continue;
+    seenRaw.add(t);
+    ordered.push(t);
   }
-  return tokens;
+
+  // Stage 2: adjacent-pair expansion. Lets multi-word user input
+  // (e.g. "data type") match single-word catalogue terms (`dtype`)
+  // via the synonym table.
+  const direct = new Set<string>(ordered);
+  for (let i = 0; i < ordered.length - 1; i++) {
+    direct.add(ordered[i]! + ordered[i + 1]!);
+  }
+
+  // Stage 3: synonym expansion. For each direct token, if it has a
+  // synonym group, add the other members and remember which input
+  // token brought them in.
+  const synonyms = new Map<string, string>();
+  for (const t of direct) {
+    const partners = SYNONYM_MAP.get(t);
+    if (!partners) continue;
+    for (const p of partners) {
+      if (direct.has(p) || synonyms.has(p)) continue;
+      synonyms.set(p, t);
+    }
+  }
+
+  // Stage 4: fuzzy candidate set — direct tokens (not synonym
+  // additions) of sufficient length.
+  const fuzzyCandidates: string[] = [];
+  for (const t of direct) {
+    if (t.length >= FUZZY_MIN_LEN) fuzzyCandidates.push(t);
+  }
+
+  return { direct, synonyms, fuzzyCandidates };
 }
 
 function kebabSegments(value: string): string[] {
@@ -80,41 +240,57 @@ function kebabSegments(value: string): string[] {
     .filter((t) => t.length >= 3 && !STOPWORDS.has(t));
 }
 
+interface SegmentMatch {
+  matched: boolean;
+  via?: 'synonym' | 'fuzzy';
+  input?: string;
+}
+
+function matchSegment(seg: string, tokens: TokenSet): SegmentMatch {
+  if (tokens.direct.has(seg)) return { matched: true };
+  const synonymInput = tokens.synonyms.get(seg);
+  if (synonymInput !== undefined) {
+    return { matched: true, via: 'synonym', input: synonymInput };
+  }
+  if (seg.length >= FUZZY_MIN_LEN) {
+    for (const candidate of tokens.fuzzyCandidates) {
+      if (withinDistance1(seg, candidate)) {
+        return { matched: true, via: 'fuzzy', input: candidate };
+      }
+    }
+  }
+  return { matched: false };
+}
+
 function scoreRecipe(
   recipe: RecipeEntry,
-  tokens: ReadonlySet<string>,
+  tokens: TokenSet,
 ): ScoredRecipe {
   const matched: MatchedToken[] = [];
   let score = 0;
 
+  const apply = (
+    source: MatchedToken['source'],
+    weight: number,
+    seg: string,
+  ) => {
+    const m = matchSegment(seg, tokens);
+    if (!m.matched) return;
+    score += weight;
+    const entry: MatchedToken = { source, token: seg };
+    if (m.via) entry.via = m.via;
+    if (m.input !== undefined) entry.input = m.input;
+    matched.push(entry);
+  };
+
   if (recipe.symptom) {
-    for (const seg of kebabSegments(recipe.symptom)) {
-      if (tokens.has(seg)) {
-        score += 5;
-        matched.push({ source: 'symptom', token: seg });
-      }
-    }
+    for (const seg of kebabSegments(recipe.symptom)) apply('symptom', 5, seg);
   }
   for (const tag of recipe.tags ?? []) {
-    for (const seg of kebabSegments(tag)) {
-      if (tokens.has(seg)) {
-        score += 3;
-        matched.push({ source: 'tags', token: seg });
-      }
-    }
+    for (const seg of kebabSegments(tag)) apply('tags', 3, seg);
   }
-  for (const seg of kebabSegments(recipe.project)) {
-    if (tokens.has(seg)) {
-      score += 2;
-      matched.push({ source: 'project', token: seg });
-    }
-  }
-  for (const seg of kebabSegments(recipe.slug)) {
-    if (tokens.has(seg)) {
-      score += 2;
-      matched.push({ source: 'slug', token: seg });
-    }
-  }
+  for (const seg of kebabSegments(recipe.project)) apply('project', 2, seg);
+  for (const seg of kebabSegments(recipe.slug)) apply('slug', 2, seg);
 
   return { recipe, score, matched };
 }
@@ -132,11 +308,10 @@ export async function matchError(
   );
 
   const tokens = tokenise(text);
-  const tokenSet = new Set(tokens);
 
   const { recipes } = await getCatalogue();
   const scored = recipes
-    .map((r) => scoreRecipe(r, tokenSet))
+    .map((r) => scoreRecipe(r, tokens))
     .filter((s) => s.score > 0);
 
   scored.sort((a, b) => {
@@ -148,7 +323,7 @@ export async function matchError(
 
   return {
     ok: true,
-    query_token_count: tokens.length,
+    query_token_count: tokens.direct.size,
     total_recipes: recipes.length,
     matches: scored.slice(0, limit),
   };
@@ -157,14 +332,14 @@ export async function matchError(
 export const MATCH_ERROR_TOOL = {
   name: 'match_error',
   description:
-    "Find Vivarium recipes that match a pasted error message or stack trace by mechanical token overlap (no LLM, no fuzzy match). The text is tokenised, lowercase-compared against each recipe's symptom (weight 5 per segment), tags (3), project (2), and slug (2). Recipes with score > 0 are returned in descending score order; ties broken by (layer asc, slug asc). Returns the recipe entry plus the matched tokens for each candidate so agents can show which fragments hit. Pair with `get_recipe` to drill into a specific result, or `list_recipes` for unfiltered browsing.",
+    "Find Vivarium recipes that match a pasted error message or stack trace by mechanical token overlap (no LLM). The text is tokenised, lowercase-compared against each recipe's symptom (weight 5 per segment), tags (3), project (2), and slug (2). v2 (Phase 7 A5) adds adjacent-pair tokens (so 'data type' can hit `dtype`), a small synonym table (e.g. dtype⇄datatype, segfault⇄sigsegv), and bounded Levenshtein-1 fuzzy matching for tokens of length ≥ 6. Stopword set covers English, Japanese, German, Spanish, French, Chinese, and Korean noise tokens. Recipes with score > 0 are returned in descending score order; ties broken by (layer asc, slug asc). Each matched token reports its `via` (`synonym` or `fuzzy` when non-exact) and the original `input` that triggered it, so agents can render the provenance. Pair with `get_recipe` to drill into a specific result, or `list_recipes` for unfiltered browsing.",
   inputSchema: {
     type: 'object' as const,
     properties: {
       text: {
         type: 'string' as const,
         description:
-          'Error message, stack trace, or any free-text fragment to match against the catalogue. Tokenised on non-alphanumeric runs after lowercasing; tokens shorter than 3 chars and a fixed English+Japanese stopword list are dropped. Input longer than 16 KB is truncated from the front.',
+          'Error message, stack trace, or any free-text fragment to match against the catalogue. Tokenised on non-alphanumeric runs after lowercasing; tokens shorter than 3 chars and a multi-language stopword list are dropped. Input longer than 16 KB is truncated from the front.',
       },
       limit: {
         type: 'integer' as const,

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -224,4 +224,79 @@ describe('match_error', () => {
       assert.ok(tokens.includes('dtype') || tokens.includes('mismatch'));
     }
   });
+
+  // Phase 7 A5 — accuracy improvements (synonym, fuzzy, multi-lang stopwords).
+
+  it('expands "data type" → datatype → dtype via synonym table', async () => {
+    const r = await matchError({
+      text: 'pandas DataFrame has a data type mismatch',
+    });
+    assert.equal('ok' in r && r.ok, true);
+    if ('ok' in r && r.ok) {
+      assert.equal(r.matches[0]!.recipe.slug, 'pandas-56679');
+      const dtypeMatch = r.matches[0]!.matched.find(
+        (m) => m.token === 'dtype' && m.source === 'symptom',
+      );
+      assert.ok(dtypeMatch, 'expected dtype symptom match via synonym');
+      assert.equal(dtypeMatch!.via, 'synonym');
+      assert.equal(dtypeMatch!.input, 'datatype');
+    }
+  });
+
+  it('matches typos via fuzzy distance-1 (e.g. missmatch → mismatch)', async () => {
+    const r = await matchError({
+      text: 'pandas dtype missmatch error',
+    });
+    assert.equal('ok' in r && r.ok, true);
+    if ('ok' in r && r.ok) {
+      assert.equal(r.matches[0]!.recipe.slug, 'pandas-56679');
+      const fuzzyHit = r.matches[0]!.matched.find(
+        (m) => m.token === 'mismatch' && m.via === 'fuzzy',
+      );
+      assert.ok(fuzzyHit, 'expected fuzzy match for mismatch');
+      assert.equal(fuzzyHit!.input, 'missmatch');
+    }
+  });
+
+  it('does not fuzzy-match short tokens (length < 6)', async () => {
+    // 'dtype' is 5 chars, below FUZZY_MIN_LEN. A typo "dtyp" must NOT
+    // accidentally match — would be too noisy.
+    const r = await matchError({ text: 'pandas dtyp error' });
+    if ('ok' in r && r.ok && r.matches.length > 0) {
+      const dtypeFuzzy = r.matches[0]!.matched.find(
+        (m) => m.token === 'dtype' && m.via === 'fuzzy',
+      );
+      assert.equal(dtypeFuzzy, undefined);
+    }
+  });
+
+  it('drops German stopwords ("der", "fehler") so they cannot match accidentally', async () => {
+    // "fehler" is added to the German stopword set; it must not appear
+    // as a query token even though it would otherwise pass length / regex.
+    const r = await matchError({
+      text: 'der fehler ist ein dtype mismatch',
+    });
+    assert.equal('ok' in r && r.ok, true);
+    if ('ok' in r && r.ok) {
+      // Should still match pandas via the surviving tokens.
+      assert.equal(r.matches[0]!.recipe.slug, 'pandas-56679');
+      assert.ok(
+        r.matches[0]!.matched.every((m) => m.token !== 'fehler'),
+        'fehler should have been stopworded out',
+      );
+    }
+  });
+
+  it('marks exact matches without via (v1 wire-compat for non-fuzzy hits)', async () => {
+    const r = await matchError({ text: 'pandas dtype mismatch' });
+    if ('ok' in r && r.ok && r.matches.length > 0) {
+      const exactSymptom = r.matches[0]!.matched.find(
+        (m) => m.token === 'dtype' && m.source === 'symptom',
+      );
+      assert.ok(exactSymptom);
+      // Direct exact hit — `via` and `input` must be absent.
+      assert.equal(exactSymptom!.via, undefined);
+      assert.equal(exactSymptom!.input, undefined);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Phase 7 A5 (ADR-0028) — accuracy improvements to the error→recipe matcher. Same scoring weights (symptom +5, tags +3, project/slug +2); v2 adds three token-set extensions:

1. **Adjacent-pair tokens** — \"data type\" hits single-word catalogue terms (\`dtype\`) via synonym.
2. **Synonym groups** (10 entries) — \`dtype⇄datatype\`, \`nullptr⇄nullpointer\`, \`segfault⇄sigsegv\`, \`flock⇄filelock\`, \`deadlock\`, \`datarace⇄racecondition\`, \`exitcode⇄exitstatus⇄returncode\`, \`oom⇄outofmemory\`, \`encoding⇄utf\`, \`mismatch⇄mismatched\`.
3. **Bounded fuzzy** — Levenshtein ≤ 1 for tokens of length ≥ 6. Same weight as exact; matched token records \`via: 'fuzzy'\` and the original \`input\`.
4. **Multi-language stopwords** — added German, Spanish, French, Chinese (Simplified + Traditional), and Korean common particles + error words.

## Wire compatibility

- \`MatchedToken\` gains optional \`via\` and \`input\` fields. v1 clients ignore them; v2 clients render provenance.
- Tool description updated.
- No breaking change.

## Sync constraint

The matcher logic remains duplicated between [\`packages/mcp-server/src/tools/match_error.ts\`](packages/mcp-server/src/tools/match_error.ts) and [\`docs/components/ErrorRecipeMatcher.tsx\`](docs/components/ErrorRecipeMatcher.tsx) per ADR-0025 §Neutral / ADR-0028 §A5. Both files now carry a CRITICAL-keep-in-sync comment block. Future structural extraction is its own PR.

## Test plan

- [x] 5 new MCP tests: synonym expansion, fuzzy positive, fuzzy-negative below \`FUZZY_MIN_LEN\`, German stopword filter, v1 wire-compat for exact matches.
- [x] All 29 MCP tests pass (\`mise run ci:mcp\`).
- [x] Docs build clean (\`mise run ci:docs\`).
- [x] UI verified on \`/vivarium/ja/repro/match\` via Claude Preview:
  - \"data type mismatch\" → pandas-56679 score 20, dtype matched via synonym (input: datatype, marker ≡)
  - \"dtype missmatch\" → pandas-56679 score 14, mismatch matched via fuzzy (input: missmatch, marker ~)
  - \"der fehler ist ein dtype mismatch in pandas\" → German stopwords (der, fehler) filtered; pandas still matches
- [x] CI test-mcp + test-docs-build green

## Out of scope

- Lifting the duplicated matcher into a shared package (structural refactor; ADR-blessed for now).
- Expanding synonym table — sized to current catalogue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)