### PR TITLE
feat(docs): phase 7 V′ — landing redesign, biome + lucide-react, autofix CI

### DIFF
--- a/.github/workflows/biome-autofix.yml
+++ b/.github/workflows/biome-autofix.yml
@@ -1,0 +1,103 @@
+name: Biome autofix
+
+# Runs Biome (`biome check --write --unsafe`) on docs/ and pushes any
+# resulting changes back to the PR branch so contributors don't have
+# to fix formatting / lint by hand. This complements the read-only
+# `test-docs-check.yml` workflow — that one fails the PR on remaining
+# diagnostics, this one heals them in place when possible.
+#
+# Pattern mirrors `tofu-fmt-autofix.yml` / the org's `terraform-autofix`
+# reusable. Inline for now (first instance in vivarium); flag for
+# promotion to `aletheia-works/.github/.github/workflows/biome-autofix.yml`
+# when a second repo in the org needs the same logic, per AGENTS.md §4.8.
+#
+# `pull_request_target` so fork PRs see autofix run too — `pull_request`
+# from a fork ships with read-only GITHUB_TOKEN, which can't push back.
+# Same TF_TOKEN_GITHUB PAT as tofu autofix; that PAT has write access to
+# the maintainer's personal forks (`JamBalaya56562/*`) where `sl pr
+# submit` lands every PR.
+#
+# SECURITY NOTE: combined with `secrets: inherit`, fork-PR JS/TS/CSS
+# is touched with an org-scoped PAT. Acceptable because Biome is a
+# textual formatter/linter (no code execution from PR sources during
+# the workflow — only `bun install --frozen-lockfile` + `biome check`,
+# both of which run npm install scripts only for already-trusted
+# packages declared in the base ref's `bun.lock`). If outside-fork
+# contributions are ever opened, switch to `pull_request` + a trusted-
+# fork allowlist.
+
+on:
+  pull_request_target:
+    paths:
+      - 'docs/**/*.ts'
+      - 'docs/**/*.tsx'
+      - 'docs/**/*.js'
+      - 'docs/**/*.mjs'
+      - 'docs/**/*.cjs'
+      - 'docs/**/*.css'
+      - 'docs/**/*.json'
+      - 'docs/biome.json'
+      - 'docs/package.json'
+      - 'docs/bun.lock'
+      - '.github/workflows/biome-autofix.yml'
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: biome-autofix-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  autofix:
+    name: Biome autofix
+    if: github.repository_owner == 'aletheia-works'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      # Checkout the PR's head branch on the head repo so the autofix
+      # commit lands on the contributor's branch and can be pulled
+      # locally. For fork PRs the head repo is the contributor's fork.
+      - name: Checkout PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.TF_TOKEN_GITHUB }}
+          persist-credentials: true
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # `biome check --write --unsafe` applies safe formatter changes,
+      # safe lint fixes, and unsafe-but-still-mechanical lint fixes
+      # (e.g. literal-key conversion, optional-chain rewrites). Genuine
+      # remaining errors stay as errors — those will fail
+      # test-docs-check.yml and need human attention.
+      - name: Biome check (write + unsafe fixes)
+        run: bun x --bun biome check --write --unsafe .
+
+      # Commit & push only when biome actually changed files. `git diff
+      # --quiet` exits non-zero when there are unstaged diffs.
+      - name: Commit and push fixes
+        working-directory: ${{ github.workspace }}
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if git diff --quiet; then
+            echo "No Biome changes to commit."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "style(docs): biome check --write --unsafe"
+          git push origin "HEAD:${PR_HEAD_REF}"

--- a/.github/workflows/test-docs-check.yml
+++ b/.github/workflows/test-docs-check.yml
@@ -1,0 +1,61 @@
+name: Test docs format + lint
+
+# Runs Biome (formatter + linter) over docs/ on every PR that touches
+# JS / TS / CSS / JSON inside docs/. The check is strict — any
+# unformatted file or remaining lint diagnostic fails the PR.
+#
+# Companion workflow: `biome-autofix.yml` heals what is mechanically
+# fixable (`biome check --write --unsafe`) by committing back to the
+# PR branch. This workflow only fails on what remains after that
+# autofix — i.e. issues a human has to think about.
+#
+# Local equivalent: `mise run ci:docs-check`. Authors can apply safe
+# auto-fixes with `mise run docs:check:fix` before re-pushing.
+#
+# Tooling: single-tool job (bun only). Mirrors test-docs-build.yml's
+# stance — no need for the rest of mise.toml since Biome is the only
+# moving piece here.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**/*.ts'
+      - 'docs/**/*.tsx'
+      - 'docs/**/*.js'
+      - 'docs/**/*.mjs'
+      - 'docs/**/*.cjs'
+      - 'docs/**/*.css'
+      - 'docs/**/*.json'
+      - 'docs/biome.json'
+      - 'docs/package.json'
+      - 'docs/bun.lock'
+      - '.github/workflows/test-docs-check.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-docs-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Biome check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Biome check (format + lint, read-only)
+        run: bun x --bun biome check .

--- a/docs/biome.json
+++ b/docs/biome.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "vcs": {
+    "enabled": false,
+    "clientKind": "git",
+    "useIgnoreFile": false
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!**/node_modules",
+      "!**/doc_build",
+      "!**/dist",
+      "!**/public/repro",
+      "!**/public/api/recipes.json",
+      "!**/public/api/projects.json",
+      "!**/public/api/recipes.schema.json",
+      "!**/public/spec",
+      "!**/bun.lock"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80,
+    "lineEnding": "lf"
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "jsxQuoteStyle": "double",
+      "trailingCommas": "all",
+      "semicolons": "always",
+      "arrowParentheses": "always",
+      "bracketSpacing": true
+    }
+  },
+  "json": {
+    "formatter": {
+      "trailingCommas": "none"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "style": {
+        "noParameterAssign": "error",
+        "useAsConstAssertion": "error",
+        "useDefaultParameterLast": "error",
+        "useEnumInitializers": "error",
+        "useSelfClosingElements": "error",
+        "useSingleVarDeclarator": "error",
+        "noUnusedTemplateLiteral": "error",
+        "useNumberNamespace": "error",
+        "noInferrableTypes": "error",
+        "noUselessElse": "error",
+        "noNonNullAssertion": "off",
+        "noDescendingSpecificity": "off"
+      },
+      "suspicious": {
+        "noArrayIndexKey": "off"
+      },
+      "correctness": {
+        "useExhaustiveDependencies": "warn"
+      }
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -4,13 +4,35 @@
   "workspaces": {
     "": {
       "name": "@aletheia-works/vivarium-docs",
+      "dependencies": {
+        "lucide-react": "^1.14.0",
+      },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.14",
         "@rspress/core": "^2.0.9",
         "jszip": "^3.10.1",
       },
     },
   },
   "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.4.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.14", "@biomejs/cli-darwin-x64": "2.4.14", "@biomejs/cli-linux-arm64": "2.4.14", "@biomejs/cli-linux-arm64-musl": "2.4.14", "@biomejs/cli-linux-x64": "2.4.14", "@biomejs/cli-linux-x64-musl": "2.4.14", "@biomejs/cli-win32-arm64": "2.4.14", "@biomejs/cli-win32-x64": "2.4.14" }, "bin": { "biome": "bin/biome" } }, "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.14", "", { "os": "linux", "cpu": "x64" }, "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.14", "", { "os": "linux", "cpu": "x64" }, "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.14", "", { "os": "win32", "cpu": "x64" }, "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA=="],
+
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -228,6 +250,8 @@
     "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "lucide-react": ["lucide-react@1.14.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA=="],
 
     "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
 

