### PR TITLE
fix(docs): regain rspress overrides via specificity, not !important

### DIFF
--- a/docs/styles/nav-overrides.css
+++ b/docs/styles/nav-overrides.css
@@ -2,9 +2,17 @@
  * Brand colour overrides — repaint rspress's default blue to the
  * Vivarium teal palette (#00d4aa / #33e5ba) so sidebars, outlines,
  * inline links, and active states all match the landing hero.
+ *
+ * Specificity note: rspress defines its tokens on `:root` (specificity
+ * 0,1,0) in a stylesheet that loads *after* this one. If we also use
+ * `:root` we tie on specificity and lose by load order, so we double
+ * the pseudo-class to `:root:root` (specificity 0,2,0). This is the
+ * smallest specificity bump that beats rspress without needing
+ * `!important`. The same trick is used below for layout vars and for
+ * the dark-mode block.
  * ────────────────────────────────────────────────────────────────── */
 
-:root {
+:root:root {
   --rp-c-brand: #00b894;
   --rp-c-brand-dark: #00d4aa;
   --rp-c-brand-darker: #007a63;
@@ -12,7 +20,7 @@
   --rp-c-brand-lighter: #66f0d0;
 }
 
-html.dark {
+html.dark:root {
   --rp-c-brand: #33e5ba;
   --rp-c-brand-dark: #00d4aa;
   --rp-c-brand-darker: #00b894;
@@ -31,15 +39,19 @@ html.dark {
  * so we lower rspress's threshold here to keep the docs nav consistent
  * with that pattern: from 960px upwards, GitHub + theme toggle live
  * directly in the nav, the hamburger is hidden.
+ *
+ * Specificity: rspress targets `.rp-nav__others` and `.rp-nav-hamburger`
+ * directly (0,1,0). We prepend the parent `.rp-nav` to lift our
+ * selectors to (0,2,0) so they win without `!important`.
  */
 
 @media (min-width: 960px) {
-  .rp-nav__others {
+  .rp-nav .rp-nav__others {
     display: flex;
   }
 
-  .rp-nav-hamburger,
-  .rp-nav-hamburger__md {
+  .rp-nav .rp-nav-hamburger,
+  .rp-nav .rp-nav-hamburger__md {
     display: none;
   }
 }
@@ -49,6 +61,11 @@ html.dark {
  * rspress's default sidebar is functional but plain; align it to the
  * Vivarium home / hero palette so the docs feel cohesive with the
  * landing.
+ *
+ * The selectors below already win specificity against rspress's
+ * single-class selectors (e.g. our `[class*="rp-sidebar"] a[class*="active"]`
+ * is 0,2,1; rspress's `.rp-sidebar-item--active` is 0,1,0), so no
+ * `!important` is needed here.
  * ────────────────────────────────────────────────────────────────── */
 
 /* Active sidebar item — teal accent strip + brighter text */
@@ -89,12 +106,12 @@ html.dark {
  * pre-sidebar pageType:custom layout. rspress's defaults give the
  * sidebars priority and squeeze the content; we flip the budget so
  * content always gets enough room and sidebars truncate text instead.
+ *
+ * Same `:root:root` doubling as the brand-colour block above so we
+ * win the cascade against rspress's `:root` defaults.
  * ────────────────────────────────────────────────────────────────── */
 
-/* CSS custom properties that rspress sets on :root with the same
- * specificity. We need !important to win the cascade because rspress's
- * stylesheet loads after this one. */
-:root {
+:root:root {
   --rp-sidebar-width: 232px;
   --rp-outline-width: 200px;
   --rp-content-max-width: 1100px;


### PR DESCRIPTION

Regression introduced by PR #174's `biome --write --unsafe` pass.
biome stripped `!important` from `docs/styles/nav-overrides.css`,
which silently broke every non-landing page: sidebar reverted to
rspress's wider default, desktop nav (≥960px) collapsed back into
the hamburger, sidebar / outline active markers + content max-width
all reverted off-target.

biome was right to flag !important — it is an anti-pattern and there
is a cleaner fix. The actual cascade problem was specificity ties:
rspress targets `:root` / `.rp-nav__others` / `.rp-nav-hamburger`
with single-class specificity (0,1,0) and loads after our stylesheet,
so a tie meant we lost on load order.

Two surgical specificity bumps fix it without `!important`:

1. CSS variable overrides (brand colours, sidebar/outline/content
   widths) move from `:root { … }` (0,1,0) to `:root:root { … }`
   (0,2,0). The pseudo-class doubling is a documented specificity
   technique; the `:root:root` selector is self-documenting once you
   know the trick, and the file's leading comment explains why.

2. Desktop nav-inline / hide-hamburger media-query rules prepend the
   parent `.rp-nav` selector — `.rp-nav .rp-nav__others` (0,2,0)
   beats rspress's `.rp-nav__others` (0,1,0) cleanly.

The other rules (sidebar active marker, outline active, hover, eyebrow
colour) already had higher specificity than rspress's single-class
selectors — `!important` had been added defensively but was never
load-bearing. Removed.

biome.json: drop the `complexity.noImportantStyles: off` override I
added in the previous attempt. The recommended-on rule now passes
because the file legitimately contains zero `!important`.

Memory note saved (`feedback_biome_unsafe_keeps_important.md`) so the
next biome --unsafe run doesn't repeat the regression.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/176).
* __->__ #176
* #175