### PR TITLE
feat(docs): phase 7 V′ — orientation strip on /repro/compare

### DIFF
--- a/docs/components/VivariumCompareIntro.tsx
+++ b/docs/components/VivariumCompareIntro.tsx
@@ -1,0 +1,109 @@
+import { ClipboardPaste, Link2, Upload } from 'lucide-react';
+import type { ReactNode } from 'react';
+import './vivarium-compare-intro.css';
+
+/** Render a string with `backticks` becoming inline <code> spans.
+ *  Markdown-lite — just enough for the card bodies. */
+function renderInlineCode(text: string): ReactNode {
+  return text.split('`').map((part, i) =>
+    // Odd indices are inside backticks → wrap in <code>.
+    i % 2 === 1 ? <code key={i}>{part}</code> : part,
+  );
+}
+
+/* ============================================================================
+ * Phase 7 V′ — orientation strip for /repro/compare.
+ *
+ * Sits between PageHero and <ReproCompareApp>. Surfaces the three input
+ * modes that ReproCompare supports so a fresh visitor knows up-front
+ * whether they have what they need (a verdict bundle) and which way
+ * to bring it. Detailed how-to (the four-step bundle generation guide)
+ * lives at the bottom of <ReproCompareApp> as before.
+ * ========================================================================== */
+
+type Lang = 'en' | 'ja';
+
+const STRINGS = {
+  en: {
+    eyebrow: '// THREE WAYS TO LOAD A VERDICT',
+    heading: 'Bring a verdict bundle, three ways.',
+    sub: 'Every comparison starts with a Contract v1 verdict from your branch fix. Use whichever path fits how the bundle reached you.',
+    cards: [
+      {
+        micro: 'DROP',
+        title: 'Drop the bundle',
+        body: 'Drag a `branch-fix-verdict.yml` artefact (zip) — or a bare `verdict.json` — onto the page. Original is auto-fetched from the deployed snapshot.',
+      },
+      {
+        micro: 'PASTE',
+        title: 'Paste verdict JSON',
+        body: 'Paste the branch-fix and (optionally) original `verdict.json` payloads directly. Useful when CI logs are the only handle you have.',
+      },
+      {
+        micro: 'SLUG + URL',
+        title: 'Type the slug',
+        body: 'Enter a recipe slug (e.g. `pandas/56679`) — the deployed snapshot loads automatically; supply your branch-fix verdict URL or drop file alongside.',
+      },
+    ],
+  },
+  ja: {
+    eyebrow: '// VERDICT を読み込む 3 つの経路',
+    heading: 'verdict バンドルを、3 つのうち 1 つで持参。',
+    sub: '比較はすべて、自分のブランチ修正から得た Contract v1 verdict から始まる。手元にある形に合った経路を選ぶ。',
+    cards: [
+      {
+        micro: 'DROP',
+        title: 'バンドルをドロップ',
+        body: '`branch-fix-verdict.yml` の artefact (zip) または bare の `verdict.json` をページに投下。オリジナルはデプロイ済みスナップショットから自動取得。',
+      },
+      {
+        micro: 'PASTE',
+        title: 'verdict JSON を貼り付け',
+        body: 'branch-fix と（任意で）オリジナルの `verdict.json` を直接貼り付け。CI ログしか手がかりがない時に有用。',
+      },
+      {
+        micro: 'SLUG + URL',
+        title: 'slug を入力',
+        body: 'レシピ slug（例: `pandas/56679`）を入れるとデプロイ済みスナップショットが自動ロード。branch-fix verdict の URL を入れるかファイルを併用。',
+      },
+    ],
+  },
+} as const;
+
+const ICONS = [Upload, ClipboardPaste, Link2] as const;
+
+export function VivariumCompareIntro({ lang = 'en' }: { lang?: Lang } = {}) {
+  const s = STRINGS[lang];
+  return (
+    <section className="v-compare-intro" aria-labelledby="v-compare-intro-h">
+      <div className="v-compare-intro__inner">
+        <p className="v-compare-intro__eyebrow">{s.eyebrow}</p>
+        <h2 id="v-compare-intro-h" className="v-compare-intro__heading">
+          {s.heading}
+        </h2>
+        <p className="v-compare-intro__sub">{s.sub}</p>
+        <div className="v-compare-intro__grid">
+          {s.cards.map((card, i) => {
+            const Icon = ICONS[i];
+            return (
+              <article key={i} className="v-compare-intro__card">
+                <div className="v-compare-intro__card-head">
+                  <Icon
+                    className="v-compare-intro__icon"
+                    strokeWidth={1.75}
+                    aria-hidden="true"
+                  />
+                  <span className="v-compare-intro__micro">{card.micro}</span>
+                </div>
+                <h3 className="v-compare-intro__card-title">{card.title}</h3>
+                <p className="v-compare-intro__card-body">
+                  {renderInlineCode(card.body)}
+                </p>
+              </article>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/docs/components/vivarium-compare-intro.css
+++ b/docs/components/vivarium-compare-intro.css
@@ -1,0 +1,128 @@
+/* Phase 7 V′ — orientation strip for /repro/compare.
+ *
+ * Inherits --vh-* tokens from vivarium-hero.css (loaded by VivariumHero
+ * on the landing page) AND from page-chrome.css (loaded by every doc
+ * page via PageChrome). The compare page goes through PageChrome, so
+ * the tokens are present.
+ */
+
+.v-compare-intro {
+  width: 100%;
+  margin: 1rem 0 2.5rem;
+  color: var(--vh-text);
+  font-family:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.v-compare-intro__inner {
+  /* Sits inside rspress's content column, so no max-width clamp needed
+   * here — the doc layout already constrains us. */
+  width: 100%;
+}
+
+.v-compare-intro__eyebrow {
+  margin: 0 0 0.6rem;
+  font-family:
+    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vh-accent-teal);
+}
+
+.v-compare-intro__heading {
+  margin: 0 0 0.5rem;
+  font-family: "Space Grotesk", sans-serif;
+  font-size: clamp(1.375rem, 2.5vw, 1.75rem);
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  color: var(--vh-text);
+}
+
+.v-compare-intro__sub {
+  margin: 0 0 1.75rem;
+  max-width: 44rem;
+  font-size: 1rem;
+  line-height: 1.55;
+  color: var(--vh-text-muted);
+}
+
+.v-compare-intro__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 720px) {
+  .v-compare-intro__grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.v-compare-intro__card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1.25rem;
+  border: 1px solid var(--vh-hairline);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.015);
+}
+
+:root:not(.dark) .v-compare-intro__card {
+  background: rgba(4, 34, 28, 0.02);
+}
+
+.v-compare-intro__card-head {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-bottom: 0.15rem;
+}
+
+.v-compare-intro__icon {
+  width: 1.4rem;
+  height: 1.4rem;
+  flex-shrink: 0;
+  color: var(--vh-accent-teal-bright);
+}
+
+.v-compare-intro__micro {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vh-accent-teal);
+}
+
+.v-compare-intro__card-title {
+  margin: 0.25rem 0 0;
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--vh-text);
+}
+
+.v-compare-intro__card-body {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.55;
+  color: var(--vh-text-muted);
+}
+
+.v-compare-intro__card-body code {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.92em;
+  padding: 0.05em 0.3em;
+  background: rgba(0, 212, 170, 0.08);
+  border-radius: 3px;
+  color: var(--vh-accent-teal-bright);
+}
+
+:root:not(.dark) .v-compare-intro__card-body code {
+  background: rgba(0, 212, 170, 0.1);
+  color: var(--vh-accent-teal);
+}

--- a/docs/docs/en/repro/compare.mdx
+++ b/docs/docs/en/repro/compare.mdx
@@ -4,6 +4,7 @@ title: Branch-fix comparison
 ---
 
 import { Page, PageHero } from '../../../components/PageChrome';
+import { VivariumCompareIntro } from '../../../components/VivariumCompareIntro';
 import { ReproCompareApp } from '../../../components/ReproCompare';
 
 <Page>
@@ -12,6 +13,8 @@ import { ReproCompareApp } from '../../../components/ReproCompare';
     title={<>branch-fix vs original.</>}
     sub="Drop a verdict bundle from branch-fix-verdict.yml and see your fix line up against the deployed snapshot. All parsing happens locally — your verdicts never leave this browser."
   />
+
+  <VivariumCompareIntro />
 
   <ReproCompareApp lang="en" />
 </Page>

--- a/docs/docs/ja/repro/compare.mdx
+++ b/docs/docs/ja/repro/compare.mdx
@@ -4,6 +4,7 @@ title: ブランチ修正の比較
 ---
 
 import { Page, PageHero } from '../../../components/PageChrome';
+import { VivariumCompareIntro } from '../../../components/VivariumCompareIntro';
 import { ReproCompareApp } from '../../../components/ReproCompare';
 
 <Page>
@@ -12,6 +13,8 @@ import { ReproCompareApp } from '../../../components/ReproCompare';
     title={<>ブランチ修正 と オリジナルの比較。</>}
     sub="branch-fix-verdict.yml が出力した verdict バンドルをドロップして、自分の修正がデプロイ済みスナップショットに対してどう変化したかを確認できる。すべての解析はブラウザ内で完結する——verdict はこのブラウザの外に出ない。"
   />
+
+  <VivariumCompareIntro lang="ja" />
 
   <ReproCompareApp lang="ja" />
 </Page>


### PR DESCRIPTION

Audit memo §1.3 flagged that the comparison page drops a fresh
visitor straight into <ReproCompareApp> with only a one-line sub.
The component supports three input modes (file drop, JSON paste,
slug+URL) but a visitor has to read the form internals to discover
that. The detailed how-to lives at the bottom of the component as
the four-step bundle generation guide — useful, but only after
they have already decided to commit to the page.

Adds a small `<VivariumCompareIntro>` strip between PageHero and
ReproCompareApp: a three-card grid (Upload / ClipboardPaste / Link2
icons from lucide-react) that names each input mode, what arrives
in it, and a one-sentence orientation. Inline `<code>` rendering
via a tiny `renderInlineCode` helper keeps `manifest.toml` /
`verdict.json` / `pandas/56679` styled correctly without pulling in
a markdown parser for three card bodies.

EN+JA same-PR per ADR-0028. Reuses --vh-* tokens from
vivarium-hero.css / page-chrome.css; no new design surface.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