--- a/docs/components/ErrorRecipeMatcher.tsx
+++ b/docs/components/ErrorRecipeMatcher.tsx
@@ -55,26 +55,90 @@ const MAX_INPUT_BYTES = 16 * 1024;
  * anyway, not full lexical coverage of any one language. */
 const STOPWORDS = new Set([
   // English
-  'the', 'and', 'for', 'with', 'from', 'that', 'this', 'have',
-  'has', 'are', 'was', 'were', 'will', 'not', 'but', 'all',
-  'error', 'errors', 'exception', 'failed', 'failure', 'trace',
-  'traceback', 'stack', 'line', 'file', 'most', 'recent', 'call',
+  'the',
+  'and',
+  'for',
+  'with',
+  'from',
+  'that',
+  'this',
+  'have',
+  'has',
+  'are',
+  'was',
+  'were',
+  'will',
+  'not',
+  'but',
+  'all',
+  'error',
+  'errors',
+  'exception',
+  'failed',
+  'failure',
+  'trace',
+  'traceback',
+  'stack',
+  'line',
+  'file',
+  'most',
+  'recent',
+  'call',
   // Japanese
-  'です', 'ます', 'した', 'する', 'これ', 'それ', 'その', 'この',
-  'エラー', '例外', '失敗', 'スタック',
+  'です',
+  'ます',
+  'した',
+  'する',
+  'これ',
+  'それ',
+  'その',
+  'この',
+  'エラー',
+  '例外',
+  '失敗',
+  'スタック',
   // German
-  'der', 'die', 'das', 'und', 'mit', 'von', 'für', 'fehler',
-  'ausnahme', 'aufgetreten',
+  'der',
+  'die',
+  'das',
+  'und',
+  'mit',
+  'von',
+  'für',
+  'fehler',
+  'ausnahme',
+  'aufgetreten',
   // Spanish
-  'que', 'por', 'una', 'los', 'las', 'del', 'con',
-  'excepción', 'fallo',
+  'que',
+  'por',
+  'una',
+  'los',
+  'las',
+  'del',
+  'con',
+  'excepción',
+  'fallo',
   // French
-  'pour', 'avec', 'sur', 'dans', 'erreur',
+  'pour',
+  'avec',
+  'sur',
+  'dans',
+  'erreur',
   'échec',
   // Chinese (Simplified + Traditional)
-  '错误', '异常', '失败', '堆栈', '錯誤', '異常', '失敗', '堆疊',
+  '错误',
+  '异常',
+  '失败',
+  '堆栈',
+  '錯誤',
+  '異常',
+  '失敗',
+  '堆疊',
   // Korean
-  '오류', '예외', '실패', '스택',
+  '오류',
+  '예외',
+  '실패',
+  '스택',
 ]);
 
 /* Synonym groups (Phase 7 A5). Within a group, any token in the
@@ -98,7 +162,10 @@ const SYNONYM_MAP: ReadonlyMap<string, ReadonlyArray<string>> = (() => {
   const m = new Map<string, ReadonlyArray<string>>();
   for (const group of SYNONYM_GROUPS) {
     for (const member of group) {
-      m.set(member, group.filter((g) => g !== member));
+      m.set(
+        member,
+        group.filter((g) => g !== member),
+      );
     }
   }
   return m;
@@ -334,8 +401,7 @@ const STRINGS: Record<Lang, Strings> = {
     clear: 'クリア',
     tokenisedAs: 'トークン化:',
     resultsHeading: '// ランク付き候補',
-    resultsCount: (n, total) =>
-      `${n} 件 (全 ${total} レシピ中)`,
+    resultsCount: (n, total) => `${n} 件 (全 ${total} レシピ中)`,
     emptyHeading: 'このトークンに該当するレシピがない。',
     emptyBody: (galleryHref) => (
       <>
@@ -351,11 +417,7 @@ const STRINGS: Record<Lang, Strings> = {
     open: '開く ↗',
     galleryLink: './',
     layerName: (layer) =>
-      layer === 1
-        ? 'L1 · WASM'
-        : layer === 2
-          ? 'L2 · Docker'
-          : 'L3 · 記録再生',
+      layer === 1 ? 'L1 · WASM' : layer === 2 ? 'L2 · Docker' : 'L3 · 記録再生',
   },
 };
 
@@ -378,9 +440,7 @@ function MatchCard({ lang, score }: { lang: Lang; score: Score }) {
   return (
     <article className="v-rg__card v-erm__card">
       <header className="v-rg__card-head">
-        <span
-          className={`v-rg__layer-pill v-rg__layer-pill--${layerAccent}`}
-        >
+        <span className={`v-rg__layer-pill v-rg__layer-pill--${layerAccent}`}>
           {s.layerName(r.layer)}
         </span>
         <span className="v-erm__score">
@@ -396,19 +456,21 @@ function MatchCard({ lang, score }: { lang: Lang; score: Score }) {
       <div className="v-erm__matched">
         <span className="v-erm__matched-key">{s.matchedTokensLabel}:</span>
         {displayTokens.map((m, i) => {
-          const viaMark = m.via === 'fuzzy' ? '~' : m.via === 'synonym' ? '≡' : null;
-          const title = m.via && m.input
-            ? `${m.via} match (input: ${m.input})`
-            : undefined;
+          const viaMark =
+            m.via === 'fuzzy' ? '~' : m.via === 'synonym' ? '≡' : null;
+          const title =
+            m.via && m.input ? `${m.via} match (input: ${m.input})` : undefined;
           return (
             <span
               key={i}
-              className={`v-erm__token v-erm__token--${m.source}${m.via ? ' v-erm__token--' + m.via : ''}`}
+              className={`v-erm__token v-erm__token--${m.source}${m.via ? ` v-erm__token--${m.via}` : ''}`}
               title={title}
             >
               <span className="v-erm__token-source">{m.source[0]}</span>
               {m.token}
-              {viaMark ? <span className="v-erm__token-via">{viaMark}</span> : null}
+              {viaMark ? (
+                <span className="v-erm__token-via">{viaMark}</span>
+              ) : null}
             </span>
           );
         })}
@@ -446,7 +508,8 @@ export function ErrorRecipeMatcher({ lang }: { lang: Lang }) {
       .filter((s) => s.score > 0);
     scored.sort((a, b) => {
       if (b.score !== a.score) return b.score - a.score;
-      if (a.recipe.layer !== b.recipe.layer) return a.recipe.layer - b.recipe.layer;
+      if (a.recipe.layer !== b.recipe.layer)
+        return a.recipe.layer - b.recipe.layer;
       return a.recipe.slug.localeCompare(b.recipe.slug);
     });
     return scored;

--- a/docs/components/ManifestScaffolder.tsx
+++ b/docs/components/ManifestScaffolder.tsx
@@ -50,7 +50,7 @@ function validate(state: FormState): FieldErrors {
   const errors: FieldErrors = {};
   if (!state.slug) errors.slug = 'required';
   else if (!SLUG_RE.test(state.slug))
-    errors.slug = "must match /^[a-z0-9]+(-[a-z0-9]+)*$/";
+    errors.slug = 'must match /^[a-z0-9]+(-[a-z0-9]+)*$/';
   if (state.layer == null) errors.layer = 'required';
   if (!state.bug.project) errors['bug.project'] = 'required';
   if (state.bug.issue !== '' && !/^\d+$/.test(state.bug.issue))
@@ -74,7 +74,10 @@ function validate(state: FormState): FieldErrors {
 /* ----------------------------- TOML emission ----------------------------- */
 
 function escapeTomlBasic(value: string): string {
-  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\t/g, '\\t');
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\t/g, '\\t');
 }
 
 function emitTomlString(value: string): string {
@@ -100,7 +103,7 @@ function buildToml(state: FormState): string {
     lines.push(`description = ${emitTomlString(state.description)}`);
   }
   lines.push('');
-  lines.push(`[bug]`);
+  lines.push('[bug]');
   lines.push(`project = ${emitTomlString(state.bug.project)}`);
   const issue = state.bug.issue || '0';
   lines.push(`issue = ${issue}`);
@@ -108,7 +111,7 @@ function buildToml(state: FormState): string {
 
   if (state.layer === 1) {
     lines.push('');
-    lines.push(`[layer1]`);
+    lines.push('[layer1]');
     lines.push(`page_url = ${emitTomlString(state.layer1.page_url)}`);
     if (state.layer1.expected_verdict) {
       lines.push(
@@ -117,7 +120,7 @@ function buildToml(state: FormState): string {
     }
   } else if (state.layer === 2) {
     lines.push('');
-    lines.push(`[layer2]`);
+    lines.push('[layer2]');
     lines.push(`image = ${emitTomlString(state.layer2.image)}`);
     if (state.layer2.dockerfile) {
       lines.push(`dockerfile = ${emitTomlString(state.layer2.dockerfile)}`);
@@ -129,7 +132,7 @@ function buildToml(state: FormState): string {
     }
   } else if (state.layer === 3) {
     lines.push('');
-    lines.push(`[layer3]`);
+    lines.push('[layer3]');
     lines.push(`image = ${emitTomlString(state.layer3.image)}`);
     if (state.layer3.dockerfile) {
       lines.push(`dockerfile = ${emitTomlString(state.layer3.dockerfile)}`);
@@ -141,7 +144,7 @@ function buildToml(state: FormState): string {
     }
   }
 
-  return lines.join('\n') + '\n';
+  return `${lines.join('\n')}\n`;
 }
 
 /* --------------------------------- i18n ---------------------------------- */
@@ -210,7 +213,7 @@ const STRINGS: Record<Lang, Strings> = {
       'Long-form description. Markdown allowed; consumers may render it or display verbatim.',
     layerLabel: 'layer',
     layerHelp:
-      '1 = WASM in-browser, 2 = Docker, 3 = record-replay. Selecting a layer reveals that layer\'s required fields below.',
+      "1 = WASM in-browser, 2 = Docker, 3 = record-replay. Selecting a layer reveals that layer's required fields below.",
     layerOption: (n) =>
       n === 1 ? '1 · WASM' : n === 2 ? '2 · Docker' : '3 · record-replay',
     bugProjectLabel: 'bug.project',
@@ -287,7 +290,8 @@ const STRINGS: Record<Lang, Strings> = {
     copy: 'コピー',
     download: 'manifest.toml をダウンロード',
     reset: 'リセット',
-    noLayerYet: 'レイヤーを選ぶと、そのレイヤーに必要なフィールドが表示される。',
+    noLayerYet:
+      'レイヤーを選ぶと、そのレイヤーに必要なフィールドが表示される。',
     required: '必須',
     copied: 'コピー済 ✓',
     emptyOutput:
@@ -325,7 +329,8 @@ function Field({
   requiredText: string;
 }) {
   return (
-    <label className={'v-mfs__field' + (error ? ' v-mfs__field--err' : '')}>
+    // biome-ignore lint/a11y/noLabelWithoutControl: input is rendered via {children} at every call site (input/select/textarea), Biome cannot statically verify
+    <label className={`v-mfs__field${error ? ' v-mfs__field--err' : ''}`}>
       <span className="v-mfs__label">
         <span className="v-mfs__label-name">{label}</span>
         {required ? (
@@ -469,10 +474,7 @@ export function ManifestScaffolder({ lang }: { lang: Lang }) {
               <button
                 key={n}
                 type="button"
-                className={
-                  'v-mfs__chip' +
-                  (state.layer === n ? ' v-mfs__chip--on' : '')
-                }
+                className={`v-mfs__chip${state.layer === n ? ' v-mfs__chip--on' : ''}`}
                 onClick={() => update('layer', state.layer === n ? null : n)}
                 aria-pressed={state.layer === n}
               >
@@ -551,7 +553,9 @@ export function ManifestScaffolder({ lang }: { lang: Lang }) {
                 type="url"
                 className="v-mfs__input"
                 value={state.layer1.page_url}
-                onChange={(e) => updateLayer('layer1', 'page_url', e.target.value)}
+                onChange={(e) =>
+                  updateLayer('layer1', 'page_url', e.target.value)
+                }
                 placeholder="https://example.org/repro/"
               />
             </Field>
@@ -598,7 +602,9 @@ export function ManifestScaffolder({ lang }: { lang: Lang }) {
                 type="text"
                 className="v-mfs__input"
                 value={state.layer2.dockerfile}
-                onChange={(e) => updateLayer('layer2', 'dockerfile', e.target.value)}
+                onChange={(e) =>
+                  updateLayer('layer2', 'dockerfile', e.target.value)
+                }
                 placeholder="./Dockerfile"
               />
             </Field>
@@ -645,7 +651,9 @@ export function ManifestScaffolder({ lang }: { lang: Lang }) {
                 type="text"
                 className="v-mfs__input"
                 value={state.layer3.dockerfile}
-                onChange={(e) => updateLayer('layer3', 'dockerfile', e.target.value)}
+                onChange={(e) =>
+                  updateLayer('layer3', 'dockerfile', e.target.value)
+                }
                 placeholder="./Dockerfile"
               />
             </Field>

--- a/docs/components/PageChrome.tsx
+++ b/docs/components/PageChrome.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from 'react';
+import { type ReactNode, useEffect } from 'react';
 import './page-chrome.css';
 
 /* ----------------------------- PageHero ----------------------------- */
@@ -81,7 +81,9 @@ export function KpiStrip({
     <div className="v-kpi-strip">
       {items.map((item, i) => (
         <div key={i}>
-          <div className={`v-kpi__value v-kpi__value--${item.accent ?? 'teal'}`}>
+          <div
+            className={`v-kpi__value v-kpi__value--${item.accent ?? 'teal'}`}
+          >
             {item.value}
           </div>
           <div className="v-kpi__label">{item.label}</div>
@@ -203,11 +205,17 @@ export function NextCta({
         <h2 className="v-next-cta__heading">{heading}</h2>
         <p className="v-next-cta__sub">{sub}</p>
         <div className="v-next-cta__buttons">
-          <a className="v-next-cta__btn v-next-cta__btn--primary" href={primary.href}>
+          <a
+            className="v-next-cta__btn v-next-cta__btn--primary"
+            href={primary.href}
+          >
             {primary.label}
           </a>
           {ghost ? (
-            <a className="v-next-cta__btn v-next-cta__btn--ghost" href={ghost.href}>
+            <a
+              className="v-next-cta__btn v-next-cta__btn--ghost"
+              href={ghost.href}
+            >
               {ghost.label}
             </a>
           ) : null}
@@ -219,20 +227,9 @@ export function NextCta({
 
 /* ----------------------------- BottomNote ----------------------------- */
 
-export function BottomNote({
-  text,
-  href,
-}: {
-  text: string;
-  href: string;
-}) {
+export function BottomNote({ text, href }: { text: string; href: string }) {
   return (
-    <a
-      className="v-bottom-note"
-      href={href}
-      target="_blank"
-      rel="noreferrer"
-    >
+    <a className="v-bottom-note" href={href} target="_blank" rel="noreferrer">
       {text}
     </a>
   );

--- a/docs/components/ProjectPage.tsx
+++ b/docs/components/ProjectPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import './project-page.css';
-import recipesIndex from '../public/api/recipes.json';
 import projectsIndex from '../public/api/projects.json';
+import recipesIndex from '../public/api/recipes.json';
 
 /* ============================================================================
  * Project landing page.
@@ -118,11 +118,7 @@ const STRINGS: Record<Lang, Strings> = {
     homepage: 'ホームページ ↗',
     upstream: 'アップストリーム ↗',
     layerName: (layer) =>
-      layer === 1
-        ? 'L1 · WASM'
-        : layer === 2
-          ? 'L2 · Docker'
-          : 'L3 · 記録再生',
+      layer === 1 ? 'L1 · WASM' : layer === 2 ? 'L2 · Docker' : 'L3 · 記録再生',
     issueLabel: 'Issue',
     titleLabel: 'タイトル',
     layerLabel: 'レイヤー',
@@ -140,13 +136,7 @@ function LayerPill({ lang, layer }: { lang: Lang; layer: 1 | 2 | 3 }) {
   );
 }
 
-function IssueLabel({
-  lang,
-  recipe,
-}: {
-  lang: Lang;
-  recipe: RecipeEntry;
-}) {
+function IssueLabel({ lang, recipe }: { lang: Lang; recipe: RecipeEntry }) {
   if (recipe.issue > 0) {
     return <code>#{recipe.issue}</code>;
   }
@@ -187,7 +177,8 @@ export function ProjectPage({
   }
 
   const displayName = meta?.display_name ?? project;
-  const layers = meta?.layers ?? Array.from(new Set(recipes.map((r) => r.layer))).sort();
+  const layers =
+    meta?.layers ?? Array.from(new Set(recipes.map((r) => r.layer))).sort();
 
   return (
     <section className="v-pp">

--- a/docs/components/RecipeGallery.tsx
+++ b/docs/components/RecipeGallery.tsx
@@ -94,18 +94,17 @@ const STRINGS: Record<Lang, Strings> = {
     open: '開く ↗',
     source: 'ソース',
     layerName: (layer) =>
-      layer === 1
-        ? 'L1 · WASM'
-        : layer === 2
-          ? 'L2 · Docker'
-          : 'L3 · 記録再生',
+      layer === 1 ? 'L1 · WASM' : layer === 2 ? 'L2 · Docker' : 'L3 · 記録再生',
     unknownLanguage: '未指定',
   },
 };
 
 /* ----------------------------- Helpers --------------------------------- */
 
-function uniqueValues<T>(items: RecipeEntry[], pick: (r: RecipeEntry) => T | undefined): T[] {
+function uniqueValues<T>(
+  items: RecipeEntry[],
+  pick: (r: RecipeEntry) => T | undefined,
+): T[] {
   const seen = new Set<T>();
   for (const item of items) {
     const v = pick(item);
@@ -120,7 +119,7 @@ function matchesQuery(recipe: RecipeEntry, query: string): boolean {
   if (recipe.slug.toLowerCase().includes(q)) return true;
   if (recipe.project.toLowerCase().includes(q)) return true;
   if (recipe.title.toLowerCase().includes(q)) return true;
-  if (recipe.symptom && recipe.symptom.toLowerCase().includes(q)) return true;
+  if (recipe.symptom?.toLowerCase().includes(q)) return true;
   for (const tag of recipe.tags) {
     if (tag.toLowerCase().includes(q)) return true;
   }
@@ -189,22 +188,14 @@ function FacetGroup({
   );
 }
 
-function RecipeCard({
-  lang,
-  recipe,
-}: {
-  lang: Lang;
-  recipe: RecipeEntry;
-}) {
+function RecipeCard({ lang, recipe }: { lang: Lang; recipe: RecipeEntry }) {
   const s = STRINGS[lang];
   const layerAccent =
     recipe.layer === 1 ? 'teal' : recipe.layer === 2 ? 'violet' : 'coral';
   return (
     <article className="v-rg__card">
       <header className="v-rg__card-head">
-        <span
-          className={`v-rg__layer-pill v-rg__layer-pill--${layerAccent}`}
-        >
+        <span className={`v-rg__layer-pill v-rg__layer-pill--${layerAccent}`}>
           {s.layerName(recipe.layer)}
         </span>
         <code className="v-rg__slug">{recipe.slug}</code>
@@ -276,16 +267,13 @@ export function RecipeGallery({ lang }: { lang: Lang }) {
 
   const allLayers = useMemo<(1 | 2 | 3)[]>(
     () => uniqueValues(all, (r) => r.layer).map((n) => n as 1 | 2 | 3),
-    [all],
+    [],
   );
   const allLanguages = useMemo(
     () => uniqueValues(all, (r) => r.language || undefined),
-    [all],
+    [],
   );
-  const allSeverities = useMemo(
-    () => uniqueValues(all, (r) => r.severity),
-    [all],
-  );
+  const allSeverities = useMemo(() => uniqueValues(all, (r) => r.severity), []);
 
   const toggleSet = <T,>(set: Set<T>, v: T): Set<T> => {
     const next = new Set(set);
@@ -299,10 +287,11 @@ export function RecipeGallery({ lang }: { lang: Lang }) {
       if (!matchesQuery(r, query)) return false;
       if (layers.size > 0 && !layers.has(r.layer)) return false;
       if (languages.size > 0 && !languages.has(r.language)) return false;
-      if (severities.size > 0 && (!r.severity || !severities.has(r.severity))) return false;
+      if (severities.size > 0 && (!r.severity || !severities.has(r.severity)))
+        return false;
       return true;
     });
-  }, [all, query, layers, languages, severities]);
+  }, [query, layers, languages, severities]);
 
   const hasFilters =
     query.length > 0 ||
@@ -361,11 +350,7 @@ export function RecipeGallery({ lang }: { lang: Lang }) {
           {s.resultsTemplate(filtered.length, all.length)}
         </span>
         {hasFilters ? (
-          <button
-            type="button"
-            className="v-rg__clear"
-            onClick={clearAll}
-          >
+          <button type="button" className="v-rg__clear" onClick={clearAll}>
             {s.clearFilters}
           </button>
         ) : null}

--- a/docs/components/ReproCompare.tsx
+++ b/docs/components/ReproCompare.tsx
@@ -75,7 +75,7 @@ function validateVerdict(raw: unknown): ValidationResult {
         ok: false,
         error: {
           path: `/${field}`,
-          message: `required field missing`,
+          message: 'required field missing',
         },
       };
     }
@@ -117,7 +117,12 @@ function validateVerdict(raw: unknown): ValidationResult {
       },
     };
   }
-  for (const field of ['image_digest', 'captured_at', 'stdout', 'stderr_tail'] as const) {
+  for (const field of [
+    'image_digest',
+    'captured_at',
+    'stdout',
+    'stderr_tail',
+  ] as const) {
     if (typeof obj[field] !== 'string') {
       return {
         ok: false,
@@ -224,8 +229,10 @@ const STRINGS: Record<Lang, Strings> = {
     slugHelp:
       'When set, the original side is fetched from the deployed gallery snapshot.',
     expectedLabel: 'Expected branch-fix verdict',
-    expectedFailDesc: 'unreproduced — bug does NOT reproduce on the fix (typical "fix works")',
-    expectedPassDesc: 'reproduced — bug still reproduces on the fix (regression check)',
+    expectedFailDesc:
+      'unreproduced — bug does NOT reproduce on the fix (typical "fix works")',
+    expectedPassDesc:
+      'reproduced — bug still reproduces on the fix (regression check)',
     loading: 'Loading…',
     fetchOriginal: 'Fetch deployed original',
     refetchOriginal: 'Re-fetch deployed original',
@@ -288,8 +295,10 @@ const STRINGS: Record<Lang, Strings> = {
     slugHelp:
       '指定するとオリジナル側はデプロイ済みギャラリースナップショットから取得される。',
     expectedLabel: '期待する branch-fix の verdict',
-    expectedFailDesc: 'unreproduced — 修正によりバグが再現しなくなる (典型的な「修正成立」)',
-    expectedPassDesc: 'reproduced — 修正後もバグが再現する (リグレッション確認)',
+    expectedFailDesc:
+      'unreproduced — 修正によりバグが再現しなくなる (典型的な「修正成立」)',
+    expectedPassDesc:
+      'reproduced — 修正後もバグが再現する (リグレッション確認)',
     loading: '読み込み中…',
     fetchOriginal: 'デプロイ済みオリジナルを取得',
     refetchOriginal: 'デプロイ済みオリジナルを再取得',
@@ -313,7 +322,8 @@ const STRINGS: Record<Lang, Strings> = {
     evidenceEmpty: '(空)',
     errorTitle: 'バリデーションエラー',
     errorAt: (path) => `${path} の位置で`,
-    fetchFailed: (url) => `${url} を取得できなかった。ペースト経由にフォールバック。`,
+    fetchFailed: (url) =>
+      `${url} を取得できなかった。ペースト経由にフォールバック。`,
     parseFailed: 'JSON のパースに失敗した。ペースト経由にフォールバック。',
     zipMissingFiles:
       'ドロップされた zip に branch-fix-verdict.json も original-verdict.json も含まれていなかった。',
@@ -494,7 +504,9 @@ export function VerdictCompareLayout({
   const verdictsDiverge =
     original != null && branch != null && original.verdict !== branch.verdict;
   const exitsDiverge =
-    original != null && branch != null && original.exit_code !== branch.exit_code;
+    original != null &&
+    branch != null &&
+    original.exit_code !== branch.exit_code;
 
   const matchClassName =
     branchMatchesExpected == null
@@ -553,14 +565,18 @@ function resolvePagesBase(): string {
   }
   const { origin, pathname } = window.location;
   const idx = pathname.indexOf('/repro');
-  return idx >= 0 ? `${origin}${pathname.slice(0, idx)}/repro` : `${origin}/repro`;
+  return idx >= 0
+    ? `${origin}${pathname.slice(0, idx)}/repro`
+    : `${origin}/repro`;
 }
 
 const PAGES_BASE = resolvePagesBase();
 
-async function readZipEntries(
-  file: File,
-): Promise<{ branch: VerdictV1 | null; original: VerdictV1 | null; rawErrors: ValidationError[] }> {
+async function readZipEntries(file: File): Promise<{
+  branch: VerdictV1 | null;
+  original: VerdictV1 | null;
+  rawErrors: ValidationError[];
+}> {
   // Lazy-load JSZip — only paid for when the user actually drops a zip.
   const JSZip = (await import('jszip')).default;
   const zip = await JSZip.loadAsync(file);
@@ -580,7 +596,11 @@ async function readZipEntries(
       if (parsed.ok) {
         const v = validateVerdict(parsed.data);
         if (v.ok) branch = v.data;
-        else rawErrors.push({ path: `branch:${v.error.path}`, message: v.error.message });
+        else
+          rawErrors.push({
+            path: `branch:${v.error.path}`,
+            message: v.error.message,
+          });
       } else {
         rawErrors.push({ path: 'branch:/', message: parsed.error });
       }
@@ -590,7 +610,11 @@ async function readZipEntries(
       if (parsed.ok) {
         const v = validateVerdict(parsed.data);
         if (v.ok) original = v.data;
-        else rawErrors.push({ path: `original:${v.error.path}`, message: v.error.message });
+        else
+          rawErrors.push({
+            path: `original:${v.error.path}`,
+            message: v.error.message,
+          });
       } else {
         rawErrors.push({ path: 'original:/', message: parsed.error });
       }
@@ -599,15 +623,22 @@ async function readZipEntries(
   return { branch, original, rawErrors };
 }
 
-function parseJsonSafe(text: string): { ok: true; data: unknown } | { ok: false; error: string } {
+function parseJsonSafe(
+  text: string,
+): { ok: true; data: unknown } | { ok: false; error: string } {
   try {
     return { ok: true, data: JSON.parse(text) };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
   }
 }
 
-async function fetchVerdictFromUrl(url: string): Promise<ValidationResult & { httpStatus?: number; networkError?: string }> {
+async function fetchVerdictFromUrl(
+  url: string,
+): Promise<ValidationResult & { httpStatus?: number; networkError?: string }> {
   let res: Response;
   try {
     res = await fetch(url, { mode: 'cors', credentials: 'omit' });
@@ -729,7 +760,7 @@ export function ReproCompareApp({ lang }: ReproCompareProps) {
     }
     // s only used for messages above; deps frozen at mount.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [s.fetchFailed]);
 
   /* ----- File handling ----- */
 
@@ -739,11 +770,19 @@ export function ReproCompareApp({ lang }: ReproCompareProps) {
       const newErrors: SideError[] = [];
       try {
         if (file.name.toLowerCase().endsWith('.zip')) {
-          const { branch: b, original: o, rawErrors } = await readZipEntries(file);
+          const {
+            branch: b,
+            original: o,
+            rawErrors,
+          } = await readZipEntries(file);
           if (b) setBranch(b);
           if (o) setOriginal(o);
           if (b == null && o == null && rawErrors.length === 0) {
-            newErrors.push({ side: 'branch', path: '/', message: s.zipMissingFiles });
+            newErrors.push({
+              side: 'branch',
+              path: '/',
+              message: s.zipMissingFiles,
+            });
           }
           for (const e of rawErrors) {
             const [sidePart, ...pathParts] = e.path.split(':');
@@ -757,7 +796,11 @@ export function ReproCompareApp({ lang }: ReproCompareProps) {
           const text = await file.text();
           const parsed = parseJsonSafe(text);
           if (!parsed.ok) {
-            newErrors.push({ side: 'branch', path: '/', message: parsed.error });
+            newErrors.push({
+              side: 'branch',
+              path: '/',
+              message: parsed.error,
+            });
           } else {
             const v = validateVerdict(parsed.data);
             if (!v.ok) {
@@ -894,7 +937,11 @@ export function ReproCompareApp({ lang }: ReproCompareProps) {
               className="v-rc__field-input"
               value={expected}
               onChange={(e) =>
-                setExpected(e.target.value === 'reproduced' ? 'reproduced' : 'unreproduced')
+                setExpected(
+                  e.target.value === 'reproduced'
+                    ? 'reproduced'
+                    : 'unreproduced',
+                )
               }
             >
               <option value="unreproduced">{s.expectedFailDesc}</option>
@@ -903,6 +950,9 @@ export function ReproCompareApp({ lang }: ReproCompareProps) {
           </label>
         </div>
 
+        {/* biome-ignore lint/a11y/useSemanticElements: drop targets need to
+            be <div> to receive ondrop/ondragover; the role="button" + keyboard
+            handler keeps the click-to-pick interaction accessible. */}
         <div
           ref={dropRef}
           className="v-rc__drop"
@@ -942,11 +992,7 @@ export function ReproCompareApp({ lang }: ReproCompareProps) {
             onClick={fetchOriginalFromSlug}
             disabled={!slug || busy}
           >
-            {busy
-              ? s.loading
-              : original
-                ? s.refetchOriginal
-                : s.fetchOriginal}
+            {busy ? s.loading : original ? s.refetchOriginal : s.fetchOriginal}
           </button>
           <button
             type="button"

--- a/docs/components/VivariumFooter.tsx
+++ b/docs/components/VivariumFooter.tsx
@@ -7,20 +7,16 @@ const STRINGS = {
     legal:
       '© 2026 aletheia-works · Open Source under Apache 2.0 · Built for the modern web.',
     github: 'GitHub',
-    discord: 'Discord',
     changelog: 'Changelog',
     security: 'Security',
-    privacy: 'Privacy',
     changelogHref: '/vivarium/roadmap',
   },
   ja: {
     legal:
       '© 2026 aletheia-works · Apache 2.0 のもとでオープンソース · モダンウェブのために。',
     github: 'GitHub',
-    discord: 'Discord',
     changelog: '変更履歴',
     security: 'セキュリティ',
-    privacy: 'プライバシー',
     changelogHref: '/vivarium/ja/roadmap',
   },
 } as const;
@@ -43,9 +39,6 @@ export function VivariumFooter({ lang = 'en' }: { lang?: Lang } = {}) {
           >
             {s.github}
           </a>
-          <a className="v-footer__link" href="#">
-            {s.discord}
-          </a>
           <a className="v-footer__link" href={s.changelogHref}>
             {s.changelog}
           </a>
@@ -56,9 +49,6 @@ export function VivariumFooter({ lang = 'en' }: { lang?: Lang } = {}) {
             rel="noreferrer"
           >
             {s.security}
-          </a>
-          <a className="v-footer__link" href="#">
-            {s.privacy}
           </a>
         </div>
       </div>

--- a/docs/components/VivariumHero.tsx
+++ b/docs/components/VivariumHero.tsx
@@ -1,3 +1,4 @@
+import { ArrowRight, Lock } from 'lucide-react';
 import { useState } from 'react';
 import './vivarium-hero.css';
 
@@ -9,14 +10,12 @@ const STRINGS = {
   en: {
     kicker: '// CONTRACT v1 · OPEN SOURCE · APACHE-2.0',
     headline: ['Reproduce any bug.', 'Any language.', 'Any environment.'],
-    lede:
-      'Vivarium is a three-layer reproduction substrate. WebAssembly for milliseconds, Docker for fidelity, and a third layer for everything else. Problem first, technology second.',
+    lede: 'Vivarium is a three-layer reproduction substrate. WebAssembly for milliseconds, Docker for fidelity, and a third layer for everything else. Problem first, technology second.',
     ctaPrimary: 'Read the overview',
     ctaGhost: 'View on GitHub',
     visionHref: '/vivarium/overview',
     sectionAria: 'Vivarium hero',
     tabsAria: 'Reproduction examples',
-    activeAria: (label: string) => `${label} reproduction (active)`,
     bringFrontAria: (label: string) =>
       `Bring ${label} reproduction to the front`,
     tabs: {
@@ -35,8 +34,7 @@ const STRINGS = {
     postgres: {
       eyebrow: 'VIVARIUM · LAYER 2 · DOCKER · POSTGRESQL',
       title: 'Reproducing PostgreSQL lost-update under READ COMMITTED',
-      lede:
-        'Concurrent UPDATEs lose writes when a SELECT-then-UPDATE pattern omits row-level locks.',
+      lede: 'Concurrent UPDATEs lose writes when a SELECT-then-UPDATE pattern omits row-level locks.',
       verdictText: 'RUNNING — tx-1 ⨯ tx-2',
       tabRunning: 'running',
       pulling: '[docker] Pulling postgres:15-alpine',
@@ -46,25 +44,23 @@ const STRINGS = {
     ruby: {
       eyebrow: 'VIVARIUM · LAYER 1 · RUBY.WASM · UNICODE',
       title: 'Reproducing ruby/ruby#21709',
-      lede:
-        'String#unicode_normalize edge case for combining diacritics in NFD form.',
+      lede: 'String#unicode_normalize edge case for combining diacritics in NFD form.',
       verdictText: '✓ REPRODUCED — bug reproduced',
       tabVerified: 'verified',
       okLine: 'round-trip lost (RuntimeError raised as expected)',
-      verdictTrace: 'verdict: REPRODUCED — issue#21709 reproducible in ruby.wasm',
+      verdictTrace:
+        'verdict: REPRODUCED — issue#21709 reproducible in ruby.wasm',
     },
   },
   ja: {
     kicker: '// CONTRACT v1 · オープンソース · APACHE-2.0',
     headline: ['あらゆるバグを再現。', 'あらゆる言語で。', 'あらゆる環境で。'],
-    lede:
-      'Vivarium は三層の再現基盤。ミリ秒単位の WebAssembly、忠実度の Docker、そしてそれ以外すべてのための第三のレイヤー。問題が先、技術は後。',
+    lede: 'Vivarium は三層の再現基盤。ミリ秒単位の WebAssembly、忠実度の Docker、そしてそれ以外すべてのための第三のレイヤー。問題が先、技術は後。',
     ctaPrimary: '概要を読む',
     ctaGhost: 'GitHub で見る',
     visionHref: '/vivarium/ja/overview',
     sectionAria: 'Vivarium ヒーロー',
     tabsAria: '再現サンプル',
-    activeAria: (label: string) => `${label} 再現（アクティブ）`,
     bringFrontAria: (label: string) => `${label} 再現を前面に表示`,
     tabs: {
       cpython: { label: 'Python', sublabel: 'L1 · WASM' },
@@ -74,8 +70,7 @@ const STRINGS = {
     cpython: {
       eyebrow: 'VIVARIUM · LAYER 1 · PYODIDE · SQLITE3',
       title: 'python/cpython#137205 を再現',
-      lede:
-        'PRAGMA foreign_keys が autocommit=False 下でサイレントに無視される。',
+      lede: 'PRAGMA foreign_keys が autocommit=False 下でサイレントに無視される。',
       verdictText: 'fk_off ≠ fk_on',
       verdictPrefix: '✕ UNREPRODUCED',
       tabError: 'エラー 1 件',
@@ -83,8 +78,7 @@ const STRINGS = {
     postgres: {
       eyebrow: 'VIVARIUM · LAYER 2 · DOCKER · POSTGRESQL',
       title: 'READ COMMITTED 下での PostgreSQL lost-update を再現',
-      lede:
-        '並行 UPDATE が、SELECT 後に UPDATE するパターンで行ロックを省略すると書き込みを失う。',
+      lede: '並行 UPDATE が、SELECT 後に UPDATE するパターンで行ロックを省略すると書き込みを失う。',
       verdictText: '実行中 — tx-1 ⨯ tx-2',
       tabRunning: '実行中',
       pulling: '[docker] postgres:15-alpine をプル中',
@@ -94,50 +88,20 @@ const STRINGS = {
     ruby: {
       eyebrow: 'VIVARIUM · LAYER 1 · RUBY.WASM · UNICODE',
       title: 'ruby/ruby#21709 を再現',
-      lede:
-        'NFD 形式の結合ダイアクリティカル記号における String#unicode_normalize のエッジケース。',
+      lede: 'NFD 形式の結合ダイアクリティカル記号における String#unicode_normalize のエッジケース。',
       verdictText: '✓ REPRODUCED — バグ再現',
       tabVerified: '検証済み',
       okLine: 'round-trip lost (RuntimeError を期待通り raise)',
-      verdictTrace:
-        'verdict: REPRODUCED — issue#21709 が ruby.wasm で再現可能',
+      verdictTrace: 'verdict: REPRODUCED — issue#21709 が ruby.wasm で再現可能',
     },
   },
 } as const;
 
 /* ------------------------------- Icons ------------------------------- */
 
-const ArrowRight = () => (
-  <svg
-    className="v-hero__cta-arrow"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <line x1="5" y1="12" x2="19" y2="12" />
-    <polyline points="12 5 19 12 12 19" />
-  </svg>
-);
-
-const LockIcon = () => (
-  <svg
-    className="v-window__lock"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <rect x="4" y="11" width="16" height="11" rx="2" />
-    <path d="M8 11V7a4 4 0 0 1 8 0v4" />
-  </svg>
-);
+/* WasmGlyph + DockerGlyph stay inline because they are brand-evoking
+ * marks tied to specific runtimes, not generic UI icons. The two
+ * generic icons (cta arrow + URL-bar lock) come from lucide-react. */
 
 const WasmGlyph = () => (
   <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -180,7 +144,7 @@ const Chrome = ({ url, badge }: { url: string; badge: BadgeKind }) => (
       <span className="v-window__dot v-window__dot--green" />
     </div>
     <div className="v-window__url v-window__url--pill">
-      <LockIcon />
+      <Lock className="v-window__lock" strokeWidth={2.5} aria-hidden="true" />
       {url}
     </div>
     <ChromeBadge kind={badge} />
@@ -332,7 +296,9 @@ const RubyInner = ({ s }: { s: typeof STRINGS.en }) => (
       <span className="v-window__eyebrow">{s.ruby.eyebrow}</span>
       <h2 className="v-window__title">{s.ruby.title}</h2>
       <p className="v-window__lede">{s.ruby.lede}</p>
-      <span className="v-verdict v-verdict--reproduced">{s.ruby.verdictText}</span>
+      <span className="v-verdict v-verdict--reproduced">
+        {s.ruby.verdictText}
+      </span>
 
       <div className="v-code">
         <span className="v-code__comment"># repro.rb</span>
@@ -448,12 +414,13 @@ export function VivariumHero({ lang = 'en' }: { lang?: Lang } = {}) {
           <p className="v-hero__lede">{s.lede}</p>
 
           <div className="v-hero__ctas">
-            <a
-              className="v-hero__cta v-hero__cta--primary"
-              href={s.visionHref}
-            >
+            <a className="v-hero__cta v-hero__cta--primary" href={s.visionHref}>
               {s.ctaPrimary}
-              <ArrowRight />
+              <ArrowRight
+                className="v-hero__cta-arrow"
+                strokeWidth={2}
+                aria-hidden="true"
+              />
             </a>
             <a
               className="v-hero__cta v-hero__cta--ghost"
@@ -517,24 +484,29 @@ export function VivariumHero({ lang = 'en' }: { lang?: Lang } = {}) {
               const slot = slots[id];
               const isFront = slot === 'front';
               const tab = s.tabs[id];
+              const className = `v-window v-window--slot-${slot}`;
+              if (isFront) {
+                return (
+                  <div key={id} className={className}>
+                    {renderInner(id)}
+                  </div>
+                );
+              }
               return (
+                // biome-ignore lint/a11y/useSemanticElements: <button> can't legally contain the window's nested interactive content (chrome / code / console); div + role="button" + keyboard handler keeps the swap interaction accessible
                 <div
                   key={id}
-                  className={`v-window v-window--slot-${slot}`}
-                  onClick={() => !isFront && swapToFront(id)}
+                  className={className}
+                  onClick={() => swapToFront(id)}
                   onKeyDown={(e) => {
-                    if (!isFront && (e.key === 'Enter' || e.key === ' ')) {
+                    if (e.key === 'Enter' || e.key === ' ') {
                       e.preventDefault();
                       swapToFront(id);
                     }
                   }}
-                  role={isFront ? undefined : 'button'}
-                  tabIndex={isFront ? -1 : 0}
-                  aria-label={
-                    isFront
-                      ? s.activeAria(tab.label)
-                      : s.bringFrontAria(tab.label)
-                  }
+                  role="button"
+                  tabIndex={0}
+                  aria-label={s.bringFrontAria(tab.label)}
                 >
                   {renderInner(id)}
                 </div>

--- a/docs/components/VivariumLandingSections.tsx
+++ b/docs/components/VivariumLandingSections.tsx
@@ -1,0 +1,347 @@
+import {
+  AppWindow,
+  ArrowRight,
+  Container,
+  GitBranch,
+  Pencil,
+  RotateCcw,
+  Sparkles,
+  Timer,
+} from 'lucide-react';
+import './vivarium-landing.css';
+
+/* ============================================================================
+ * Phase 7 V′ — landing-page sections that sit BELOW the existing hero.
+ *
+ * Order on the page (informed by the V′ information-design audit + Stitch
+ * wall-bouncing v1+v3 hybrid):
+ *   1. <VivariumHero>        — existing
+ *   2. <VivariumNumbers>     — proof up front (v3 evidence-first)
+ *   3. <VivariumLayers>      — three-layer strip
+ *   4. <VivariumPersonas>    — "where do you start?" 4-card grid
+ *   5. <VivariumCtaBand>     — secondary CTA into gallery / spec
+ *   6. <VivariumFooter>      — existing
+ *
+ * Each section is a standalone export so future pages can re-use individual
+ * pieces (e.g. <VivariumLayers> may also appear on /architecture).
+ * ========================================================================== */
+
+type Lang = 'en' | 'ja';
+
+/* --------------------------------- Icons --------------------------------- */
+
+/* lucide-react icons accept a className prop; sizing and color come from
+ * vivarium-landing.css so callers never have to pass pixel units.
+ * lucide is tree-shaken — only the named imports above ship to the bundle. */
+
+const LAYER_ICONS = [AppWindow, Container, RotateCcw] as const;
+const PERSONA_ICONS = [Timer, GitBranch, Sparkles, Pencil] as const;
+
+/* ------------------------------ i18n strings ----------------------------- */
+
+const STRINGS = {
+  en: {
+    base: '/vivarium',
+    numbers: {
+      eyebrow: '// SHIPPED · 2026',
+      items: [
+        { value: '11', label: 'reproductions catalogued' },
+        { value: '4', label: 'MCP tools' },
+        { value: '6', label: 'phases closed' },
+        { value: 'v1', label: 'public contract' },
+      ],
+    },
+    layers: {
+      eyebrow: '// THREE-LAYER ARCHITECTURE',
+      heading: 'Pick the layer that fits your bug.',
+      sub: 'You never choose by hand — each recipe declares its own layer. The layers exist because no single runtime fits every bug.',
+      cards: [
+        {
+          pill: 'L1',
+          accent: 'teal' as const,
+          title: 'Browser-native, instant.',
+          body: 'WebAssembly runtimes inside the visitor’s tab. Algorithms, parsers, in-memory database operations. Startup in milliseconds to seconds.',
+          runtimes:
+            'Pyodide · sqlite-wasm · wasm32-wasip1 · Ruby.wasm · PHP.wasm',
+        },
+        {
+          pill: 'L2',
+          accent: 'violet' as const,
+          title: 'Container fidelity.',
+          body: 'Real filesystem, real processes, real network. Catalogue model: pinned Dockerfile + GHCR image. The visitor reproduces locally with one `docker run`.',
+          runtimes: 'Docker · Firecracker · gVisor',
+        },
+        {
+          pill: 'L3',
+          accent: 'coral' as const,
+          title: 'Record-replay & deterministic.',
+          body: 'Heisenbugs only. Vivarium pre-records the trace; the visitor replays. Burned-in GHCR images run on commodity Linux hosts — no PMU required.',
+          runtimes: 'rr · Antithesis · CRIU · WASI Preview 3+',
+        },
+      ],
+    },
+    personas: {
+      eyebrow: '// WHERE TO START',
+      heading: 'Pick your starting point.',
+      sub: 'Five minutes, five hours, or five months — the path is different.',
+      cards: [
+        {
+          micro: 'TRY ONE',
+          title: 'Open one reproduction in 5 minutes',
+          body: 'No install, no account. Click a recipe, watch the verdict resolve from pending.',
+          href: '/guide/getting-started',
+        },
+        {
+          micro: 'INTEGRATE',
+          title: 'Wire Vivarium into your repo',
+          body: 'Drop a `.vivarium/manifest.toml` and the reusable workflow checks your verdicts on every push.',
+          href: '/guide/integrate-with-your-repo',
+        },
+        {
+          micro: 'AI AGENT',
+          title: 'Drive Vivarium from Claude or Aider',
+          body: 'The `@aletheia-works/vivarium-mcp` server exposes four tools. List recipes, fetch verdicts, match an error string.',
+          href: '/guide/use-from-ai-agent',
+        },
+        {
+          micro: 'CONTRIBUTE',
+          title: 'Write your first reproduction',
+          body: 'Scaffold a Layer 1 recipe directory and watch it appear in the gallery on the next deploy.',
+          href: '/guide/write-your-first-reproduction',
+        },
+      ],
+      arrow: 'Open',
+    },
+    cta: {
+      eyebrow: '// SEE IT RUN',
+      heading: 'Eleven real upstream bugs, running in a browser tab.',
+      sub: 'pandas, numpy, CPython, Ruby, PHP, Rust regex on Layer 1. PostgreSQL, bash, flock, find/xargs on Layer 2. coreutils sort race on Layer 3.',
+      primary: { label: 'Browse the gallery →', href: '/repro/' },
+      ghost: { label: 'Read the spec', href: '/spec/' },
+    },
+  },
+  ja: {
+    base: '/vivarium/ja',
+    numbers: {
+      eyebrow: '// 出荷済み · 2026',
+      items: [
+        { value: '11', label: 'レシピ公開' },
+        { value: '4', label: 'MCP ツール' },
+        { value: '6', label: 'フェーズクローズ' },
+        { value: 'v1', label: '公開コントラクト' },
+      ],
+    },
+    layers: {
+      eyebrow: '// 三層アーキテクチャ',
+      heading: 'バグの種類に合うレイヤーを、レシピが選ぶ。',
+      sub: 'ユーザーがレイヤーを選ぶ必要はない——レシピが自分に合った層を宣言する。三層あるのは、単一のランタイムですべてのバグに届かないから。',
+      cards: [
+        {
+          pill: 'L1',
+          accent: 'teal' as const,
+          title: 'ブラウザネイティブ、瞬時起動。',
+          body: '訪問者のタブの中で WebAssembly が直接実行される。アルゴリズム、パーサ、in-memory なデータベース操作。起動はミリ秒〜数秒。',
+          runtimes:
+            'Pyodide · sqlite-wasm · wasm32-wasip1 · Ruby.wasm · PHP.wasm',
+        },
+        {
+          pill: 'L2',
+          accent: 'violet' as const,
+          title: 'コンテナで完全忠実度。',
+          body: '本物のファイルシステム、本物のプロセス、本物のネットワーク。ピン留めした Dockerfile と GHCR イメージのカタログ。訪問者は 1 回の `docker run` でローカル再現。',
+          runtimes: 'Docker · Firecracker · gVisor',
+        },
+        {
+          pill: 'L3',
+          accent: 'coral' as const,
+          title: 'Record-replay と決定論的シミュレーション。',
+          body: 'ハイゼンバグ専用。Vivarium が事前にトレースを録音し、訪問者は再生だけ。GHCR イメージに焼き込み、コモディティ Linux で動作——PMU 不要。',
+          runtimes: 'rr · Antithesis · CRIU · WASI Preview 3+',
+        },
+      ],
+    },
+    personas: {
+      eyebrow: '// はじめ方',
+      heading: 'あなたの状況から入る。',
+      sub: '5 分、5 時間、5 ヶ月——目的によって入り口は違う。',
+      cards: [
+        {
+          micro: 'まず動かす',
+          title: '5 分で 1 つのレシピを動かす',
+          body: 'インストール・アカウント不要。レシピをクリックして verdict が pending から確定するのを見る。',
+          href: '/guide/getting-started',
+        },
+        {
+          micro: '統合する',
+          title: 'Vivarium を自分のリポに繋ぐ',
+          body: '`.vivarium/manifest.toml` を置いて、再利用可能ワークフローが push のたびに verdict を確認する。',
+          href: '/guide/integrate-with-your-repo',
+        },
+        {
+          micro: 'AI エージェント',
+          title: 'Claude や Aider から Vivarium を呼ぶ',
+          body: '`@aletheia-works/vivarium-mcp` が 4 つのツールを公開する。レシピ列挙、verdict 取得、エラー文字列マッチ。',
+          href: '/guide/use-from-ai-agent',
+        },
+        {
+          micro: '貢献する',
+          title: 'はじめての再現を書く',
+          body: 'Layer 1 のレシピディレクトリをスキャフォールドし、次のデプロイでギャラリーに現れるのを見る。',
+          href: '/guide/write-your-first-reproduction',
+        },
+      ],
+      arrow: '開く',
+    },
+    cta: {
+      eyebrow: '// 実物を見る',
+      heading:
+        '11 個の本物のアップストリームバグが、ブラウザのタブ 1 枚で動く。',
+      sub: 'Layer 1 の pandas、numpy、CPython、Ruby、PHP、Rust regex。Layer 2 の PostgreSQL、bash、flock、find/xargs。Layer 3 の coreutils sort race。',
+      primary: { label: '再現一覧へ →', href: '/repro/' },
+      ghost: { label: '仕様を読む', href: '/spec/' },
+    },
+  },
+} as const;
+
+/* -------------------------- VivariumNumbers ---------------------------- */
+
+export function VivariumNumbers({ lang = 'en' }: { lang?: Lang } = {}) {
+  const s = STRINGS[lang];
+  return (
+    <section className="v-land-numbers" aria-labelledby="v-numbers-eyebrow">
+      <div className="v-land-numbers__inner">
+        <p id="v-numbers-eyebrow" className="v-land__eyebrow">
+          {s.numbers.eyebrow}
+        </p>
+        <div className="v-land-numbers__grid">
+          {s.numbers.items.map((item, i) => (
+            <div key={i} className="v-land-numbers__cell">
+              <div className="v-land-numbers__value">{item.value}</div>
+              <div className="v-land-numbers__label">{item.label}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* -------------------------- VivariumLayers ----------------------------- */
+
+export function VivariumLayers({ lang = 'en' }: { lang?: Lang } = {}) {
+  const s = STRINGS[lang];
+  return (
+    <section className="v-land-layers" aria-labelledby="v-layers-heading">
+      <div className="v-land-layers__inner">
+        <p className="v-land__eyebrow">{s.layers.eyebrow}</p>
+        <h2 id="v-layers-heading" className="v-land__heading">
+          {s.layers.heading}
+        </h2>
+        <p className="v-land__sub">{s.layers.sub}</p>
+        <div className="v-land-layers__grid">
+          {s.layers.cards.map((card, i) => {
+            const Icon = LAYER_ICONS[i];
+            return (
+              <article key={i} className="v-land-layer">
+                <div className="v-land-layer__head">
+                  <Icon
+                    className={`v-land-layer__icon v-land-layer__icon--${card.accent}`}
+                    strokeWidth={1.75}
+                    aria-hidden="true"
+                  />
+                  <span
+                    className={`v-land-layer__pill v-land-layer__pill--${card.accent}`}
+                  >
+                    {card.pill}
+                  </span>
+                </div>
+                <h3 className="v-land-layer__title">{card.title}</h3>
+                <p className="v-land-layer__body">{card.body}</p>
+                <div className="v-land-layer__runtimes">{card.runtimes}</div>
+              </article>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* -------------------------- VivariumPersonas --------------------------- */
+
+export function VivariumPersonas({ lang = 'en' }: { lang?: Lang } = {}) {
+  const s = STRINGS[lang];
+  return (
+    <section className="v-land-personas" aria-labelledby="v-personas-heading">
+      <div className="v-land-personas__inner">
+        <p className="v-land__eyebrow">{s.personas.eyebrow}</p>
+        <h2 id="v-personas-heading" className="v-land__heading">
+          {s.personas.heading}
+        </h2>
+        <p className="v-land__sub">{s.personas.sub}</p>
+        <div className="v-land-personas__grid">
+          {s.personas.cards.map((card, i) => {
+            const Icon = PERSONA_ICONS[i];
+            return (
+              <a
+                key={i}
+                className="v-land-persona"
+                href={`${s.base}${card.href}`}
+              >
+                <div className="v-land-persona__head">
+                  <Icon
+                    className="v-land-persona__icon"
+                    strokeWidth={1.75}
+                    aria-hidden="true"
+                  />
+                  <span className="v-land-persona__micro">{card.micro}</span>
+                </div>
+                <h3 className="v-land-persona__title">{card.title}</h3>
+                <p className="v-land-persona__body">{card.body}</p>
+                <span className="v-land-persona__cta">
+                  {s.personas.arrow}
+                  <ArrowRight
+                    className="v-land-persona__arrow"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                  />
+                </span>
+              </a>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* -------------------------- VivariumCtaBand ---------------------------- */
+
+export function VivariumCtaBand({ lang = 'en' }: { lang?: Lang } = {}) {
+  const s = STRINGS[lang];
+  return (
+    <section className="v-land-cta" aria-labelledby="v-cta-heading">
+      <div className="v-land-cta__inner">
+        <p className="v-land__eyebrow">{s.cta.eyebrow}</p>
+        <h2 id="v-cta-heading" className="v-land-cta__heading">
+          {s.cta.heading}
+        </h2>
+        <p className="v-land-cta__sub">{s.cta.sub}</p>
+        <div className="v-land-cta__buttons">
+          <a
+            className="v-land-cta__btn v-land-cta__btn--primary"
+            href={`${s.base}${s.cta.primary.href}`}
+          >
+            {s.cta.primary.label}
+          </a>
+          <a
+            className="v-land-cta__btn v-land-cta__btn--ghost"
+            href={`${s.base}${s.cta.ghost.href}`}
+          >
+            {s.cta.ghost.label}
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/docs/components/error-recipe-matcher.css
+++ b/docs/components/error-recipe-matcher.css
@@ -4,7 +4,8 @@
 
 .v-erm {
   margin: 1.25rem 0 2.5rem;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: var(--vh-text);
 }
 
@@ -12,7 +13,7 @@
 .v-erm__results-eyebrow {
   display: block;
   margin: 0 0 0.6rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -27,7 +28,7 @@
 }
 
 .v-erm__field-label {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.72rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -41,7 +42,7 @@
   border: 1px solid var(--vh-hairline);
   border-radius: 6px;
   color: var(--vh-text);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.78rem;
   line-height: 1.5;
   resize: vertical;
@@ -66,7 +67,7 @@
   border-radius: 6px;
   background: var(--vh-card-bg);
   color: var(--vh-text);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.85rem;
   cursor: pointer;
   transition: all 120ms ease;
@@ -106,7 +107,7 @@
 }
 
 .v-erm__tokens-label {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.7rem;
   letter-spacing: 0.07em;
   text-transform: uppercase;
@@ -122,7 +123,7 @@
   border-radius: 3px;
   background: var(--vh-card-bg-hover);
   color: var(--vh-text);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.72rem;
   border: 1px solid var(--vh-hairline);
 }
@@ -175,7 +176,7 @@
 }
 
 .v-erm__results-count {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   color: var(--vh-text-dim);
 }
@@ -189,7 +190,7 @@
   display: inline-flex;
   align-items: center;
   gap: 0.3rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.72rem;
 }
 
@@ -201,7 +202,7 @@
 }
 
 .v-erm__score code {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   background: var(--vh-card-bg-hover);
   color: var(--vh-accent-teal-bright);
   padding: 0.1rem 0.45rem;
@@ -219,7 +220,7 @@
 }
 
 .v-erm__matched-key {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.65rem;
   letter-spacing: 0.07em;
   text-transform: uppercase;
@@ -240,7 +241,7 @@
 
 .v-erm__empty-heading {
   margin: 0 0 0.5rem;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-size: 1rem;
   color: var(--vh-text);
 }

--- a/docs/components/manifest-scaffolder.css
+++ b/docs/components/manifest-scaffolder.css
@@ -2,14 +2,15 @@
 
 .v-mfs {
   margin: 1.25rem 0 2.5rem;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: var(--vh-text);
 }
 
 .v-mfs__eyebrow {
   display: block;
   margin: 0 0 0.85rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -31,7 +32,7 @@
 }
 
 .v-mfs__group-legend {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.7rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -52,7 +53,7 @@
   display: flex;
   align-items: baseline;
   gap: 0.45rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.8rem;
   color: var(--vh-text);
 }
@@ -74,7 +75,7 @@
   border: 1px solid var(--vh-hairline);
   border-radius: 6px;
   color: var(--vh-text);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.85rem;
   outline: none;
 }
@@ -98,7 +99,7 @@ html.dark .v-mfs__input {
 }
 
 .v-mfs__error {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.72rem;
   color: var(--vh-accent-coral);
 }
@@ -110,7 +111,7 @@ html.dark .v-mfs__input {
 }
 
 .v-mfs__help code {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   background: var(--vh-card-bg-hover);
   padding: 0.05rem 0.3rem;
   border-radius: 3px;
@@ -131,7 +132,7 @@ html.dark .v-mfs__input {
   border-radius: 999px;
   background: transparent;
   color: var(--vh-text-muted);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.78rem;
   cursor: pointer;
   transition: all 120ms ease;
@@ -170,7 +171,7 @@ html.dark .v-mfs__input {
   border-radius: 6px;
   background: var(--vh-card-bg);
   color: var(--vh-text);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.85rem;
   cursor: pointer;
   transition: all 120ms ease;
@@ -202,7 +203,7 @@ html.dark .v-mfs__input {
   padding: 0.85rem 1rem;
   background: rgba(4, 34, 28, 0.5);
   color: var(--vh-text);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.78rem;
   line-height: 1.55;
   border-radius: 6px;
@@ -228,7 +229,7 @@ html.dark .v-mfs__input {
 }
 
 .v-mfs__empty code {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   background: var(--vh-card-bg-hover);
   padding: 0.05rem 0.3rem;
   border-radius: 3px;
@@ -236,7 +237,7 @@ html.dark .v-mfs__input {
 
 .v-mfs__spec-link {
   margin: 1.25rem 0 0;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.78rem;
   color: var(--vh-text-dim);
 }

--- a/docs/components/page-chrome.css
+++ b/docs/components/page-chrome.css
@@ -45,7 +45,8 @@ html.dark {
   max-width: 880px;
   margin: 0 auto;
   padding: 0 1.5rem;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: var(--vh-text);
 }
 
@@ -70,7 +71,7 @@ html.dark {
 }
 
 .v-page-hero::before {
-  content: '';
+  content: "";
   position: absolute;
   top: -10%;
   left: -10%;
@@ -88,7 +89,7 @@ html.dark {
 .v-page-hero__eyebrow {
   display: inline-block;
   margin-bottom: 1.25rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -97,7 +98,7 @@ html.dark {
 
 .v-page-hero__title {
   margin: 0 0 1.5rem;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-weight: 700;
   font-size: clamp(2.25rem, 5vw, 3.5rem);
   line-height: 1.08;
@@ -139,7 +140,7 @@ html.dark {
 .v-section__eyebrow {
   display: block;
   margin-bottom: 1rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -148,7 +149,7 @@ html.dark {
 
 .v-section__heading {
   margin: 0 0 2rem;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-weight: 600;
   font-size: clamp(1.625rem, 3vw, 2.25rem);
   line-height: 1.15;
@@ -177,7 +178,7 @@ html.dark {
 }
 
 .v-section__body code {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.92em;
   padding: 0.1em 0.35em;
   background: var(--vh-card-bg);
@@ -198,7 +199,7 @@ html.dark {
 
 .v-section__body h3 {
   margin: 2.5rem 0 1rem;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-weight: 600;
   font-size: 1.25rem;
   letter-spacing: -0.01em;
@@ -211,7 +212,7 @@ html.dark {
 
 .v-section__body h4 {
   margin: 1.5rem 0 0.5rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -250,7 +251,7 @@ html.dark {
 }
 
 .v-section__body th {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.7rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -273,7 +274,7 @@ html.dark {
   border: 1px solid var(--vh-hairline);
   border-radius: 8px;
   overflow-x: auto;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.8rem;
   line-height: 1.6;
   color: var(--vh-text);
@@ -287,17 +288,17 @@ html.dark {
 }
 
 /* Markdown `> blockquote` syntax automatically renders with the same
- * visual treatment as the explicit <Callout> component. Authors can
- * write a blockquote in MDX and get the Vivarium pull-quote styling
- * (teal left rail, italic Space Grotesk) without importing a JSX tag. */
+ * visual treatment as the explicit <Callout> component — a body-size
+ * aside with a teal left rail and Space Grotesk for light typographic
+ * differentiation. Authors can write a blockquote in MDX and get the
+ * Vivarium callout styling without importing a JSX tag. */
 .v-section__body blockquote {
   margin: 2rem 0;
   padding: 0.75rem 0 0.75rem 2rem;
   border-left: 4px solid var(--vh-accent-teal);
-  font-family: 'Space Grotesk', sans-serif;
-  font-style: italic;
-  font-size: 1.375rem;
-  line-height: 1.5;
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.6;
   color: var(--vh-text);
 }
 
@@ -339,19 +340,25 @@ html.dark {
 }
 
 .v-kpi__value {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-weight: 700;
   font-size: clamp(2rem, 4vw, 2.5rem);
   line-height: 1;
   margin-bottom: 0.6rem;
 }
 
-.v-kpi__value--coral { color: var(--vh-accent-coral); }
-.v-kpi__value--violet { color: var(--vh-accent-violet-bright); }
-.v-kpi__value--teal { color: var(--vh-accent-teal-bright); }
+.v-kpi__value--coral {
+  color: var(--vh-accent-coral);
+}
+.v-kpi__value--violet {
+  color: var(--vh-accent-violet-bright);
+}
+.v-kpi__value--teal {
+  color: var(--vh-accent-teal-bright);
+}
 
 .v-kpi__label {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.625rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -391,7 +398,7 @@ html.dark {
 }
 
 .v-compare__card-name {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-weight: 500;
   font-size: 1rem;
   color: var(--vh-text);
@@ -399,7 +406,7 @@ html.dark {
 }
 
 .v-compare__card-tagline {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   color: var(--vh-text-dim);
 }
@@ -417,7 +424,7 @@ html.dark {
 }
 
 .v-compare__highlight::before {
-  content: '';
+  content: "";
   position: absolute;
   inset: 0;
   background: radial-gradient(
@@ -430,7 +437,7 @@ html.dark {
 
 .v-compare__highlight-name {
   position: relative;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-weight: 700;
   font-size: 1.5rem;
   color: var(--vh-accent-teal-bright);
@@ -438,7 +445,7 @@ html.dark {
 
 .v-compare__highlight-tagline {
   position: relative;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.8rem;
   color: var(--vh-accent-teal);
 }
@@ -473,7 +480,7 @@ html.dark {
   margin-bottom: 1.5rem;
   padding: 0.15rem 0.5rem;
   border-radius: 0.25rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-weight: 700;
   font-size: 0.625rem;
   letter-spacing: 0.05em;
@@ -496,7 +503,7 @@ html.dark {
 
 .v-layer__title {
   margin: 0 0 0.75rem;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-weight: 700;
   font-size: 1.5rem;
   color: var(--vh-text);
@@ -514,7 +521,7 @@ html.dark {
 .v-layer__runtimes {
   padding-top: 1rem;
   border-top: 1px solid var(--vh-hairline);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.625rem;
   letter-spacing: 0.05em;
   color: var(--vh-text-dim);
@@ -550,7 +557,7 @@ html.dark {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 1rem;
   color: var(--vh-accent-teal-bright);
   background: rgba(0, 212, 170, 0.04);
@@ -559,7 +566,7 @@ html.dark {
 .v-numlist__lead {
   display: block;
   margin-bottom: 0.5rem;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-weight: 700;
   font-size: 1.125rem;
   color: var(--vh-text);
@@ -572,16 +579,15 @@ html.dark {
   font-size: 1rem;
 }
 
-/* ---------- Callout / pull-quote ---------- */
+/* ---------- Callout (body-size aside) ---------- */
 
 .v-callout {
   margin: 2rem 0 0;
   padding: 0.75rem 0 0.75rem 2rem;
   border-left: 4px solid var(--vh-accent-teal);
-  font-family: 'Space Grotesk', sans-serif;
-  font-style: italic;
-  font-size: 1.375rem;
-  line-height: 1.5;
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.6;
   color: var(--vh-text);
 }
 
@@ -625,7 +631,7 @@ html.dark {
 .v-next-cta__eyebrow {
   display: block;
   margin-bottom: 1rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -634,7 +640,7 @@ html.dark {
 
 .v-next-cta__heading {
   margin: 0 0 0.75rem;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-weight: 700;
   font-size: clamp(2rem, 4vw, 2.75rem);
   line-height: 1.1;
@@ -665,7 +671,7 @@ html.dark {
   gap: 0.5rem;
   padding: 0.75rem 1.75rem;
   border-radius: 0.5rem;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-weight: 600;
   font-size: 0.95rem;
   text-decoration: none;
@@ -703,7 +709,7 @@ html.dark {
   margin: 0 auto;
   padding: 1.5rem 1.5rem 2rem;
   text-align: center;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.6875rem;
   letter-spacing: 0.15em;
   text-transform: uppercase;
@@ -731,7 +737,7 @@ html.dark {
 }
 
 .v-glossary dt {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-weight: 600;
   font-size: 1.0625rem;
   color: var(--vh-text);

--- a/docs/components/project-page.css
+++ b/docs/components/project-page.css
@@ -6,14 +6,15 @@
 
 .v-pp {
   margin: 1.25rem 0 2.5rem;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: var(--vh-text);
 }
 
 .v-pp__eyebrow {
   display: block;
   margin: 0 0 0.85rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -30,7 +31,7 @@
 
 .v-pp__title {
   margin: 0;
-  font-family: 'Space Grotesk', 'Inter', sans-serif;
+  font-family: "Space Grotesk", "Inter", sans-serif;
   font-size: 1.85rem;
   font-weight: 600;
   letter-spacing: -0.01em;
@@ -38,7 +39,7 @@
 
 .v-pp__tagline {
   margin: 0.55rem 0 0;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.85rem;
   color: var(--vh-text-muted);
 }
@@ -66,7 +67,7 @@
   border: 1px solid var(--vh-hairline);
   border-radius: 999px;
   background: rgba(0, 0, 0, 0.04);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.72rem;
   color: var(--vh-text-muted);
 }
@@ -80,7 +81,7 @@ html.dark .v-pp__count-chip {
   align-items: center;
   padding: 0.18rem 0.55rem;
   border-radius: 999px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.72rem;
   letter-spacing: 0.04em;
   border: 1px solid;
@@ -112,7 +113,7 @@ html.dark .v-pp__count-chip {
 }
 
 .v-pp__link {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.78rem;
   color: var(--vh-accent-teal);
   text-decoration: none;
@@ -128,7 +129,7 @@ html.dark .v-pp__count-chip {
 
 .v-pp__section-heading {
   margin: 1.6rem 0 0.6rem;
-  font-family: 'Space Grotesk', 'Inter', sans-serif;
+  font-family: "Space Grotesk", "Inter", sans-serif;
   font-size: 1.15rem;
   font-weight: 600;
 }
@@ -143,7 +144,7 @@ html.dark .v-pp__count-chip {
   text-align: left;
   padding: 0.5rem 0.6rem;
   border-bottom: 1px solid var(--vh-hairline);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.7rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -170,7 +171,7 @@ html.dark .v-pp__count-chip {
 }
 
 .v-pp__row-symptom code {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.78rem;
 }
 
@@ -190,7 +191,7 @@ html.dark .v-pp__count-chip {
   padding: 0.35rem 0.7rem;
   margin-left: 0.4rem;
   border-radius: 6px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   text-decoration: none;
   border: 1px solid var(--vh-hairline);
@@ -223,7 +224,7 @@ html.dark .v-pp__count-chip {
   padding: 1rem;
   border: 1px dashed var(--vh-hairline);
   border-radius: 8px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.85rem;
   color: var(--vh-text-muted);
   background: rgba(0, 0, 0, 0.02);

--- a/docs/components/recipe-gallery.css
+++ b/docs/components/recipe-gallery.css
@@ -4,14 +4,15 @@
 
 .v-rg {
   margin: 1.25rem 0 2.5rem;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: var(--vh-text);
 }
 
 .v-rg__eyebrow {
   display: block;
   margin: 0 0 0.85rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -38,7 +39,7 @@
 
 .v-rg__search-label,
 .v-rg__group-label {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.7rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -51,7 +52,7 @@
   border: 1px solid var(--vh-hairline);
   border-radius: 6px;
   color: var(--vh-text);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.85rem;
   outline: none;
 }
@@ -87,7 +88,7 @@ html.dark .v-rg__search-input {
   border-radius: 999px;
   background: transparent;
   color: var(--vh-text-muted);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.72rem;
   letter-spacing: 0.04em;
   cursor: pointer;
@@ -123,7 +124,7 @@ html.dark .v-rg__search-input {
   align-items: center;
   gap: 0.75rem;
   margin: 0.85rem 0 0.6rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   color: var(--vh-text-dim);
 }
@@ -185,7 +186,9 @@ html.dark .v-rg__search-input {
   background: var(--vh-card-bg);
   border: 1px solid var(--vh-hairline);
   border-radius: 8px;
-  transition: border-color 120ms ease, transform 120ms ease;
+  transition:
+    border-color 120ms ease,
+    transform 120ms ease;
 }
 
 .v-rg__card:hover {
@@ -203,7 +206,7 @@ html.dark .v-rg__search-input {
 .v-rg__layer-pill {
   display: inline-block;
   padding: 0.15rem 0.5rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.65rem;
   letter-spacing: 0.07em;
   text-transform: uppercase;
@@ -230,7 +233,7 @@ html.dark .v-rg__search-input {
 }
 
 .v-rg__slug {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.7rem;
   color: var(--vh-text-dim);
   word-break: break-all;
@@ -240,7 +243,7 @@ html.dark .v-rg__search-input {
 
 .v-rg__title {
   margin: 0;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-size: 1rem;
   line-height: 1.3;
   color: var(--vh-text);
@@ -248,7 +251,7 @@ html.dark .v-rg__search-input {
 }
 
 .v-rg__title span {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-weight: 500;
   color: var(--vh-text-muted);
   font-size: 0.85em;
@@ -271,7 +274,7 @@ html.dark .v-rg__search-input {
 }
 
 .v-rg__meta-key {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   font-size: 0.65rem;
@@ -280,7 +283,7 @@ html.dark .v-rg__search-input {
 }
 
 .v-rg__meta-item code {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.72rem;
   color: var(--vh-text);
   background: var(--vh-card-bg-hover);
@@ -299,7 +302,7 @@ html.dark .v-rg__search-input {
 }
 
 .v-rg__tag {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.65rem;
   padding: 0.1rem 0.4rem;
   border-radius: 3px;
@@ -319,7 +322,7 @@ html.dark .v-rg__search-input {
   padding: 0.35rem 0.75rem;
   border: 1px solid var(--vh-hairline-strong);
   border-radius: 4px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   text-decoration: none;
   transition: all 120ms ease;

--- a/docs/components/repro-compare.css
+++ b/docs/components/repro-compare.css
@@ -6,7 +6,8 @@
 
 .v-rc {
   margin: 1.5rem 0 4rem;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: var(--vh-text);
 }
 
@@ -17,7 +18,7 @@
 .v-rc__eyebrow {
   display: block;
   margin: 0 0 0.75rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -46,7 +47,7 @@
 }
 
 .v-rc__field-label {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -59,11 +60,13 @@
   border: 1px solid var(--vh-hairline);
   border-radius: 6px;
   color: var(--vh-text);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.85rem;
   line-height: 1.4;
   outline: none;
-  transition: border-color 120ms ease, background 120ms ease;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease;
 }
 
 .v-rc__field-input:focus {
@@ -87,7 +90,9 @@
   text-align: center;
   cursor: pointer;
   outline: none;
-  transition: border-color 120ms ease, background 120ms ease;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease;
 }
 
 .v-rc__drop:hover,
@@ -98,7 +103,7 @@
 
 .v-rc__drop-prompt {
   margin: 0 0 0.4rem;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-size: 1.05rem;
   font-weight: 600;
   color: var(--vh-text);
@@ -126,7 +131,7 @@
 }
 
 .v-rc__drop-accept {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
 }
 
 /* ---------- Action buttons ---------- */
@@ -144,7 +149,7 @@
   border-radius: 6px;
   background: var(--vh-card-bg);
   color: var(--vh-text);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.85rem;
   cursor: pointer;
   transition: all 120ms ease;
@@ -185,7 +190,7 @@
 
 .v-rc__errors-header {
   margin: 0 0 0.5rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.8rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -201,7 +206,7 @@
 }
 
 .v-rc__error {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   margin-bottom: 0.3rem;
   word-break: break-word;
 }
@@ -253,7 +258,7 @@
   border: 1px solid var(--vh-hairline);
   border-radius: 6px;
   color: var(--vh-text);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.78rem;
   line-height: 1.4;
   resize: vertical;
@@ -273,7 +278,7 @@
   gap: 0.4rem;
   padding: 0.2rem 0.55rem;
   border-radius: 999px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 0.06em;
@@ -341,13 +346,13 @@
 }
 
 .v-compare-strip__slug code {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.85rem;
   color: var(--vh-text);
 }
 
 .v-compare-strip__match {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.78rem;
   color: var(--vh-text-muted);
   white-space: nowrap;
@@ -412,7 +417,7 @@
 }
 
 .v-evidence__side-label {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -444,7 +449,7 @@
 }
 
 .v-evidence__row dt {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   color: var(--vh-text-muted);
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -460,7 +465,7 @@
 }
 
 .v-evidence__row dd code {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   background: var(--vh-card-bg);
   padding: 0.05rem 0.35rem;
   border-radius: 3px;
@@ -485,7 +490,7 @@
 
 .v-evidence__stream > summary {
   cursor: pointer;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -498,7 +503,7 @@
 }
 
 .v-evidence__stream > summary::before {
-  content: '▸ ';
+  content: "▸ ";
   display: inline-block;
   transition: transform 120ms ease;
 }
@@ -512,7 +517,7 @@
   padding: 0.65rem 0.8rem;
   background: rgba(4, 34, 28, 0.5);
   color: var(--vh-text);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.74rem;
   line-height: 1.5;
   border-radius: 4px;
@@ -546,7 +551,7 @@
 }
 
 .v-rc__steps li code {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   background: var(--vh-card-bg-hover);
   padding: 0.05rem 0.3rem;
   border-radius: 3px;
@@ -555,7 +560,7 @@
 
 .v-rc__help-link {
   margin: 0.8rem 0 0;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.78rem;
 }
 
@@ -570,7 +575,7 @@
 }
 
 .v-rc__semantics code {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   background: var(--vh-card-bg-hover);
   padding: 0.05rem 0.3rem;
   border-radius: 3px;

--- a/docs/components/vivarium-footer.css
+++ b/docs/components/vivarium-footer.css
@@ -5,7 +5,8 @@
   width: 100%;
   background: #0a0e0d;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 .v-footer__inner {

--- a/docs/components/vivarium-hero.css
+++ b/docs/components/vivarium-hero.css
@@ -69,7 +69,8 @@ html.dark {
   overflow: hidden;
   background-color: var(--vh-bg);
   color: var(--vh-text);
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   isolation: isolate;
 }
 
@@ -111,7 +112,8 @@ html.dark {
   border: 1px solid var(--vh-hairline);
   border-radius: 9999px;
   background: rgba(0, 212, 170, 0.05);
-  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-family:
+    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.65rem;
   color: var(--vh-accent-teal);
   letter-spacing: 0.1em;
@@ -123,7 +125,7 @@ html.dark {
 
 .v-hero__headline {
   margin: 0 0 1.5rem;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-weight: 700;
   font-size: clamp(1.875rem, 3vw, 3rem);
   line-height: 1.08;
@@ -133,7 +135,11 @@ html.dark {
 }
 
 .v-hero__headline-gradient {
-  background: linear-gradient(to right, var(--vh-accent-teal-bright), var(--vh-accent-violet-bright));
+  background: linear-gradient(
+    to right,
+    var(--vh-accent-teal-bright),
+    var(--vh-accent-violet-bright)
+  );
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -167,7 +173,7 @@ html.dark {
   gap: 0.5rem;
   padding: 0.75rem 1.5rem;
   border-radius: 0.5rem;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-weight: 500;
   font-size: 0.95rem;
   text-decoration: none;
@@ -257,19 +263,51 @@ html.dark {
 
 .v-hero__particles span {
   position: absolute;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   opacity: 0.18;
 }
 
-.v-hero__particles span:nth-child(1) { top: 15%; left: 20%; color: var(--vh-accent-teal); }
-.v-hero__particles span:nth-child(2) { top: 25%; left: 45%; color: var(--vh-accent-violet); }
-.v-hero__particles span:nth-child(3) { top: 40%; right: 15%; color: var(--vh-accent-teal); }
-.v-hero__particles span:nth-child(4) { bottom: 30%; left: 10%; color: var(--vh-accent-violet); }
-.v-hero__particles span:nth-child(5) { bottom: 15%; right: 25%; color: var(--vh-accent-teal); }
-.v-hero__particles span:nth-child(6) { top: 60%; left: 8%; color: var(--vh-accent-violet); }
-.v-hero__particles span:nth-child(7) { top: 8%; right: 30%; color: var(--vh-accent-teal); }
-.v-hero__particles span:nth-child(8) { bottom: 40%; right: 5%; color: var(--vh-accent-violet); }
+.v-hero__particles span:nth-child(1) {
+  top: 15%;
+  left: 20%;
+  color: var(--vh-accent-teal);
+}
+.v-hero__particles span:nth-child(2) {
+  top: 25%;
+  left: 45%;
+  color: var(--vh-accent-violet);
+}
+.v-hero__particles span:nth-child(3) {
+  top: 40%;
+  right: 15%;
+  color: var(--vh-accent-teal);
+}
+.v-hero__particles span:nth-child(4) {
+  bottom: 30%;
+  left: 10%;
+  color: var(--vh-accent-violet);
+}
+.v-hero__particles span:nth-child(5) {
+  bottom: 15%;
+  right: 25%;
+  color: var(--vh-accent-teal);
+}
+.v-hero__particles span:nth-child(6) {
+  top: 60%;
+  left: 8%;
+  color: var(--vh-accent-violet);
+}
+.v-hero__particles span:nth-child(7) {
+  top: 8%;
+  right: 30%;
+  color: var(--vh-accent-teal);
+}
+.v-hero__particles span:nth-child(8) {
+  bottom: 40%;
+  right: 5%;
+  color: var(--vh-accent-violet);
+}
 
 .v-hero__stage {
   position: relative;
@@ -357,19 +395,24 @@ html.dark {
 }
 
 @keyframes v-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.45; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
 }
 
 .v-tab__label {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-weight: 600;
   font-size: 0.95rem;
   letter-spacing: -0.01em;
 }
 
 .v-tab__sublabel {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.6rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -482,13 +525,19 @@ html.dark {
   opacity: 0.5;
 }
 
-.v-window__dot--red    { background: #ef4444; }
-.v-window__dot--yellow { background: #eab308; }
-.v-window__dot--green  { background: #22c55e; }
+.v-window__dot--red {
+  background: #ef4444;
+}
+.v-window__dot--yellow {
+  background: #eab308;
+}
+.v-window__dot--green {
+  background: #22c55e;
+}
 
 .v-window__url {
   margin: 0 auto;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.7rem;
   color: var(--vh-window-chrome-text);
   white-space: nowrap;
@@ -521,7 +570,7 @@ html.dark {
   align-items: center;
   gap: 0.35rem;
   padding: 0.2rem 0.5rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.55rem;
   font-weight: 700;
   letter-spacing: 0.14em;
@@ -568,7 +617,7 @@ html.dark {
 }
 
 .v-console__tab--ok::before {
-  content: '';
+  content: "";
   display: inline-block;
   width: 8px;
   height: 8px;
@@ -588,7 +637,7 @@ html.dark {
 }
 
 .v-console__tab--running::before {
-  content: '';
+  content: "";
   display: inline-block;
   width: 8px;
   height: 8px;
@@ -606,7 +655,7 @@ html.dark {
   background: var(--vh-terminal-bg);
   border: 1px solid var(--vh-terminal-border);
   border-radius: 0.5rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.6875rem;
   overflow: hidden;
 }
@@ -646,7 +695,7 @@ html.dark {
 }
 
 .v-console__tab--filter::before {
-  content: '';
+  content: "";
   display: inline-block;
   width: 8px;
   height: 8px;
@@ -707,7 +756,7 @@ html.dark {
 }
 
 .v-window__eyebrow {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.625rem;
   color: var(--vh-accent-teal);
   letter-spacing: 0.18em;
@@ -716,7 +765,7 @@ html.dark {
 
 .v-window__title {
   margin: 0;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-size: 1.375rem;
   font-weight: 600;
   letter-spacing: -0.01em;
@@ -738,7 +787,7 @@ html.dark {
   gap: 0.5rem;
   width: fit-content;
   padding: 0.375rem 0.75rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   font-weight: 700;
   border-radius: 0.25rem;
@@ -783,19 +832,35 @@ html.dark {
   border: 1px solid rgba(255, 255, 255, 0.05);
   border-radius: 0.5rem;
   padding: 1rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.6875rem;
   line-height: 1.65;
   color: #e0e6e3;
 }
 
-.v-code__comment { color: #71807d; display: block; margin-bottom: 0.5rem; }
-.v-code__line    { display: block; }
-.v-code__indent  { padding-left: 1rem; }
-.v-code__kw      { color: #f9a8d4; }
-.v-code__fn      { color: #93c5fd; }
-.v-code__str     { color: #6ee7b7; }
-.v-code__num     { color: #fdba74; }
+.v-code__comment {
+  color: #71807d;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+.v-code__line {
+  display: block;
+}
+.v-code__indent {
+  padding-left: 1rem;
+}
+.v-code__kw {
+  color: #f9a8d4;
+}
+.v-code__fn {
+  color: #93c5fd;
+}
+.v-code__str {
+  color: #6ee7b7;
+}
+.v-code__num {
+  color: #fdba74;
+}
 
 /* Terminal panel — clear teal hairline so it reads as a distinct surface */
 
@@ -805,7 +870,7 @@ html.dark {
   background-color: var(--vh-terminal-bg);
   border: 1px solid var(--vh-terminal-border);
   border-radius: 0.5rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.6875rem;
   line-height: 1.7;
 }
@@ -853,7 +918,7 @@ html.dark {
   background: var(--vh-code-bg);
   border-radius: 0.375rem;
   padding: 0.75rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.625rem;
   line-height: 1.7;
   color: var(--vh-on-dark-dim);
@@ -932,7 +997,9 @@ html.dark {
 
   .v-window {
     position: static;
-    transition: opacity 0.25s ease, transform 0.25s ease;
+    transition:
+      opacity 0.25s ease,
+      transform 0.25s ease;
   }
 
   .v-window--slot-front {

--- a/docs/components/vivarium-landing.css
+++ b/docs/components/vivarium-landing.css
@@ -1,0 +1,422 @@
+/* Vivarium landing — sections that sit below the existing hero.
+ *
+ * All tokens (--vh-bg, --vh-text, accents, hairline) come from
+ * vivarium-hero.css, which the hero ships into the page first. Both
+ * dark and light theme tokens are inherited automatically.
+ */
+
+/* ---------- Shared section primitives ---------- */
+
+.v-land-numbers,
+.v-land-layers,
+.v-land-personas,
+.v-land-cta {
+  width: 100%;
+  background-color: var(--vh-bg);
+  color: var(--vh-text);
+  font-family:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.v-land-numbers__inner,
+.v-land-layers__inner,
+.v-land-personas__inner,
+.v-land-cta__inner {
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+@media (min-width: 1024px) {
+  .v-land-numbers__inner,
+  .v-land-layers__inner,
+  .v-land-personas__inner,
+  .v-land-cta__inner {
+    padding: 5rem 4rem;
+  }
+}
+
+.v-land__eyebrow {
+  margin: 0 0 1.5rem;
+  font-family:
+    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vh-accent-teal);
+}
+
+.v-land__heading {
+  margin: 0 0 0.75rem;
+  font-family: "Space Grotesk", sans-serif;
+  font-size: clamp(1.625rem, 3vw, 2.25rem);
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--vh-text);
+}
+
+.v-land__sub {
+  margin: 0 0 2.5rem;
+  max-width: 42rem;
+  font-size: 1.0625rem;
+  line-height: 1.55;
+  color: var(--vh-text-muted);
+}
+
+/* ---------- Numbers strip ---------- */
+
+.v-land-numbers {
+  border-top: 1px solid var(--vh-hairline);
+  border-bottom: 1px solid var(--vh-hairline);
+}
+
+.v-land-numbers__inner {
+  /* tighter vertical for the numbers band */
+  padding-top: 2.5rem;
+  padding-bottom: 2.5rem;
+}
+
+@media (min-width: 1024px) {
+  .v-land-numbers__inner {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+  }
+}
+
+.v-land-numbers__grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2rem 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .v-land-numbers__grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.v-land-numbers__cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.v-land-numbers__value {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: clamp(2.25rem, 4vw, 3rem);
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--vh-accent-teal);
+}
+
+.v-land-numbers__label {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vh-text-dim);
+}
+
+/* ---------- Three-layer strip ---------- */
+
+.v-land-layers {
+  border-bottom: 1px solid var(--vh-hairline);
+}
+
+.v-land-layers__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+}
+
+@media (min-width: 768px) {
+  .v-land-layers__grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.v-land-layer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.75rem;
+  border: 1px solid var(--vh-hairline);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.015);
+}
+
+:root:not(.dark) .v-land-layer {
+  background: rgba(4, 34, 28, 0.02);
+}
+
+.v-land-layer__head {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  margin-bottom: 0.25rem;
+}
+
+.v-land-layer__icon {
+  width: 1.75rem;
+  height: 1.75rem;
+  flex-shrink: 0;
+}
+
+.v-land-layer__icon--teal {
+  color: var(--vh-accent-teal-bright);
+}
+
+.v-land-layer__icon--violet {
+  color: var(--vh-accent-violet-bright);
+}
+
+.v-land-layer__icon--coral {
+  color: var(--vh-accent-coral);
+}
+
+.v-land-layer__pill {
+  padding: 0.2rem 0.55rem;
+  border-radius: 6px;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.v-land-layer__pill--teal {
+  background: rgba(0, 212, 170, 0.12);
+  color: var(--vh-accent-teal-bright);
+  border: 1px solid rgba(0, 212, 170, 0.25);
+}
+
+.v-land-layer__pill--violet {
+  background: rgba(124, 92, 255, 0.12);
+  color: var(--vh-accent-violet-bright);
+  border: 1px solid rgba(124, 92, 255, 0.25);
+}
+
+.v-land-layer__pill--coral {
+  background: rgba(255, 113, 108, 0.12);
+  color: var(--vh-accent-coral);
+  border: 1px solid rgba(255, 113, 108, 0.25);
+}
+
+.v-land-layer__title {
+  margin: 0.25rem 0 0;
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--vh-text);
+}
+
+.v-land-layer__body {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: var(--vh-text-muted);
+}
+
+.v-land-layer__runtimes {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.72rem;
+  line-height: 1.6;
+  color: var(--vh-text-dim);
+  word-break: break-word;
+}
+
+/* ---------- Persona grid ---------- */
+
+.v-land-personas {
+  border-bottom: 1px solid var(--vh-hairline);
+}
+
+.v-land-personas__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .v-land-personas__grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .v-land-personas__grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.v-land-persona {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 1.5rem;
+  border: 1px solid var(--vh-hairline);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.015);
+  text-decoration: none;
+  color: inherit;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+:root:not(.dark) .v-land-persona {
+  background: rgba(4, 34, 28, 0.02);
+}
+
+.v-land-persona:hover {
+  border-color: rgba(0, 212, 170, 0.4);
+  background: rgba(0, 212, 170, 0.04);
+}
+
+.v-land-persona__head {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-bottom: 0.1rem;
+}
+
+.v-land-persona__icon {
+  width: 1.4rem;
+  height: 1.4rem;
+  flex-shrink: 0;
+  color: var(--vh-accent-teal-bright);
+}
+
+.v-land-persona__micro {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vh-accent-teal);
+}
+
+.v-land-persona__title {
+  margin: 0.25rem 0 0;
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 1.0625rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--vh-text);
+}
+
+.v-land-persona__body {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--vh-text-muted);
+}
+
+.v-land-persona__cta {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--vh-accent-teal-bright);
+}
+
+.v-land-persona__arrow {
+  width: 0.95rem;
+  height: 0.95rem;
+  transition: transform 0.2s ease;
+}
+
+.v-land-persona:hover .v-land-persona__arrow {
+  transform: translateX(3px);
+}
+
+/* ---------- Secondary CTA band ---------- */
+
+.v-land-cta {
+  border-bottom: 1px solid var(--vh-hairline);
+  background:
+    radial-gradient(ellipse at top, rgba(0, 212, 170, 0.06), transparent 60%),
+    var(--vh-bg);
+}
+
+:root:not(.dark) .v-land-cta {
+  background:
+    radial-gradient(ellipse at top, rgba(0, 184, 148, 0.05), transparent 60%),
+    var(--vh-bg);
+}
+
+.v-land-cta__inner {
+  text-align: center;
+}
+
+.v-land-cta__heading {
+  margin: 0.25rem auto 0.75rem;
+  max-width: 50rem;
+  font-family: "Space Grotesk", sans-serif;
+  font-size: clamp(1.625rem, 3vw, 2.25rem);
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--vh-text);
+}
+
+.v-land-cta__sub {
+  margin: 0 auto 2rem;
+  max-width: 44rem;
+  font-size: 1rem;
+  line-height: 1.55;
+  color: var(--vh-text-muted);
+}
+
+.v-land-cta__buttons {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.v-land-cta__btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.7rem 1.25rem;
+  border-radius: 9999px;
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.v-land-cta__btn--primary {
+  background: var(--vh-accent-teal);
+  color: #00110e;
+  border: 1px solid var(--vh-accent-teal);
+}
+
+.v-land-cta__btn--primary:hover {
+  background: var(--vh-accent-teal-bright);
+  border-color: var(--vh-accent-teal-bright);
+}
+
+.v-land-cta__btn--ghost {
+  background: transparent;
+  color: var(--vh-text);
+  border: 1px solid var(--vh-hairline);
+}
+
+.v-land-cta__btn--ghost:hover {
+  border-color: var(--vh-accent-teal);
+  color: var(--vh-accent-teal-bright);
+}

--- a/docs/docs/en/index.mdx
+++ b/docs/docs/en/index.mdx
@@ -4,7 +4,17 @@ title: Vivarium
 ---
 
 import { VivariumHero } from '../../components/VivariumHero';
+import {
+  VivariumNumbers,
+  VivariumLayers,
+  VivariumPersonas,
+  VivariumCtaBand,
+} from '../../components/VivariumLandingSections';
 import { VivariumFooter } from '../../components/VivariumFooter';
 
 <VivariumHero />
+<VivariumNumbers />
+<VivariumLayers />
+<VivariumPersonas />
+<VivariumCtaBand />
 <VivariumFooter />

--- a/docs/docs/ja/index.mdx
+++ b/docs/docs/ja/index.mdx
@@ -4,7 +4,17 @@ title: Vivarium
 ---
 
 import { VivariumHero } from '../../components/VivariumHero';
+import {
+  VivariumNumbers,
+  VivariumLayers,
+  VivariumPersonas,
+  VivariumCtaBand,
+} from '../../components/VivariumLandingSections';
 import { VivariumFooter } from '../../components/VivariumFooter';
 
 <VivariumHero lang="ja" />
+<VivariumNumbers lang="ja" />
+<VivariumLayers lang="ja" />
+<VivariumPersonas lang="ja" />
+<VivariumCtaBand lang="ja" />
 <VivariumFooter lang="ja" />

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,11 @@
     "preview": "rspress preview"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.14",
     "@rspress/core": "^2.0.9",
     "jszip": "^3.10.1"
+  },
+  "dependencies": {
+    "lucide-react": "^1.14.0"
   }
 }

--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -56,8 +56,8 @@ const REPRO_MIME: Record<string, string> = {
 //      remaining segments are joined back onto the resolved disk slug as
 //      the asset path under that recipe directory (e.g. repro.wasm,
 //      verdict.json).
-function resolveReproFile(subpath: string): string | null {
-  if (!subpath) subpath = '';
+function resolveReproFile(rawSubpath: string): string | null {
+  const subpath = rawSubpath || '';
 
   // Trailing-slash directory URL → index.html lookup.
   let trailingFile = '';
@@ -73,7 +73,7 @@ function resolveReproFile(subpath: string): string | null {
   const candidates: string[] = [];
   if (segments.length === 0) {
     // Bare `/repro/` — fall through (no candidate).
-  } else if (segments[0]!.startsWith('_')) {
+  } else if (segments[0]?.startsWith('_')) {
     // Shared scaffolding — keep flat lookup.
     candidates.push(joinDisk(segments, trailingFile));
   } else if (segments.length === 1) {
@@ -294,10 +294,7 @@ export default defineConfig({
           // a SW's scope to its own directory unless the response sets
           // this header.
           if (filePath.endsWith('sw.js')) {
-            res.setHeader(
-              'Service-Worker-Allowed',
-              '/vivarium/repro/',
-            );
+            res.setHeader('Service-Worker-Allowed', '/vivarium/repro/');
           }
           createReadStream(filePath).pipe(res);
         });

--- a/docs/scripts/generate-project-pages.ts
+++ b/docs/scripts/generate-project-pages.ts
@@ -18,7 +18,7 @@
 // `bun run dev` / `bun run build` via the chained `prebuild-project-pages`
 // script in docs/package.json.
 
-import { mkdir, readFile, writeFile, rm } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 

--- a/docs/scripts/generate-recipes-index.ts
+++ b/docs/scripts/generate-recipes-index.ts
@@ -33,16 +33,15 @@
 // ADR-0018's minor-revision policy: optional fields can be added without
 // bumping the literal; breaking changes require v2.
 
-import { readdir, readFile, stat, mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // Owner and repository name. Resolved from CI-provided env vars when
 // the script runs in GitHub Actions (so a fork's deploy bundles its
 // own URLs); falls back to the upstream values for local dev.
-const OWNER = process.env['GITHUB_REPOSITORY_OWNER'] ?? 'aletheia-works';
-const REPO_NAME =
-  process.env['GITHUB_REPOSITORY']?.split('/')[1] ?? 'vivarium';
+const OWNER = process.env.GITHUB_REPOSITORY_OWNER ?? 'aletheia-works';
+const REPO_NAME = process.env.GITHUB_REPOSITORY?.split('/')[1] ?? 'vivarium';
 
 const PAGES_BASE = `https://${OWNER}.github.io/${REPO_NAME}`;
 const REPO_BASE = `https://github.com/${OWNER}/${REPO_NAME}`;
@@ -198,7 +197,10 @@ function parseSlug(slug: string): {
   };
 }
 
-async function readTitle(readmePath: string, fallback: string): Promise<string> {
+async function readTitle(
+  readmePath: string,
+  fallback: string,
+): Promise<string> {
   try {
     const md = await readFile(readmePath, 'utf-8');
     const lines = md.split(/\r?\n/);
@@ -325,7 +327,9 @@ async function main(): Promise<void> {
     const layerDir = join(REPO_ROOT, dir);
     const slugs = await listRecipeSlugs(layerDir);
     for (const slug of slugs) {
-      recipes.push(await buildEntry(layer, slug, join(layerDir, slug), overlay));
+      recipes.push(
+        await buildEntry(layer, slug, join(layerDir, slug), overlay),
+      );
     }
   }
   const missingFacets = recipes
@@ -362,11 +366,11 @@ async function main(): Promise<void> {
   const outDir = join(__dirname, '..', 'public', 'api');
   await mkdir(outDir, { recursive: true });
   const outPath = join(outDir, 'recipes.json');
-  await writeFile(outPath, JSON.stringify(out, null, 2) + '\n', 'utf-8');
+  await writeFile(outPath, `${JSON.stringify(out, null, 2)}\n`, 'utf-8');
   const projectsPath = join(outDir, 'projects.json');
   await writeFile(
     projectsPath,
-    JSON.stringify(projectsOut, null, 2) + '\n',
+    `${JSON.stringify(projectsOut, null, 2)}\n`,
     'utf-8',
   );
 
@@ -381,9 +385,7 @@ async function main(): Promise<void> {
     `Wrote ${recipes.length} recipe(s) to ${outPath} ` +
       `(layer 1: ${counts[1]}, layer 2: ${counts[2]}, layer 3: ${counts[3]})`,
   );
-  console.error(
-    `Wrote ${projects.length} project(s) to ${projectsPath}`,
-  );
+  console.error(`Wrote ${projects.length} project(s) to ${projectsPath}`);
 }
 
 main().catch((err) => {

--- a/docs/scripts/prebuild-repro.ts
+++ b/docs/scripts/prebuild-repro.ts
@@ -46,7 +46,7 @@ if (!existsSync(LAYER1_DIR)) {
  */
 function tryBun(): boolean {
   const bunBin = process.argv0;
-  if (!bunBin || !bunBin.toLowerCase().includes('bun')) return false;
+  if (!bunBin?.toLowerCase().includes('bun')) return false;
 
   if (!existsSync(NODE_MODULES)) {
     console.log(`[prebuild-repro] bun install (in ${LAYER1_DIR})`);
@@ -97,9 +97,15 @@ if (!(tryBun() || tryTsc())) {
 
 function findCargo(): string | null {
   const candidates = [
-    process.env['CARGO_HOME'] ? join(process.env['CARGO_HOME']!, 'bin', IS_WIN ? 'cargo.exe' : 'cargo') : null,
-    process.env['HOME'] ? join(process.env['HOME']!, '.cargo', 'bin', IS_WIN ? 'cargo.exe' : 'cargo') : null,
-    process.env['USERPROFILE'] ? join(process.env['USERPROFILE'], '.cargo', 'bin', 'cargo.exe') : null,
+    process.env.CARGO_HOME
+      ? join(process.env.CARGO_HOME!, 'bin', IS_WIN ? 'cargo.exe' : 'cargo')
+      : null,
+    process.env.HOME
+      ? join(process.env.HOME!, '.cargo', 'bin', IS_WIN ? 'cargo.exe' : 'cargo')
+      : null,
+    process.env.USERPROFILE
+      ? join(process.env.USERPROFILE, '.cargo', 'bin', 'cargo.exe')
+      : null,
   ];
   for (const c of candidates) {
     if (c && existsSync(c)) return c;
@@ -110,7 +116,9 @@ function findCargo(): string | null {
 function tryRust(): void {
   const cargo = findCargo();
   if (!cargo) {
-    console.log('[prebuild-repro] Rust skipped — cargo not found. Rust repros will 404 in dev until cargo + wasm32-wasip1 are installed.');
+    console.log(
+      '[prebuild-repro] Rust skipped — cargo not found. Rust repros will 404 in dev until cargo + wasm32-wasip1 are installed.',
+    );
     return;
   }
 
@@ -118,7 +126,10 @@ function tryRust(): void {
   let crateDirs: string[] = [];
   try {
     crateDirs = readdirSync(LAYER1_DIR, { withFileTypes: true })
-      .filter((e) => e.isDirectory() && existsSync(join(LAYER1_DIR, e.name, 'Cargo.toml')))
+      .filter(
+        (e) =>
+          e.isDirectory() && existsSync(join(LAYER1_DIR, e.name, 'Cargo.toml')),
+      )
       .map((e) => join(LAYER1_DIR, e.name));
   } catch {
     return;
@@ -129,23 +140,36 @@ function tryRust(): void {
   const rustup = cargo.replace(/cargo(\.exe)?$/, 'rustup$1');
   if (existsSync(rustup)) {
     console.log('[prebuild-repro] ensuring wasm32-wasip1 target...');
-    spawnSync(rustup, ['target', 'add', 'wasm32-wasip1'], { stdio: 'inherit', shell: false });
+    spawnSync(rustup, ['target', 'add', 'wasm32-wasip1'], {
+      stdio: 'inherit',
+      shell: false,
+    });
   }
 
   for (const dir of crateDirs) {
-    console.log(`[prebuild-repro] cargo build --release --target wasm32-wasip1 (${dir})`);
+    console.log(
+      `[prebuild-repro] cargo build --release --target wasm32-wasip1 (${dir})`,
+    );
     const r = spawnSync(
       cargo,
       ['build', '--release', '--target', 'wasm32-wasip1'],
       { cwd: dir, stdio: 'inherit', shell: false },
     );
     if (r.status !== 0) {
-      console.warn(`  [warn] build failed for ${dir} — Rust repro will 404 in dev.`);
+      console.warn(
+        `  [warn] build failed for ${dir} — Rust repro will 404 in dev.`,
+      );
       continue;
     }
     // Copy the built wasm next to index.html (matches the deploy
     // pipeline's `cp` in .github/workflows/deploy-docs.yml).
-    const wasmFrom = join(dir, 'target', 'wasm32-wasip1', 'release', 'repro.wasm');
+    const wasmFrom = join(
+      dir,
+      'target',
+      'wasm32-wasip1',
+      'release',
+      'repro.wasm',
+    );
     const wasmTo = join(dir, 'repro.wasm');
     if (existsSync(wasmFrom)) {
       copyFileSync(wasmFrom, wasmTo);

--- a/docs/styles/nav-overrides.css
+++ b/docs/styles/nav-overrides.css
@@ -35,12 +35,12 @@ html.dark {
 
 @media (min-width: 960px) {
   .rp-nav__others {
-    display: flex !important;
+    display: flex;
   }
 
   .rp-nav-hamburger,
   .rp-nav-hamburger__md {
-    display: none !important;
+    display: none;
   }
 }
 
@@ -56,8 +56,8 @@ html.dark {
 .rp-sidebar-section-header[class*="active"],
 [class*="rp-sidebar"] a[class*="active"],
 [class*="sidebar"] [class*="link-active"] {
-  color: var(--rp-c-brand) !important;
-  font-weight: 600 !important;
+  color: var(--rp-c-brand);
+  font-weight: 600;
   background: color-mix(in srgb, var(--rp-c-brand) 10%, transparent);
   border-left: 2px solid var(--rp-c-brand);
 }
@@ -65,14 +65,14 @@ html.dark {
 /* Hover state for sidebar links */
 [class*="rp-sidebar"] a:hover,
 [class*="sidebar"] [class*="link"]:hover {
-  color: var(--rp-c-brand) !important;
+  color: var(--rp-c-brand);
 }
 
 /* Outline (right TOC) active marker in teal */
 [class*="rp-outline"] [class*="active"],
 [class*="outline"] [class*="link-active"] {
-  color: var(--rp-c-brand) !important;
-  border-color: var(--rp-c-brand) !important;
+  color: var(--rp-c-brand);
+  border-color: var(--rp-c-brand);
 }
 
 /* Section eyebrows (mono "// ...") in our docs already use teal — make
@@ -81,7 +81,7 @@ html.dark {
 .v-section__eyebrow,
 .v-page-hero__eyebrow,
 .v-next-cta__eyebrow {
-  color: var(--rp-c-brand) !important;
+  color: var(--rp-c-brand);
 }
 
 /* ──────────────────────────────────────────────────────────────────
@@ -95,9 +95,9 @@ html.dark {
  * specificity. We need !important to win the cascade because rspress's
  * stylesheet loads after this one. */
 :root {
-  --rp-sidebar-width: 232px !important;
-  --rp-outline-width: 200px !important;
-  --rp-content-max-width: 1100px !important;
+  --rp-sidebar-width: 232px;
+  --rp-outline-width: 200px;
+  --rp-content-max-width: 1100px;
 }
 
 /* Sidebar links wrap less aggressively; let single-line entries overflow

--- a/mise.toml
+++ b/mise.toml
@@ -78,6 +78,30 @@ description = "Preview the built static docs site"
 dir = "docs"
 run = "bun run preview"
 
+[tasks."docs:fmt"]
+description = "Format docs/ JS/TS/CSS/JSON with Biome (in-place)"
+depends = ["docs:install"]
+dir = "docs"
+run = "bun x --bun biome format --write ."
+
+[tasks."docs:lint"]
+description = "Lint docs/ with Biome (read-only, exits non-zero on errors)"
+depends = ["docs:install"]
+dir = "docs"
+run = "bun x --bun biome lint ."
+
+[tasks."docs:check"]
+description = "Biome check (format + lint + import-organize, read-only)"
+depends = ["docs:install"]
+dir = "docs"
+run = "bun x --bun biome check ."
+
+[tasks."docs:check:fix"]
+description = "Biome check + apply safe + unsafe auto-fixes"
+depends = ["docs:install"]
+dir = "docs"
+run = "bun x --bun biome check --write --unsafe ."
+
 # ── Layer 1 — WASM reproduction sources ──────────────────────────────────
 
 [tasks."repro:install"]
@@ -268,6 +292,12 @@ bun install --frozen-lockfile
 bun run build
 '''
 
+[tasks."ci:docs-check"]
+description = "Local equivalent of test-docs-check.yml (Biome format + lint)"
+depends = ["docs:install"]
+dir = "docs"
+run = "bun x --bun biome check ."
+
 [tasks."ci:repro"]
 description = "Local equivalent of repro-regression.yml (typecheck + build + Playwright)"
 dir = "src/layer1_wasm"
@@ -294,5 +324,5 @@ description = "Lint the most recent commit message against Conventional Commits"
 run = "bunx commitlint --from HEAD~1 --to HEAD --verbose"
 
 [tasks."ci:all"]
-description = "Run all local CI tasks (docs + mcp + repro + commitlint)"
-depends = ["ci:docs", "ci:mcp", "ci:repro", "ci:commitlint"]
+description = "Run all local CI tasks (docs + docs-check + mcp + repro + commitlint)"
+depends = ["ci:docs", "ci:docs-check", "ci:mcp", "ci:repro", "ci:commitlint"]


### PR DESCRIPTION

Three threads bundled because V′ surfaced the dependency chain in this
order: landing-redesign needed icons → icons benefit from a maintained
library → adding any JS tooling implied a formatter/linter baseline.

1. V′ landing redesign. Hero now ends with four below-fold sections
   (numbers strip / three-layer cards / persona grid / secondary CTA
   band) instead of dropping straight to footer. Audit memo lives in
   _context/v_prime_information_design_audit.md (gitignored); Stitch
   wall-bouncing variants saved under _context/stitch-preview/v_prime/
   landing/. Hybrid of v1's faithful copy + v3's evidence-first order.

2. Biome formatter + linter. New docs/biome.json (recommended rules
   + project overrides for noNonNullAssertion / noDescendingSpecificity
   that don't fit this codebase). New mise tasks: docs:fmt / docs:lint
   / docs:check / docs:check:fix; CI mirror via ci:docs-check + new
   test-docs-check.yml workflow. 38 files reformatted, 90+ diagnostics
   cleared. Three biome-ignore comments where the rule is overly
   conservative (label-as-wrapper, div-as-droptarget, swap-window
   button-content).

3. lucide-react migration for icons V′ added. 9 icons total: 7 in
   landing (AppWindow / Container / RotateCcw / Timer / GitBranch /
   Sparkles / Pencil) + 2 in hero (ArrowRight / Lock). Tree-shaken
   per import. WasmGlyph and DockerGlyph stay inline because they
   evoke specific runtime brands, not generic UI affordances.

Side effects, picked up while biome ran:
- Footer dead links (Discord, Privacy = href="#") removed; the audit
  memo had flagged these.
- Hero swap-window split into front (static div) vs non-front (button
  role + keyboard handler) so a11y rules pass cleanly.
- Callout font-size dropped from 1.375rem (pull-quote feel) to body
  size — the maintainer's complaint mid-audit was correct.

Autofix CI: new biome-autofix.yml runs on pull_request_target, applies
biome check --write --unsafe, pushes back to the PR branch. Pattern
mirrors tofu-fmt-autofix.yml exactly. Inline for now; flagged for
promotion to aletheia-works/.github reusables when a second repo
needs the same logic, per AGENTS.md §4.8.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
