### PR TITLE
feat(wasm,mcp,docs): phase 7 B3 — AI-slop verification end-to-end

### DIFF
--- a/docs/docs/en/guide/_meta.json
+++ b/docs/docs/en/guide/_meta.json
@@ -16,6 +16,11 @@
   },
   {
     "type": "file",
+    "name": "compare-branch-fix",
+    "label": "Verify a branch-fix"
+  },
+  {
+    "type": "file",
     "name": "fork-your-own",
     "label": "Run on your own fork"
   },

--- a/docs/docs/en/guide/compare-branch-fix.mdx
+++ b/docs/docs/en/guide/compare-branch-fix.mdx
@@ -1,0 +1,291 @@
+---
+pageType: doc
+title: Verify a branch-fix
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  NumberedList,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · BRANCH-FIX"
+    title="Test a candidate fix end-to-end."
+    sub="Vivarium pairs a recipe (the bug) with a comparison surface (your fix) and a verdict that flips when the fix actually steers around the broken code path. This guide walks the loop end-to-end — Layer 1 (in-browser) and Layer 2/3 (Docker)."
+  />
+
+  <Section
+    eyebrow="// 0 · WHAT THIS LOOP IS FOR"
+    heading="AI-slop verification — does this fix actually work?"
+  >
+    <p>
+      An AI agent (Claude Code, Cursor, Cline, Continue, …) hands you a
+      candidate fix for an upstream bug. The honest question is "did it
+      actually fix the bug, or does it just look like a fix?" Vivarium's
+      branch-fix loop answers that with a <strong>mechanical verdict
+      flip</strong>: feed the fix through the recipe's runtime and check
+      whether the bug still triggers.
+    </p>
+    <Callout>
+      <strong>Verdict semantics.</strong> <code>reproduced</code> = the
+      bug still triggers (your fix did not avoid it).{' '}
+      <code>unreproduced</code> = the bug did not trigger (your fix steered
+      around the broken code path). A working fix flips the verdict from{' '}
+      <code>reproduced</code> to <code>unreproduced</code>.
+    </Callout>
+    <p>
+      Two paths share the same wire shape (Contract v1) and the same
+      comparison surface (<a href="/vivarium/repro/compare">/repro/compare</a>):
+    </p>
+    <NumberedList
+      items={[
+        {
+          lead: 'Path A — Layer 1 (in-browser source substitution).',
+          body: <>You paste an alternative reproduction script onto the recipe page. The recipe's WASM runtime (php-wasm, ruby.wasm, Pyodide) re-runs it in your tab and captures a verdict. No CI required, no Docker required.</>,
+        },
+        {
+          lead: 'Path B — Layer 2/3 (Docker image rebuild).',
+          body: <>You build and push a branch-fix Docker image. A GitHub Actions workflow pulls the image, runs it, captures a verdict, and publishes the artefact bundle for /repro/compare to render.</>,
+        },
+      ]}
+    />
+    <p>
+      Layer dispatch is automatic — the recipe's catalogue entry already
+      knows which layer it is, and the MCP <code>verify_branch_fix</code>{' '}
+      tool returns the right scaffolding for both.
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 1 · PICK A RECIPE"
+    heading="Find the bug in the catalogue."
+  >
+    <p>
+      Two ways in, depending on whether you start from a known recipe or
+      from a paste of the error:
+    </p>
+    <NumberedList
+      items={[
+        {
+          lead: 'I know the recipe.',
+          body: <>Browse <a href="/vivarium/repro/">the gallery</a> and click through to the recipe page. Note the slug (e.g. <code>php-12167</code>).</>,
+        },
+        {
+          lead: 'I have an error message — find the recipe for me.',
+          body: <>Use <a href="/vivarium/repro/match"><code>/repro/match</code></a> (paste the error, get ranked candidates) — or call <code>match_error</code> from your AI agent (same scoring, same surface).</>,
+        },
+      ]}
+    />
+  </Section>
+
+  <Section
+    eyebrow="// 2 · PATH A — LAYER 1"
+    heading="Paste a fix on the recipe page; capture the verdict."
+  >
+    <p>
+      Layer 1 recipes that opt into Path A render a <strong>"Try a
+      fix"</strong> panel underneath the baseline output. Today this is
+      shipped on <a href="/vivarium/repro/php-12167/"><code>php-12167</code></a>;
+      others follow as the shape proves out.
+    </p>
+    <NumberedList
+      items={[
+        {
+          lead: 'Open the recipe page.',
+          body: <>The recipe runs the baseline reproduction first; the panel renders once the original verdict is captured (typically <code>reproduced</code>).</>,
+        },
+        {
+          lead: 'Provide the fix source.',
+          body: <>Three modes: (a) paste the fix into the textarea, (b) supply a publicly fetchable URL (raw GitHub / Gist), or (c) pick a file from disk. CORS errors on URL fetch fall back to paste.</>,
+        },
+        {
+          lead: 'Click Run.',
+          body: <>The recipe's already-loaded WASM runtime executes the substituted source. The panel captures a Contract v1 verdict bundle: <code>branch-fix-verdict.json</code> + <code>original-verdict.json</code>.</>,
+        },
+        {
+          lead: 'Download both verdicts.',
+          body: <>The panel renders one download link per side. Both files conform to <a href="/vivarium/spec/contract-v1">Contract v1</a> — same shape <code>/repro/compare</code> consumes from a Layer 2/3 workflow run.</>,
+        },
+        {
+          lead: 'Drop them on /repro/compare.',
+          body: <>Open <a href="/vivarium/repro/compare">/repro/compare</a> and drag both JSON files onto the drop zone. The page renders side-by-side evidence with the divergent fields highlighted.</>,
+        },
+      ]}
+    />
+    <Callout>
+      <strong>Agent-driven shortcut.</strong> If you call{' '}
+      <code>verify_branch_fix(slug, fix_url)</code> from your AI agent,
+      the tool returns a <code>compare_url</code> with <code>?fix_url=</code>{' '}
+      pre-loaded — open that URL and the recipe page auto-runs the fix.
+      Same for <code>verify_branch_fix(slug, fix_source)</code>{' '}
+      (≤4 KiB inline; longer fixes go via <code>fix_url</code>).
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 3 · PATH B — LAYER 2 / 3"
+    heading="Build an image; run a workflow; drop the artefact."
+  >
+    <p>
+      Layer 2 (Docker catalogue) and Layer 3 (record-replay) recipes can't
+      run in a browser tab — the bug needs a real OS, real sockets, real
+      filesystem. Path B shifts the build to your own infrastructure and
+      uses a GitHub Actions workflow to capture the verdict against your
+      pushed image.
+    </p>
+    <NumberedList
+      items={[
+        {
+          lead: 'Build and push your branch-fix image.',
+          body: <>Apply the AI's candidate fix to your fork, build a Docker image with the recipe's <code>Dockerfile</code>, and push to a registry the GitHub Actions runner can pull from (a public ghcr.io / Docker Hub repo). The image-as-input boundary is the contract — Vivarium does not build your source, you do.</>,
+        },
+        {
+          lead: 'Trigger the comparison workflow.',
+          body: <>Run <code>gh workflow run branch-fix-verdict.yml --repo aletheia-works/vivarium -f slug=&lt;slug&gt; -f branch_image=&lt;your-image-ref&gt;</code>. The workflow pulls your image, runs the reproduction inside it, captures a Contract v1 verdict, and uploads <code>branch-fix-verdict-&lt;slug&gt;-&lt;run_id&gt;</code> as an artefact.</>,
+        },
+        {
+          lead: 'Download the artefact zip.',
+          body: <>From the workflow run page, grab the artefact zip. It contains <code>branch-fix-verdict.json</code> and (when a deployed snapshot exists) <code>original-verdict.json</code>.</>,
+        },
+        {
+          lead: 'Drop the zip on /repro/compare.',
+          body: <>The page parses the zip client-side, validates both verdicts against the Contract v1 schema, and renders side-by-side evidence.</>,
+        },
+      ]}
+    />
+    <Callout>
+      <strong>Agent-driven shortcut.</strong>{' '}
+      <code>verify_branch_fix(slug)</code> on a Layer 2/3 slug returns
+      the <code>gh_command</code> ready to copy-paste. The agent still
+      needs <code>gh</code> auth and registry access to actually run it
+      — but the command itself is constructed for you.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 4 · READ THE VERDICT"
+    heading="What `reproduced` and `unreproduced` mean here."
+  >
+    <p>
+      The branch-fix verdict tells you exactly one thing: did the bug
+      trigger when the fix was in place?
+    </p>
+    <ul>
+      <li>
+        <strong>Original = <code>reproduced</code>, branch-fix ={' '}
+        <code>unreproduced</code>.</strong> The fix avoided the bug. This
+        is the typical "fix works" outcome.
+      </li>
+      <li>
+        <strong>Original = <code>reproduced</code>, branch-fix ={' '}
+        <code>reproduced</code>.</strong> The fix is slop — it did not
+        change the outcome. Iterate on the fix and re-run.
+      </li>
+      <li>
+        <strong>Original = <code>unreproduced</code>, branch-fix ={' '}
+        <code>reproduced</code>.</strong> Regression — your change
+        introduced the bug. Reverse the diff or check what you changed.
+      </li>
+      <li>
+        <strong>Original = <code>unreproduced</code>, branch-fix ={' '}
+        <code>unreproduced</code>.</strong> No change either way. Either
+        the recipe is inactive (upstream already fixed it), or your fix
+        is a no-op against the current runtime.
+      </li>
+    </ul>
+    <Callout>
+      Path A is testing whether your <em>userland</em> fix sidesteps the
+      buggy code path — it is not patching the upstream interpreter.
+      Path B is testing whether your <em>fully-rebuilt image</em> fixes
+      the bug at the binary level. Different weight, same wire format.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 5 · EDGE CASES"
+    heading="When the loop doesn't go to plan."
+  >
+    <ul>
+      <li>
+        <strong>The runtime errored before producing a verdict.</strong>{' '}
+        On Path A, this surfaces as the panel's status line going red
+        with the runtime error text. Common cause: a syntax error in the
+        pasted fix. Fix the syntax and click Run again.
+      </li>
+      <li>
+        <strong>The schema rejected the verdict shape.</strong> /repro/compare
+        validates each verdict against <code>verdict.schema.json</code>{' '}
+        (Contract v1 rev3). The error region shows the JSON path of the
+        bad field. Path A produces well-formed verdicts by construction;
+        if you see this, you are likely dropping a hand-edited file.
+      </li>
+      <li>
+        <strong>CORS blocked the URL fetch.</strong> Public raw GitHub
+        and Gist URLs return CORS-friendly headers. Self-hosted URLs
+        often don't. Fall back to paste mode in that case.
+      </li>
+      <li>
+        <strong>Path B private-registry image.</strong> The runner pulls
+        unauthenticated; private registries are out of scope for v1. Push
+        to a public ref or wait for the pull-credential follow-up.
+      </li>
+      <li>
+        <strong>The fix is so long it doesn't fit in <code>?fix=</code>.</strong>{' '}
+        The inline URL-param cap is 4 KiB. Use <code>?fix_url=</code>{' '}
+        with a Gist or fork URL instead.
+      </li>
+    </ul>
+  </Section>
+
+  <Section
+    eyebrow="// 6 · WHAT'S NEXT"
+    heading="The agent loop you can build on top of this."
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'Loop the agent end-to-end.',
+          body: <>Pipeline: <code>match_error</code> → narrow to a slug → <code>verify_branch_fix</code> → open the compare_url → read the verdict. If <code>reproduced</code>, ask the agent for another candidate. If <code>unreproduced</code>, ship.</>,
+        },
+        {
+          lead: 'Add the recipe for your bug.',
+          body: <>If your bug isn't in the catalogue yet, <a href="/vivarium/guide/write-your-first-reproduction">write the recipe</a>. Path A then opts in with a one-liner.</>,
+        },
+        {
+          lead: 'Wire the verdict into your CI.',
+          body: <>The <a href="/vivarium/guide/integrate-with-your-repo">integrate-with-your-repo</a> path catches verdict drift on every push, not just on demand.</>,
+        },
+      ]}
+    />
+  </Section>
+
+  <Callout>
+    Stuck somewhere in the loop? That's a bug in this guide. File an
+    issue with the slug, the layer, the path (A or B), and the step
+    number you got stuck on.
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      Glossary{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="The vocabulary the rest of these guides assume — Layer, manifest, contract, verdict, evidence, slug — in one place."
+  primary={{ label: 'Glossary →', href: '/vivarium/guide/glossary' }}
+  ghost={{ label: 'Comparison page', href: '/vivarium/repro/compare' }}
+/>
+
+<BottomNote
+  text="VIVARIUM IS PART OF ALETHEIA-WORKS · SEE SOURCE ON GITHUB →"
+  href="https://github.com/aletheia-works/vivarium"
+/>

--- a/docs/docs/en/guide/use-from-ai-agent.mdx
+++ b/docs/docs/en/guide/use-from-ai-agent.mdx
@@ -17,7 +17,7 @@ import {
   <PageHero
     eyebrow="// GUIDE · AI AGENT"
     title="Drive the Vivarium MCP server from Claude Code, Cursor, or Cline."
-    sub="Vivarium ships an MCP (Model Context Protocol) server with four tools that let an agent search and read the entire catalogue programmatically. No HTML scraping of the docs site required."
+    sub="Vivarium ships an MCP (Model Context Protocol) server with five tools that let an agent search the catalogue, read verdict snapshots, and scaffold branch-fix verification end-to-end. No HTML scraping of the docs site required."
   />
 
   <Section
@@ -28,11 +28,12 @@ import {
       The Vivarium MCP server (<code>@aletheia-works/vivarium-mcp</code>)
       speaks{' '}
       <a href="https://modelcontextprotocol.io">Model Context Protocol</a>{' '}
-      over stdio and exposes four tools:{' '}
+      over stdio and exposes five tools:{' '}
       <code>list_recipes</code>, <code>get_recipe</code>,{' '}
-      <code>lookup_verdict</code>, and <code>match_error</code>. An agent
-      can browse the catalogue, fetch metadata for a given recipe, and
-      pull deployed Layer 2 / 3 verdict snapshots through them.
+      <code>lookup_verdict</code>, <code>match_error</code>, and{' '}
+      <code>verify_branch_fix</code>. An agent can browse the catalogue,
+      fetch metadata for a given recipe, pull deployed Layer 2 / 3 verdict
+      snapshots, and scaffold the AI-slop verification loop end-to-end.
     </p>
     <Callout>
       <strong>The first JSR / npm publish is intentionally on hold</strong>.
@@ -139,6 +140,17 @@ bun run build
         token hits against symptom / tags / project / slug, weighted
         per source.
       </li>
+      <li>
+        <strong><code>verify_branch_fix(slug, fix_url? | fix_source?)</code></strong> —
+        scaffolding helper for the AI-slop verification loop (NOT an
+        execution engine). Layer 1 returns Path A: a recipe-page{' '}
+        <code>compare_url</code> with the fix pre-loaded via{' '}
+        <code>?fix_url=</code> or <code>?fix=&lt;base64url&gt;</code>.
+        Layer 2 / 3 returns Path B: a <code>/repro/compare</code> deep-link
+        plus the <code>gh workflow run branch-fix-verdict.yml</code>{' '}
+        command the contributor runs. Full walkthrough:{' '}
+        <a href="/vivarium/en/guide/compare-branch-fix">Verify a branch-fix</a>.
+      </li>
     </ul>
   </Section>
 
@@ -214,8 +226,8 @@ bun run build
           body: <><a href="/vivarium/en/guide/integrate-with-your-repo">Integrate with your own repo</a> sets up the verdict-watch side from your own CI. The two sides — agent + CI — close the loop.</>,
         },
         {
-          lead: 'Verify a branch fix end-to-end (planned in B3).',
-          body: <>Confirming "did my candidate fix flip reproduced → unreproduced?" through the agent in one shot is what Phase 7's B3 sub-stream (ADR-0028) is meant to wire up. For now the <a href="/vivarium/en/repro/compare">comparison page</a> is the manual surface; B3 will let the agent drive it.</>,
+          lead: 'Verify a branch fix end-to-end.',
+          body: <>Confirming "did my candidate fix flip reproduced → unreproduced?" through the agent in one shot is wired up via <code>verify_branch_fix</code> (Phase 7 B3). Full walkthrough: <a href="/vivarium/en/guide/compare-branch-fix">Verify a branch-fix</a>.</>,
         },
       ]}
     />

--- a/docs/docs/ja/guide/_meta.json
+++ b/docs/docs/ja/guide/_meta.json
@@ -16,6 +16,11 @@
   },
   {
     "type": "file",
+    "name": "compare-branch-fix",
+    "label": "ブランチ修正を検証する"
+  },
+  {
+    "type": "file",
     "name": "fork-your-own",
     "label": "自分のフォークで動かす"
   },

--- a/docs/docs/ja/guide/compare-branch-fix.mdx
+++ b/docs/docs/ja/guide/compare-branch-fix.mdx
@@ -1,0 +1,291 @@
+---
+pageType: doc
+title: ブランチ修正を検証する
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  NumberedList,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · BRANCH-FIX"
+    title="候補の修正を end-to-end でテストする。"
+    sub="Vivarium はレシピ（バグ）と比較サーフェス（あなたの修正）と、修正が壊れた code path を実際に回避したときに反転する verdict を組み合わせている。本ガイドはそのループを Layer 1（ブラウザ内）と Layer 2/3（Docker）の両方で end-to-end に歩く。"
+  />
+
+  <Section
+    eyebrow="// 0 · このループの目的"
+    heading="AI-slop 検証 — その修正、本当に動く?"
+  >
+    <p>
+      AI エージェント（Claude Code、Cursor、Cline、Continue、…）が
+      アップストリームのバグに対する候補の修正を提案してきた。素直な問いは
+      「本当にバグを直したのか、それとも修正に見えるだけか?」。Vivarium の
+      branch-fix ループはこれに <strong>機械的な verdict 反転</strong>{' '}
+      で答える: 修正をレシピのランタイムに通し、バグがまだ trigger するか
+      を見るだけ。
+    </p>
+    <Callout>
+      <strong>verdict のセマンティクス。</strong> <code>reproduced</code> は
+      「バグが trigger する（修正は回避できていない）」、{' '}
+      <code>unreproduced</code> は「バグが trigger しない（修正が壊れた
+      code path を回避できた）」。動く修正は verdict を{' '}
+      <code>reproduced</code> から <code>unreproduced</code> に反転させる。
+    </Callout>
+    <p>
+      2 つのパスは同じワイヤ形（Contract v1）と同じ比較サーフェス
+      （<a href="/vivarium/ja/repro/compare">/repro/compare</a>）を共有する:
+    </p>
+    <NumberedList
+      items={[
+        {
+          lead: 'Path A — Layer 1（ブラウザ内ソース置換）。',
+          body: <>レシピページに代替版の再現スクリプトをペーストする。レシピの WASM ランタイム（php-wasm、ruby.wasm、Pyodide）が同じタブで再走させ、verdict をキャプチャする。CI 不要、Docker 不要。</>,
+        },
+        {
+          lead: 'Path B — Layer 2/3（Docker イメージ再ビルド）。',
+          body: <>branch-fix Docker イメージを自分でビルドして push する。GitHub Actions ワークフローがそのイメージを pull して走らせ、verdict をキャプチャ、/repro/compare が描画するアーティファクトバンドルを公開する。</>,
+        },
+      ]}
+    />
+    <p>
+      Layer ディスパッチは自動 — レシピのカタログエントリが既にどの Layer
+      かを知っているし、MCP の <code>verify_branch_fix</code> ツールは両方に
+      正しい足場を返す。
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 1 · レシピを選ぶ"
+    heading="カタログでバグを探す。"
+  >
+    <p>
+      既知のレシピから入るか、エラー文から入るかで 2 通り:
+    </p>
+    <NumberedList
+      items={[
+        {
+          lead: 'レシピが既に分かっている。',
+          body: <><a href="/vivarium/ja/repro/">ギャラリー</a>を眺めて該当レシピのページに入る。slug をメモする（例: <code>php-12167</code>）。</>,
+        },
+        {
+          lead: 'エラー文があるのでレシピを探したい。',
+          body: <><a href="/vivarium/ja/repro/match"><code>/repro/match</code></a>（エラーをペーストして候補をスコア順に表示）を使うか、AI エージェントから <code>match_error</code> を呼ぶ（同じスコアリング、同じサーフェス）。</>,
+        },
+      ]}
+    />
+  </Section>
+
+  <Section
+    eyebrow="// 2 · PATH A — LAYER 1"
+    heading="レシピページに修正をペースト、verdict をキャプチャ。"
+  >
+    <p>
+      Path A に opt-in した Layer 1 レシピは、ベースライン出力の下に{' '}
+      <strong>「Try a fix」</strong> パネルを描画する。現時点では
+      <a href="/vivarium/ja/repro/php-12167/"><code>php-12167</code></a>{' '}
+      に出荷済み、形が proven したら他のレシピも続く。
+    </p>
+    <NumberedList
+      items={[
+        {
+          lead: 'レシピページを開く。',
+          body: <>ベースラインの再現が先に走り、オリジナルの verdict（典型的には <code>reproduced</code>）がキャプチャされたあとパネルが描画される。</>,
+        },
+        {
+          lead: '修正ソースを供給する。',
+          body: <>3 つのモード: (a) textarea にペースト、(b) 公開取得可能 URL（raw GitHub / Gist）を指定、(c) ディスクからファイル選択。URL 取得時の CORS エラーはペーストへフォールバック。</>,
+        },
+        {
+          lead: '実行をクリック。',
+          body: <>レシピが既にロード済みの WASM ランタイムが置換ソースを実行する。パネルは Contract v1 形の verdict バンドルをキャプチャする: <code>branch-fix-verdict.json</code> + <code>original-verdict.json</code>。</>,
+        },
+        {
+          lead: '両方の verdict をダウンロード。',
+          body: <>パネルは side ごとに 1 つずつダウンロードリンクを描画する。両ファイルは <a href="/vivarium/ja/spec/contract-v1">Contract v1</a> に準拠 — Layer 2/3 のワークフロー実行から /repro/compare が消費するのと同じ形。</>,
+        },
+        {
+          lead: '/repro/compare にドロップ。',
+          body: <><a href="/vivarium/ja/repro/compare">/repro/compare</a> を開いて両方の JSON ファイルをドロップゾーンにドラッグする。ページは side-by-side で evidence を描画し、divergent なフィールドをハイライトする。</>,
+        },
+      ]}
+    />
+    <Callout>
+      <strong>エージェント駆動のショートカット。</strong> AI エージェントから
+      <code>verify_branch_fix(slug, fix_url)</code> を呼ぶと、ツールは
+      <code>?fix_url=</code> 事前読み込み済みの <code>compare_url</code>{' '}
+      を返す — その URL を開けばレシピページが自動で fix を走らせる。
+      <code>verify_branch_fix(slug, fix_source)</code> も同様
+      （≤4 KiB inline、長い fix は <code>fix_url</code> 経由）。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 3 · PATH B — LAYER 2 / 3"
+    heading="イメージをビルド、ワークフローを実行、アーティファクトをドロップ。"
+  >
+    <p>
+      Layer 2（Docker カタログ）と Layer 3（record-replay）はブラウザ
+      タブでは走らせられない — バグは本物の OS、本物のソケット、
+      本物のファイルシステムを要求する。Path B はビルドをあなた自身の
+      インフラに移し、push したイメージに対する verdict を GitHub Actions
+      ワークフローでキャプチャする。
+    </p>
+    <NumberedList
+      items={[
+        {
+          lead: 'branch-fix イメージをビルドして push する。',
+          body: <>AI の候補修正を fork に当て、レシピの <code>Dockerfile</code> で Docker イメージをビルドし、GitHub Actions ランナーが pull できるレジストリ（公開 ghcr.io / Docker Hub repo）に push する。image-as-input の境界は contract — Vivarium はあなたのソースをビルドしない、あなたが行う。</>,
+        },
+        {
+          lead: '比較ワークフローを trigger する。',
+          body: <><code>gh workflow run branch-fix-verdict.yml --repo aletheia-works/vivarium -f slug=&lt;slug&gt; -f branch_image=&lt;your-image-ref&gt;</code> を実行する。ワークフローはあなたのイメージを pull、その中で再現を走らせ、Contract v1 verdict をキャプチャ、<code>branch-fix-verdict-&lt;slug&gt;-&lt;run_id&gt;</code> をアーティファクトとしてアップロードする。</>,
+        },
+        {
+          lead: 'アーティファクト zip をダウンロード。',
+          body: <>ワークフロー実行ページからアーティファクト zip を取得する。<code>branch-fix-verdict.json</code> と（デプロイ済みスナップショットがあれば）<code>original-verdict.json</code> が含まれる。</>,
+        },
+        {
+          lead: 'zip を /repro/compare にドロップ。',
+          body: <>ページは zip をクライアントサイドでパースし、両 verdict を Contract v1 スキーマに照らして検証、side-by-side で evidence を描画する。</>,
+        },
+      ]}
+    />
+    <Callout>
+      <strong>エージェント駆動のショートカット。</strong> Layer 2/3 の slug に対する
+      <code>verify_branch_fix(slug)</code> は、コピペ可能な
+      <code>gh_command</code> を返す。エージェントが実際にそれを走らせるには
+      <code>gh</code> 認証とレジストリアクセスが必要 — だがコマンド自体は
+      組み立て済み。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 4 · VERDICT を読む"
+    heading="ここでの `reproduced` と `unreproduced` の意味。"
+  >
+    <p>
+      branch-fix の verdict が伝えるのはちょうど 1 つ: 修正が当たった状態で
+      バグは trigger したか?
+    </p>
+    <ul>
+      <li>
+        <strong>オリジナル = <code>reproduced</code>、branch-fix ={' '}
+        <code>unreproduced</code>。</strong> 修正がバグを回避した。典型的な
+        「修正が動いた」結果。
+      </li>
+      <li>
+        <strong>オリジナル = <code>reproduced</code>、branch-fix ={' '}
+        <code>reproduced</code>。</strong> 修正は slop — outcome を変えていない。
+        修正を反復して再走させる。
+      </li>
+      <li>
+        <strong>オリジナル = <code>unreproduced</code>、branch-fix ={' '}
+        <code>reproduced</code>。</strong> リグレッション — あなたの変更が
+        バグを導入した。diff を巻き戻すか、何を変えたかを確認する。
+      </li>
+      <li>
+        <strong>オリジナル = <code>unreproduced</code>、branch-fix ={' '}
+        <code>unreproduced</code>。</strong> どちらも変化なし。レシピが
+        非アクティブ（アップストリームが既に修正済み）か、現在のランタイム
+        に対してあなたの修正が no-op。
+      </li>
+    </ul>
+    <Callout>
+      Path A は <em>ユーザーランド</em> の修正が壊れた code path を回避するか
+      をテストする — アップストリームのインタプリタにパッチを当てる
+      わけではない。Path B は <em>完全に再ビルドしたイメージ</em>{' '}
+      がバイナリレベルでバグを直すかをテストする。重みは違う、ワイヤ形は同じ。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 5 · エッジケース"
+    heading="ループが計画通り進まないとき。"
+  >
+    <ul>
+      <li>
+        <strong>ランタイムが verdict 生成前にエラーした。</strong>
+        Path A ではパネルのステータスラインが赤になり、ランタイムエラー
+        テキストが出る。よくある原因: ペーストした修正の構文エラー。
+        構文を直して Run をもう一度クリック。
+      </li>
+      <li>
+        <strong>スキーマが verdict 形を reject した。</strong>{' '}
+        /repro/compare は各 verdict を <code>verdict.schema.json</code>{' '}
+        （Contract v1 rev3）に照らして検証する。エラーリージョンは
+        bad フィールドの JSON path を表示する。Path A は構造的に
+        well-formed な verdict を生成するので、これが見えるなら
+        手編集ファイルをドロップしている可能性が高い。
+      </li>
+      <li>
+        <strong>CORS で URL 取得がブロックされた。</strong> 公開 raw GitHub
+        と Gist URL は CORS 対応ヘッダを返す。セルフホスト URL はしばしば
+        返さない。その場合はペーストモードへフォールバック。
+      </li>
+      <li>
+        <strong>Path B のプライベートレジストリイメージ。</strong>{' '}
+        ランナーは認証なしで pull する。プライベートレジストリは v1 の
+        スコープ外。public ref に push するか、pull 認証情報フォロー
+        アップを待つ。
+      </li>
+      <li>
+        <strong>修正が長すぎて <code>?fix=</code> に入らない。</strong>{' '}
+        インライン URL パラメータの上限は 4 KiB。Gist や fork URL を
+        使った <code>?fix_url=</code> を使う。
+      </li>
+    </ul>
+  </Section>
+
+  <Section
+    eyebrow="// 6 · この先"
+    heading="このループの上に組めるエージェントループ。"
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'エージェントループを end-to-end に閉じる。',
+          body: <>パイプライン: <code>match_error</code> → slug に絞り込み → <code>verify_branch_fix</code> → compare_url を開く → verdict を読む。<code>reproduced</code> ならエージェントに別の候補を頼む。<code>unreproduced</code> ならマージへ。</>,
+        },
+        {
+          lead: '自分のバグのレシピを足す。',
+          body: <>カタログにまだあなたのバグが無いなら、<a href="/vivarium/ja/guide/write-your-first-reproduction">レシピを書く</a>。Path A は 1 行で opt-in できる。</>,
+        },
+        {
+          lead: 'verdict を自分の CI と組み合わせる。',
+          body: <><a href="/vivarium/ja/guide/integrate-with-your-repo">自分のリポジトリに統合する</a> パスは push のたびに verdict ドリフトを検出する — オンデマンドだけではない。</>,
+        },
+      ]}
+    />
+  </Section>
+
+  <Callout>
+    どこかで詰まったら、それは本ガイドのバグです。slug、Layer、path（A か B）、
+    詰まったステップ番号を Issue に残してください。
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      用語集{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="残りのガイドが前提にしている語彙 — Layer、manifest、contract、verdict、evidence、slug — を 1 ページにまとめてある。"
+  primary={{ label: '用語集 →', href: '/vivarium/ja/guide/glossary' }}
+  ghost={{ label: '比較ページ', href: '/vivarium/ja/repro/compare' }}
+/>
+
+<BottomNote
+  text="VIVARIUM は ALETHEIA-WORKS の一部 · GitHub でソースを見る →"
+  href="https://github.com/aletheia-works/vivarium"
+/>

--- a/docs/docs/ja/guide/use-from-ai-agent.mdx
+++ b/docs/docs/ja/guide/use-from-ai-agent.mdx
@@ -17,7 +17,7 @@ import {
   <PageHero
     eyebrow="// GUIDE · AI エージェント"
     title="Vivarium MCP サーバを Claude Code / Cursor / Cline から呼ぶ。"
-    sub="Vivarium は MCP（Model Context Protocol）サーバを同梱しており、4 つのツールでカタログ全体をエージェントから機械的に検索・取得できる。docs サイトを HTML スクレイプする必要はない。"
+    sub="Vivarium は MCP（Model Context Protocol）サーバを同梱しており、5 つのツールでカタログ全体をエージェントから機械的に検索・取得・branch-fix 検証できる。docs サイトを HTML スクレイプする必要はない。"
   />
 
   <Section
@@ -27,11 +27,13 @@ import {
     <p>
       Vivarium MCP サーバ (<code>@aletheia-works/vivarium-mcp</code>) は{' '}
       <a href="https://modelcontextprotocol.io">Model Context Protocol</a>{' '}
-      の stdio トランスポート経由で 4 つのツールを提供します:{' '}
+      の stdio トランスポート経由で 5 つのツールを提供します:{' '}
       <code>list_recipes</code>、<code>get_recipe</code>、
-      <code>lookup_verdict</code>、<code>match_error</code>。
+      <code>lookup_verdict</code>、<code>match_error</code>、
+      <code>verify_branch_fix</code>。
       エージェント側からカタログを検索し、特定レシピのメタデータを取得し、
-      Layer 2 / 3 の verdict スナップショットを読めます。
+      Layer 2 / 3 の verdict スナップショットを読み、候補修正の検証フローを
+      組み立てられます。
     </p>
     <Callout>
       <strong>JSR / npm への初回公開は現時点で意図的に保留中</strong>です。
@@ -108,7 +110,7 @@ bun run build
 
   <Section
     eyebrow="// 3 · ツール一覧"
-    heading="4 つすべて MCP の標準 stdio 経由で呼べる。"
+    heading="5 つすべて MCP の標準 stdio 経由で呼べる。"
   >
     <ul>
       <li>
@@ -131,6 +133,15 @@ bun run build
         <strong><code>match_error(text, limit?)</code></strong> — エラー文字列・スタックトレースから
         機械的トークンマッチで候補レシピをスコア順で返す。LLM もファジーマッチも使わず、
         symptom / tags / project / slug への完全一致で重みづけ。
+      </li>
+      <li>
+        <strong><code>verify_branch_fix(slug, fix_url? | fix_source?)</code></strong> —
+        候補修正を検証するための足場ヘルパー（実行エンジンではない）。
+        Layer 1 は Path A — レシピページに <code>?fix_url=</code> / <code>?fix=</code> を
+        事前読み込みした <code>compare_url</code> を返す。Layer 2 / 3 は Path B —
+        <code>gh workflow run branch-fix-verdict.yml</code> コマンドと
+        <code>/repro/compare</code> deep-link を返す。フルウォークスルーは{' '}
+        <a href="/vivarium/ja/guide/compare-branch-fix">「ブランチ修正を検証する」</a>。
       </li>
     </ul>
   </Section>
@@ -207,8 +218,8 @@ bun run build
           body: <><a href="/vivarium/ja/guide/integrate-with-your-repo">自分のリポジトリに統合する</a> でCI 側の verdict 監視が立ち、エージェント側からは MCP でカタログを検索する、という両方向の組み合わせができます。</>,
         },
         {
-          lead: 'ブランチ修正を verdict で検証する（B3 で予定）。',
-          body: <>修正候補が本当に reproduced → unreproduced を起こしたかをエージェントから一発で確認するためのフロー（B3、ADR-0028）が Phase 7 で予定されています。今は <a href="/vivarium/ja/repro/compare">比較ページ</a> を手動で使う形ですが、将来は MCP 経由で完結する見込みです。</>,
+          lead: 'ブランチ修正を verdict で検証する。',
+          body: <>修正候補が本当に reproduced → unreproduced を起こしたかをエージェントから一発で確認するフローは <code>verify_branch_fix</code>（Phase 7 B3 で出荷）に集約されました。フル手順は <a href="/vivarium/ja/guide/compare-branch-fix">「ブランチ修正を検証する」</a>を参照。</>,
         },
       ]}
     />

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -19,6 +19,8 @@ deployed verdict snapshots, without scraping the docs site.
 | `list_recipes(layer?, project?, q?)` | Filtered list of catalogue entries. | All layers (1, 2, 3). |
 | `get_recipe(slug)` | Full metadata for one recipe (title, project, issue, page URL, verdict snapshot URL, GitHub source URL). | All layers. |
 | `lookup_verdict(slug)` | Layer 1 → `kind: "live"` + page URL (verdicts run in the browser). Layer 2/3 → `kind: "snapshot"` with the deployed `verdict.json` contents (verdict, exit code, image digest, stdout, stderr tail). | All layers (Layer 1 returns a stub). |
+| `match_error(text, limit?)` | Mechanical token-overlap ranking of recipes against a pasted error message or stack trace. Synonym table + bounded fuzzy match + multi-language stopwords (Phase 7 A5). | All layers. |
+| `verify_branch_fix(slug, fix_url? \| fix_source?)` | Scaffolding helper for the AI-slop verification loop. Layer 1 → Path A: a recipe-page `compare_url` with the fix pre-loaded. Layer 2/3 → Path B: a `/repro/compare` deep-link plus the `gh workflow run branch-fix-verdict.yml` command. NOT an execution engine — actual reproduction runs in the visitor's browser (Path A) or in GitHub Actions (Path B). | All layers. |
 
 ## Install
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aletheia-works/vivarium-mcp",
   "version": "0.1.0",
-  "description": "MCP server exposing the Vivarium reproduction catalogue (list_recipes, get_recipe, lookup_verdict) to AI agent clients (Claude Code, Cline, Cursor, Continue, etc.).",
+  "description": "MCP server exposing the Vivarium reproduction catalogue (list_recipes, get_recipe, lookup_verdict, match_error, verify_branch_fix) to AI agent clients (Claude Code, Cline, Cursor, Continue, etc.).",
   "license": "Apache-2.0",
   "homepage": "https://github.com/aletheia-works/vivarium/tree/main/packages/mcp-server",
   "bugs": {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -6,6 +6,10 @@
 //   match_error                                 — Phase 6 X.2, mirrors the
 //                                                 docs S.2 matcher
 //                                                 (ADR-0025 §Neutral).
+//   verify_branch_fix                           — Phase 7 B3, deep-link
+//                                                 helper for the AI-slop
+//                                                 verification loop
+//                                                 (ADR-0030).
 //
 // See ADR-0019 §1 for the stdio-transport choice.
 
@@ -31,11 +35,20 @@ import {
   matchError,
   type MatchErrorArgs,
 } from './tools/match_error.js';
+import {
+  VERIFY_BRANCH_FIX_TOOL,
+  verifyBranchFix,
+  type VerifyBranchFixArgs,
+} from './tools/verify_branch_fix.js';
 
 const SERVER_NAME = 'vivarium-mcp';
 // Keep in sync with package.json + jsr.json. Updated by the publish
 // workflow on tag push; unsynced values produce a confusing client
 // experience (the MCP `initialize` response carries this string).
+// Stays at 0.1.0 across the Phase 7 A5 + B3 tool additions because
+// the package has not been published to JSR / npm yet — bumping a
+// pre-publish version literal only confuses clients that ever see
+// a development build.
 const SERVER_VERSION = '0.1.0';
 
 export function createServer(): Server {
@@ -50,6 +63,7 @@ export function createServer(): Server {
       GET_RECIPE_TOOL,
       LOOKUP_VERDICT_TOOL,
       MATCH_ERROR_TOOL,
+      VERIFY_BRANCH_FIX_TOOL,
     ],
   }));
 
@@ -71,6 +85,11 @@ export function createServer(): Server {
           break;
         case 'match_error':
           payload = await matchError(args as unknown as MatchErrorArgs);
+          break;
+        case 'verify_branch_fix':
+          payload = await verifyBranchFix(
+            args as unknown as VerifyBranchFixArgs,
+          );
           break;
         default:
           return {

--- a/packages/mcp-server/src/tools/verify_branch_fix.ts
+++ b/packages/mcp-server/src/tools/verify_branch_fix.ts
@@ -1,0 +1,289 @@
+// Phase 7 B3 — verify_branch_fix tool (5th MCP tool, ADR-0030).
+//
+// A scaffolding helper, NOT an execution engine. Stdio TypeScript can't
+// run php-wasm / pyodide (ADR-0019 §F rejected the headless-browser
+// dependency). The tool's job is to give the agent a deep-link URL plus
+// instructions, leaving execution to the visitor's browser (or to a
+// browser MCP the agent separately drives).
+//
+// Layer dispatch:
+//   - Layer 1 → path A. compare_url is the recipe page itself with
+//     `?fix_url=` or `?fix=<base64url>` so the visitor's browser does
+//     the run. Path A produces a verdict bundle the visitor drops on
+//     /repro/compare.
+//   - Layer 2/3 → path B. compare_url is /repro/compare with `?slug=`
+//     and `?branch_url=` placeholders; gh_command is the
+//     `branch-fix-verdict.yml` workflow_dispatch line the agent runs.
+
+import { getCatalogue } from '../catalogue.js';
+import type { Layer, RecipeEntry } from '../types.js';
+
+export interface VerifyBranchFixArgs {
+  slug: string;
+  fix_url?: string;
+  fix_source?: string;
+}
+
+interface VerifyBranchFixOk {
+  ok: true;
+  slug: string;
+  layer: Layer;
+  path: 'A' | 'B';
+  page_url: string;
+  compare_url: string;
+  gh_command?: string;
+  instructions: string;
+  notes: string[];
+}
+
+interface VerifyBranchFixError {
+  ok: false;
+  error: string;
+}
+
+export type VerifyBranchFixResult = VerifyBranchFixOk | VerifyBranchFixError;
+
+const FIX_INLINE_LIMIT_BYTES = 4 * 1024;
+
+const PIPELINE_DOC_URL =
+  'https://aletheia-works.github.io/vivarium/spec/branch-fix-pipeline';
+const D5_DOC_URL_EN =
+  'https://aletheia-works.github.io/vivarium/guide/compare-branch-fix';
+const D5_DOC_URL_JA =
+  'https://aletheia-works.github.io/vivarium/ja/guide/compare-branch-fix';
+
+/* ------------------------------------------------------------------------ */
+/* base64url (encode is sync; decode in Path A's panel)                     */
+/* ------------------------------------------------------------------------ */
+
+function base64UrlEncode(text: string): string {
+  // Use TextEncoder + manual base64 to preserve UTF-8 semantics; Node's
+  // Buffer is available but the package targets a portable ES surface.
+  const bytes = new TextEncoder().encode(text);
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  // Bun and Node both expose `btoa` globally; the package's `engines`
+  // pins them.
+  const b64 =
+    typeof btoa === 'function'
+      ? btoa(bin)
+      : Buffer.from(bytes).toString('base64');
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/* ------------------------------------------------------------------------ */
+/* Compare-URL builders                                                     */
+/* ------------------------------------------------------------------------ */
+
+interface PathAUrlInputs {
+  pageUrl: string;
+  fix_url?: string;
+  fix_source?: string;
+}
+
+interface PathBUrlInputs {
+  slug: string;
+  // Layer 2/3 deep-link template — visitor pastes the artefact URL
+  // into branch_url after the workflow run finishes.
+  compareBaseUrl: string;
+}
+
+function pathACompareUrl(inputs: PathAUrlInputs): string {
+  const u = new URL(inputs.pageUrl);
+  if (inputs.fix_url) u.searchParams.set('fix_url', inputs.fix_url);
+  else if (inputs.fix_source) u.searchParams.set('fix', base64UrlEncode(inputs.fix_source));
+  return u.toString();
+}
+
+function pathBCompareUrl(inputs: PathBUrlInputs): string {
+  const u = new URL(inputs.compareBaseUrl);
+  u.searchParams.set('slug', inputs.slug);
+  return u.toString();
+}
+
+function deriveCompareBaseFromPageUrl(pageUrl: string): string {
+  // page_url is e.g. https://aletheia-works.github.io/vivarium/repro/<slug>/.
+  // The compare page sits at /repro/compare under both /en and /ja chrome.
+  // Default to no-locale (legacy /repro/compare) — R.3 mounts the same
+  // component in both locales.
+  try {
+    const u = new URL(pageUrl);
+    return `${u.origin}/vivarium/repro/compare`;
+  } catch {
+    return 'https://aletheia-works.github.io/vivarium/repro/compare';
+  }
+}
+
+/* ------------------------------------------------------------------------ */
+/* Instructions                                                             */
+/* ------------------------------------------------------------------------ */
+
+interface InstructionInputs {
+  recipe: RecipeEntry;
+  path: 'A' | 'B';
+  compareUrl: string;
+  ghCommand?: string;
+  fixSupplied: boolean;
+}
+
+function buildInstructions(inputs: InstructionInputs): string {
+  if (inputs.path === 'A') {
+    const headline = inputs.fixSupplied
+      ? `Open ${inputs.compareUrl} in a browser. The fix is pre-loaded — the page will run it through php-wasm/ruby.wasm/pyodide and capture a Contract v1 verdict.`
+      : `Open ${inputs.compareUrl} in a browser, paste the candidate fix into the "Try a fix" panel, and click Run. The page will run it through the recipe's WASM runtime and capture a verdict.`;
+    return [
+      `**${inputs.recipe.title}** — Layer 1 (Path A: in-browser source substitution).`,
+      '',
+      headline,
+      '',
+      'After the run completes:',
+      `1. Download \`branch-fix-verdict.json\` and \`original-verdict.json\` from the panel.`,
+      `2. Drop both onto ${deriveCompareBaseFromPageUrl(inputs.recipe.page_url)} for side-by-side review.`,
+      '',
+      `**Verdict semantics.** \`reproduced\` = bug still triggers (fix is slop). \`unreproduced\` = bug avoided (fix steers around the broken code path). See [the walkthrough](${D5_DOC_URL_EN}) ([日本語版](${D5_DOC_URL_JA})) for the full loop.`,
+    ].join('\n');
+  }
+
+  // Path B
+  return [
+    `**${inputs.recipe.title}** — Layer ${inputs.recipe.layer} (Path B: Docker image-based).`,
+    '',
+    `Build and push your branch-fix Docker image to a public registry the GitHub Actions runner can pull. Then run:`,
+    '',
+    '```bash',
+    inputs.ghCommand ?? '(gh command unavailable)',
+    '```',
+    '',
+    `Once the workflow finishes:`,
+    `1. Download the \`branch-fix-verdict-${inputs.recipe.slug}-<run_id>\` artefact from the workflow run.`,
+    `2. Drop the zip onto ${inputs.compareUrl} for side-by-side review (or pass \`?branch_url=\` with a publicly fetchable URL of the verdict JSON).`,
+    '',
+    `**Verdict semantics.** A working fix flips the verdict from \`reproduced\` to \`unreproduced\`. Pipeline spec: ${PIPELINE_DOC_URL}. Walkthrough: [English](${D5_DOC_URL_EN}) · [日本語](${D5_DOC_URL_JA}).`,
+  ].join('\n');
+}
+
+/* ------------------------------------------------------------------------ */
+/* Tool                                                                     */
+/* ------------------------------------------------------------------------ */
+
+export async function verifyBranchFix(
+  args: VerifyBranchFixArgs,
+): Promise<VerifyBranchFixResult> {
+  const slug = args.slug?.trim();
+  if (!slug) {
+    return { ok: false, error: 'missing required argument: slug' };
+  }
+
+  if (args.fix_url && args.fix_source) {
+    return {
+      ok: false,
+      error:
+        'fix_url and fix_source are mutually exclusive — supply at most one',
+    };
+  }
+  if (args.fix_source && args.fix_source.length > FIX_INLINE_LIMIT_BYTES) {
+    return {
+      ok: false,
+      error: `fix_source exceeds the ${FIX_INLINE_LIMIT_BYTES}-byte inline limit; use fix_url with a publicly fetchable URL instead`,
+    };
+  }
+
+  const { recipes } = await getCatalogue();
+  const recipe = recipes.find((r) => r.slug === slug);
+  if (!recipe) {
+    return { ok: false, error: `recipe not found: ${slug}` };
+  }
+
+  const notes: string[] = [];
+
+  if (recipe.layer === 1) {
+    if (args.fix_url || args.fix_source) {
+      // Path A inputs are valid; pre-load.
+    } else {
+      notes.push(
+        'no fix_url or fix_source supplied — compare_url opens the recipe page; the user pastes manually into the "Try a fix" panel',
+      );
+    }
+    const compareUrl = pathACompareUrl({
+      pageUrl: recipe.page_url,
+      fix_url: args.fix_url,
+      fix_source: args.fix_source,
+    });
+    const instructions = buildInstructions({
+      recipe,
+      path: 'A',
+      compareUrl,
+      fixSupplied: Boolean(args.fix_url || args.fix_source),
+    });
+    return {
+      ok: true,
+      slug: recipe.slug,
+      layer: recipe.layer,
+      path: 'A',
+      page_url: recipe.page_url,
+      compare_url: compareUrl,
+      instructions,
+      notes,
+    };
+  }
+
+  // Layer 2 / 3 → Path B.
+  if (args.fix_url || args.fix_source) {
+    notes.push(
+      'fix_url and fix_source are ignored for Layer 2/3 recipes — the contributor builds and pushes a Docker image themselves; see ADR-0020 §1 for the image-as-input boundary',
+    );
+  }
+  const compareBase = deriveCompareBaseFromPageUrl(recipe.page_url);
+  const compareUrl = pathBCompareUrl({
+    slug: recipe.slug,
+    compareBaseUrl: compareBase,
+  });
+  const ghCommand = `gh workflow run branch-fix-verdict.yml --repo aletheia-works/vivarium -f slug=${recipe.slug} -f branch_image=<your-image-ref>`;
+  const instructions = buildInstructions({
+    recipe,
+    path: 'B',
+    compareUrl,
+    ghCommand,
+    fixSupplied: false,
+  });
+  return {
+    ok: true,
+    slug: recipe.slug,
+    layer: recipe.layer,
+    path: 'B',
+    page_url: recipe.page_url,
+    compare_url: compareUrl,
+    gh_command: ghCommand,
+    instructions,
+    notes,
+  };
+}
+
+export const VERIFY_BRANCH_FIX_TOOL = {
+  name: 'verify_branch_fix',
+  description:
+    "Generate a deep-link URL and instructions for verifying a candidate branch-fix against a Vivarium recipe. SCAFFOLDING HELPER, not an execution engine — actual reproduction runs in the visitor's browser (Layer 1) or in GitHub Actions (Layer 2/3). Layer dispatch is automatic from the recipe's catalogue layer. Layer 1 returns Path A: a recipe-page URL with the fix pre-loaded via `?fix_url=` or `?fix=<base64url>`. Layer 2/3 returns Path B: a `/repro/compare` URL plus the `gh workflow run branch-fix-verdict.yml` command the contributor runs to capture a verdict against their pushed Docker image. Use after `match_error` or `list_recipes` has narrowed to a specific slug. Pair with the D-5 walkthrough page (https://aletheia-works.github.io/vivarium/guide/compare-branch-fix) for the full AI-slop verification loop.",
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      slug: {
+        type: 'string' as const,
+        pattern: '^[a-z0-9]+(-[a-z0-9]+)*$',
+        description:
+          "Kebab-case recipe slug (e.g. 'php-12167', 'bash-local-shadows-exit'). Same convention as Manifest v1's `slug`.",
+      },
+      fix_url: {
+        type: 'string' as const,
+        description:
+          "Public URL of the candidate fix source (raw.githubusercontent.com / gist.githubusercontent.com). Layer 1 only — embedded in the returned compare_url as `?fix_url=`. Mutually exclusive with fix_source.",
+      },
+      fix_source: {
+        type: 'string' as const,
+        maxLength: FIX_INLINE_LIMIT_BYTES,
+        description:
+          "Inline candidate fix source (max 4096 bytes). Layer 1 only — embedded in the returned compare_url as `?fix=<base64url>`. Mutually exclusive with fix_url. Long fixes should use fix_url instead.",
+      },
+    },
+    required: ['slug'],
+  },
+} as const;

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -9,6 +9,7 @@ import { getRecipe } from '../src/tools/get_recipe.ts';
 import { listRecipes } from '../src/tools/list_recipes.ts';
 import { lookupVerdict } from '../src/tools/lookup_verdict.ts';
 import { matchError } from '../src/tools/match_error.ts';
+import { verifyBranchFix } from '../src/tools/verify_branch_fix.ts';
 
 const FIXTURE_INDEX = {
   index: 'v1',
@@ -297,6 +298,110 @@ describe('match_error', () => {
       // Direct exact hit — `via` and `input` must be absent.
       assert.equal(exactSymptom!.via, undefined);
       assert.equal(exactSymptom!.input, undefined);
+    }
+  });
+});
+
+describe('verify_branch_fix', () => {
+  it('returns ok:false on missing slug', async () => {
+    const r = await verifyBranchFix({ slug: '' });
+    assert.equal(r.ok, false);
+  });
+
+  it('returns ok:false on unknown slug', async () => {
+    const r = await verifyBranchFix({ slug: 'nonexistent-recipe' });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /not found/);
+  });
+
+  it('rejects fix_url + fix_source supplied together', async () => {
+    const r = await verifyBranchFix({
+      slug: 'pandas-56679',
+      fix_url: 'https://example.invalid/fix.py',
+      fix_source: 'print("fix")',
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /mutually exclusive/);
+  });
+
+  it('rejects fix_source larger than 4 KiB', async () => {
+    const big = 'x'.repeat(5000);
+    const r = await verifyBranchFix({ slug: 'pandas-56679', fix_source: big });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /4096-byte inline limit/);
+  });
+
+  it('Layer 1 → path A, no fix supplied → notes the manual paste flow', async () => {
+    const r = await verifyBranchFix({ slug: 'pandas-56679' });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.path, 'A');
+      assert.equal(r.layer, 1);
+      assert.equal(r.compare_url, 'https://example.invalid/repro/pandas-56679/');
+      assert.equal(r.gh_command, undefined);
+      assert.match(r.instructions, /paste the candidate fix/);
+      assert.ok(
+        r.notes.some((n) => /no fix_url or fix_source supplied/.test(n)),
+      );
+    }
+  });
+
+  it('Layer 1 → path A with fix_url embeds it in compare_url', async () => {
+    const r = await verifyBranchFix({
+      slug: 'pandas-56679',
+      fix_url: 'https://raw.githubusercontent.com/user/fork/branch/repro.py',
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.match(r.compare_url, /[?&]fix_url=https/);
+      assert.match(r.instructions, /pre-loaded/);
+    }
+  });
+
+  it('Layer 1 → path A with fix_source base64url-encodes it as ?fix=', async () => {
+    const r = await verifyBranchFix({
+      slug: 'pandas-56679',
+      fix_source: 'print("fixed")',
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      const u = new URL(r.compare_url);
+      const fix = u.searchParams.get('fix');
+      assert.ok(fix, 'fix param should be present');
+      // Decode and check.
+      const padded = fix!.replace(/-/g, '+').replace(/_/g, '/');
+      const padLen = (4 - (padded.length % 4)) % 4;
+      const b64 = padded + '='.repeat(padLen);
+      const decoded = Buffer.from(b64, 'base64').toString('utf-8');
+      assert.equal(decoded, 'print("fixed")');
+    }
+  });
+
+  it('Layer 2 → path B returns gh_command and ignores fix_source', async () => {
+    const r = await verifyBranchFix({
+      slug: 'bash-local-shadows-exit',
+      fix_source: 'echo not used on layer 2',
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.path, 'B');
+      assert.equal(r.layer, 2);
+      assert.match(r.gh_command!, /gh workflow run branch-fix-verdict\.yml/);
+      assert.match(r.gh_command!, /-f slug=bash-local-shadows-exit/);
+      assert.match(r.compare_url, /\/repro\/compare\?slug=bash-local-shadows-exit/);
+      assert.ok(
+        r.notes.some((n) => /ignored for Layer 2\/3/.test(n)),
+      );
+    }
+  });
+
+  it('Layer 3 → path B', async () => {
+    const r = await verifyBranchFix({ slug: 'lost-update' });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.path, 'B');
+      assert.equal(r.layer, 3);
+      assert.match(r.gh_command!, /-f slug=lost-update/);
     }
   });
 });

--- a/src/layer1_wasm/_shared/path_a.ts
+++ b/src/layer1_wasm/_shared/path_a.ts
@@ -1,0 +1,601 @@
+// Phase 7 B3 — R.2 Path A (Layer 1 source-substitution branch-fix).
+//
+// Recipe pages opt in by calling `enablePathA({...})` at the end of
+// their main run. The helper:
+//   1. Mounts a "Try a fix" panel into the recipe page
+//      (look for `<section id="path-a-mount">`).
+//   2. Reads the page's baseline run (captured by the recipe and passed
+//      in via `baseline`) and prepares it as `original-verdict.json`.
+//   3. Accepts a fix source via paste / public URL fetch / file pick / URL
+//      params (`?fix=` base64url, `?fix_url=`).
+//   4. Runs the fix via the recipe's `runFix` callback (which re-uses the
+//      already-loaded WASM interpreter), captures it as
+//      `branch-fix-verdict.json`.
+//   5. Exposes both as downloadable `.json` files the visitor drops on
+//      `/repro/compare`.
+//
+// The captured shape is Contract v1 (Layer 2/3 verdict shape) so R.3
+// consumes Path A's output without schema branches. Layer-1-specific
+// fields are synthesised:
+//   - `image_tag`   = `layer1:<slug>:<sha256(source)[0..12]>`
+//   - `image_digest` = empty string (schema explicitly allows empty)
+//   - `stderr_tail`  = empty string (Layer 1 has no stderr stream)
+//
+// Design decisions in ADR-0030 (private memo).
+
+const FIX_PARAM_LIMIT_BYTES = 4 * 1024;
+
+export type VerdictLiteral = "reproduced" | "unreproduced";
+
+/** Captured run produced by the recipe's `runFix` / `baseline` callbacks. */
+export interface PathACapturedRun {
+  /** Process exit code (0 for clean exit). */
+  exitCode: number;
+  /** Verdict literal for this run. */
+  verdict: VerdictLiteral;
+  /** Human-readable explanation, surfaced in the recipe-page UI and
+   *  in the captured verdict's metadata. */
+  message: string;
+  /** Stdout string (typically JSON-stringified result). Goes into the
+   *  Contract v1 `stdout` field. */
+  stdout: string;
+}
+
+/** Contract v1 verdict shape (mirrors Layer 2/3 verdict.json shape). */
+export interface ContractV1Verdict {
+  contract: "v1";
+  verdict: VerdictLiteral;
+  exit_code: number;
+  image_tag: string;
+  image_digest: string;
+  captured_at: string;
+  stdout: string;
+  stderr_tail: string;
+}
+
+export interface PathAStrings {
+  /** Section heading rendered above the panel. */
+  heading: string;
+  /** Lead paragraph below the heading. */
+  lead: string;
+  pasteLabel: string;
+  pastePlaceholder: string;
+  urlLabel: string;
+  urlPlaceholder: string;
+  filePickLabel: string;
+  runButton: string;
+  running: string;
+  resetButton: string;
+  resetHelp: string;
+  resultHeading: string;
+  baselineLabel: string;
+  branchLabel: string;
+  downloadOriginal: string;
+  downloadBranchFix: string;
+  compareLink: string;
+  errorEmpty: string;
+  errorTooLarge: string;
+  errorFetchFailed: string;
+  errorRunFailed: string;
+  semanticsHeading: string;
+  semanticsBody: string;
+  panelEyebrow: string;
+}
+
+const DEFAULT_STRINGS: PathAStrings = {
+  panelEyebrow: "// PATH A · LAYER 1 BRANCH-FIX",
+  heading: "Try a fix in this browser tab",
+  lead:
+    "Paste an alternative version of the reproduction script — a userland fix your AI agent proposed, for example — and re-run it against the same WASM runtime. The verdict tells you whether the fix avoided the bug.",
+  pasteLabel: "Paste fix source",
+  pastePlaceholder: "<?php\n// fixed reproduction…",
+  urlLabel: "or fetch from URL (raw GitHub / Gist)",
+  urlPlaceholder: "https://raw.githubusercontent.com/<user>/<fork>/<branch>/<path>",
+  filePickLabel: "or pick a file",
+  runButton: "Run fix",
+  running: "Running…",
+  resetButton: "Reset",
+  resetHelp: "Clears the loaded fix and the captured branch-fix verdict.",
+  resultHeading: "Captured runs",
+  baselineLabel: "Original (baseline)",
+  branchLabel: "Branch-fix (your source)",
+  downloadOriginal: "Download original-verdict.json",
+  downloadBranchFix: "Download branch-fix-verdict.json",
+  compareLink: "Compare side-by-side on /repro/compare →",
+  errorEmpty:
+    "No fix source loaded. Paste a script, supply a URL, or pick a file.",
+  errorTooLarge:
+    "Fix source exceeds the URL-param limit (4 KiB) when used as `?fix=`. Loading inline anyway — but for sharing prefer `?fix_url=`.",
+  errorFetchFailed: "Could not fetch the URL (CORS or network error).",
+  errorRunFailed: "The runtime errored before producing a verdict.",
+  semanticsHeading: "What the verdict means",
+  semanticsBody:
+    "`reproduced` means the bug still triggers — your fix did not avoid the bug. `unreproduced` means the bug did not trigger — your fix steered around the broken code path.",
+};
+
+const DEFAULT_STRINGS_JA: Partial<PathAStrings> = {
+  panelEyebrow: "// PATH A · LAYER 1 BRANCH-FIX",
+  heading: "このブラウザタブで fix を試す",
+  lead:
+    "再現スクリプトの代替版 (例: AI エージェントが提案したユーザーランドの fix) をペーストし、同じ WASM ランタイムで再走させる。verdict が fix がバグを回避できたかどうかを教える。",
+  pasteLabel: "fix ソースをペースト",
+  pastePlaceholder: "<?php\n// 修正版の再現…",
+  urlLabel: "または URL から取得 (raw GitHub / Gist)",
+  urlPlaceholder: "https://raw.githubusercontent.com/<user>/<fork>/<branch>/<path>",
+  filePickLabel: "またはファイルを選択",
+  runButton: "fix を実行",
+  running: "実行中…",
+  resetButton: "リセット",
+  resetHelp: "読み込まれた fix とキャプチャされた branch-fix verdict をクリアする。",
+  resultHeading: "キャプチャされた run",
+  baselineLabel: "オリジナル (ベースライン)",
+  branchLabel: "Branch-fix (あなたのソース)",
+  downloadOriginal: "original-verdict.json をダウンロード",
+  downloadBranchFix: "branch-fix-verdict.json をダウンロード",
+  compareLink: "/repro/compare で side-by-side 比較 →",
+  errorEmpty:
+    "fix ソースが読み込まれていない。スクリプトをペーストするか、URL を指定するか、ファイルを選択する。",
+  errorTooLarge:
+    "fix ソースが `?fix=` の URL パラメータ上限 (4 KiB) を超過。インラインで読み込みは継続するが、共有時は `?fix_url=` を推奨。",
+  errorFetchFailed: "URL を取得できなかった (CORS またはネットワークエラー)。",
+  errorRunFailed: "ランタイムが verdict 生成前にエラーした。",
+  semanticsHeading: "verdict の意味",
+  semanticsBody:
+    "`reproduced` はバグがまだ trigger される — fix がバグを回避できていない。`unreproduced` はバグが trigger されない — fix が壊れた code path を回避できている。",
+};
+
+export interface PathAOptions {
+  /** Recipe slug — used in the synthesised image_tag and the
+   *  comparison-page deep-link. */
+  slug: string;
+  /** The recipe's default reproduction source. Used to compute a
+   *  source-hash differentiator and as the placeholder text in the
+   *  panel's textarea. */
+  baselineSource: string;
+  /** The captured baseline run (the recipe's normal verdict). The
+   *  panel renders this as the "original" side for downloads. */
+  baseline: PathACapturedRun;
+  /** Run the substituted source through the same WASM interpreter
+   *  the recipe page already loaded. The callback owns the actual
+   *  re-run. */
+  runFix: (source: string) => Promise<PathACapturedRun>;
+  /** UI strings. Pages can override per-language; the panel does not
+   *  read `<html lang>` itself to keep the surface explicit. */
+  strings?: Partial<PathAStrings>;
+  /** Mount selector. Defaults to `#path-a-mount`. */
+  mountSelector?: string;
+  /** Override `window.location` for tests. */
+  locationOverride?: { search: string; origin: string; pathname: string };
+}
+
+interface RuntimeState {
+  baseline: PathACapturedRun;
+  baselineSource: string;
+  branchSource: string | null;
+  branchRun: PathACapturedRun | null;
+  busy: boolean;
+}
+
+/* ------------------------------------------------------------------------ */
+/* Hash + base64url helpers                                                 */
+/* ------------------------------------------------------------------------ */
+
+async function sha256Hex(text: string): Promise<string> {
+  const enc = new TextEncoder();
+  const digest = await crypto.subtle.digest("SHA-256", enc.encode(text));
+  const bytes = new Uint8Array(digest);
+  let hex = "";
+  for (const b of bytes) hex += b.toString(16).padStart(2, "0");
+  return hex;
+}
+
+function base64UrlDecode(input: string): string {
+  let padded = input.replace(/-/g, "+").replace(/_/g, "/");
+  const rem = padded.length % 4;
+  if (rem === 2) padded += "==";
+  else if (rem === 3) padded += "=";
+  else if (rem !== 0) throw new Error("invalid base64url length");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+/* ------------------------------------------------------------------------ */
+/* Verdict synthesis                                                        */
+/* ------------------------------------------------------------------------ */
+
+async function captureToVerdict(
+  slug: string,
+  source: string,
+  capture: PathACapturedRun,
+): Promise<ContractV1Verdict> {
+  const hash = (await sha256Hex(source)).slice(0, 12);
+  return {
+    contract: "v1",
+    verdict: capture.verdict,
+    exit_code: capture.exitCode,
+    image_tag: `layer1:${slug}:${hash}`,
+    image_digest: "",
+    captured_at: new Date().toISOString(),
+    stdout: capture.stdout,
+    stderr_tail: "",
+  };
+}
+
+/* ------------------------------------------------------------------------ */
+/* Panel                                                                    */
+/* ------------------------------------------------------------------------ */
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  attrs: Record<string, string | undefined> = {},
+  ...children: (Node | string)[]
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs)) {
+    if (v == null) continue;
+    if (k === "class") node.className = v;
+    else node.setAttribute(k, v);
+  }
+  for (const c of children) {
+    node.append(typeof c === "string" ? document.createTextNode(c) : c);
+  }
+  return node;
+}
+
+interface PanelHandle {
+  setStatus(text: string, kind: "info" | "error" | "ok"): void;
+  setBranchRun(run: PathACapturedRun, branchVerdict: ContractV1Verdict): void;
+  resetBranch(): void;
+  setBusy(busy: boolean): void;
+  pasteEl: HTMLTextAreaElement;
+  urlEl: HTMLInputElement;
+  fileEl: HTMLInputElement;
+  runBtn: HTMLButtonElement;
+  resetBtn: HTMLButtonElement;
+}
+
+function buildPanel(
+  mount: HTMLElement,
+  s: PathAStrings,
+  state: RuntimeState,
+  originalVerdict: ContractV1Verdict,
+  slug: string,
+): PanelHandle {
+  mount.classList.add("vh-path-a");
+
+  const panelEyebrow = el(
+    "p",
+    { class: "vh-path-a__eyebrow" },
+    s.panelEyebrow,
+  );
+  const heading = el("h2", { class: "vh-path-a__heading" }, s.heading);
+  const lead = el("p", { class: "vh-path-a__lead" }, s.lead);
+
+  const pasteLabel = el("span", { class: "vh-path-a__field-label" }, s.pasteLabel);
+  const pasteEl = el("textarea", {
+    class: "vh-path-a__textarea",
+    rows: "10",
+    spellcheck: "false",
+    placeholder: s.pastePlaceholder,
+  }) as HTMLTextAreaElement;
+
+  const pasteField = el("label", { class: "vh-path-a__field" }, pasteLabel, pasteEl);
+
+  const urlLabel = el("span", { class: "vh-path-a__field-label" }, s.urlLabel);
+  const urlEl = el("input", {
+    class: "vh-path-a__input",
+    type: "url",
+    placeholder: s.urlPlaceholder,
+    spellcheck: "false",
+    autocapitalize: "off",
+    autocorrect: "off",
+  }) as HTMLInputElement;
+  const urlField = el("label", { class: "vh-path-a__field" }, urlLabel, urlEl);
+
+  const fileLabel = el("span", { class: "vh-path-a__field-label" }, s.filePickLabel);
+  const fileEl = el("input", {
+    class: "vh-path-a__file",
+    type: "file",
+    accept: ".php,.rb,.py,.txt,.text,text/plain",
+  }) as HTMLInputElement;
+  const fileField = el("label", { class: "vh-path-a__field" }, fileLabel, fileEl);
+
+  const runBtn = el(
+    "button",
+    { type: "button", class: "vh-path-a__btn vh-path-a__btn--primary" },
+    s.runButton,
+  ) as HTMLButtonElement;
+  const resetBtn = el(
+    "button",
+    { type: "button", class: "vh-path-a__btn vh-path-a__btn--ghost" },
+    s.resetButton,
+  ) as HTMLButtonElement;
+  const actions = el(
+    "div",
+    { class: "vh-path-a__actions" },
+    runBtn,
+    resetBtn,
+  );
+
+  const statusEl = el("p", { class: "vh-path-a__status", role: "status" });
+
+  const resultHeading = el(
+    "h3",
+    { class: "vh-path-a__result-heading" },
+    s.resultHeading,
+  );
+  const downloadsEl = el("div", { class: "vh-path-a__downloads" });
+  const compareEl = el("p", { class: "vh-path-a__compare-link" });
+
+  const semanticsEl = el(
+    "section",
+    { class: "vh-path-a__semantics" },
+    el("h3", { class: "vh-path-a__semantics-heading" }, s.semanticsHeading),
+    el("p", { class: "vh-path-a__semantics-body" }, s.semanticsBody),
+  );
+
+  mount.append(
+    panelEyebrow,
+    heading,
+    lead,
+    pasteField,
+    urlField,
+    fileField,
+    actions,
+    statusEl,
+    resultHeading,
+    downloadsEl,
+    compareEl,
+    semanticsEl,
+  );
+
+  const renderDownloads = (
+    branchVerdict: ContractV1Verdict | null,
+  ): void => {
+    downloadsEl.replaceChildren();
+
+    const renderLink = (label: string, verdict: ContractV1Verdict, fileName: string) => {
+      const blob = new Blob([JSON.stringify(verdict, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = el(
+        "a",
+        {
+          class: "vh-path-a__download-link",
+          href: url,
+          download: fileName,
+        },
+        label,
+      );
+      return a;
+    };
+
+    const originalRow = el(
+      "div",
+      { class: "vh-path-a__download-row" },
+      el("span", { class: "vh-path-a__download-side" }, s.baselineLabel),
+      el(
+        "span",
+        {
+          class: `vh-path-a__verdict vh-path-a__verdict--${originalVerdict.verdict}`,
+        },
+        originalVerdict.verdict,
+      ),
+      renderLink(s.downloadOriginal, originalVerdict, "original-verdict.json"),
+    );
+    downloadsEl.append(originalRow);
+
+    if (branchVerdict) {
+      const branchRow = el(
+        "div",
+        { class: "vh-path-a__download-row" },
+        el("span", { class: "vh-path-a__download-side" }, s.branchLabel),
+        el(
+          "span",
+          {
+            class: `vh-path-a__verdict vh-path-a__verdict--${branchVerdict.verdict}`,
+          },
+          branchVerdict.verdict,
+        ),
+        renderLink(s.downloadBranchFix, branchVerdict, "branch-fix-verdict.json"),
+      );
+      downloadsEl.append(branchRow);
+    }
+  };
+
+  const renderCompareLink = (): void => {
+    compareEl.replaceChildren();
+    const compareUrl = `/vivarium/repro/compare?slug=${encodeURIComponent(slug)}`;
+    const a = el(
+      "a",
+      {
+        class: "vh-path-a__compare-anchor",
+        href: compareUrl,
+        target: "_top",
+      },
+      s.compareLink,
+    );
+    compareEl.append(a);
+  };
+
+  // Initial render: original-only.
+  renderDownloads(null);
+  renderCompareLink();
+
+  return {
+    setStatus(text, kind) {
+      statusEl.textContent = text;
+      statusEl.classList.remove(
+        "vh-path-a__status--info",
+        "vh-path-a__status--error",
+        "vh-path-a__status--ok",
+      );
+      statusEl.classList.add(`vh-path-a__status--${kind}`);
+    },
+    setBranchRun(_run, branchVerdict) {
+      renderDownloads(branchVerdict);
+    },
+    resetBranch() {
+      renderDownloads(null);
+    },
+    setBusy(busy) {
+      runBtn.disabled = busy;
+      resetBtn.disabled = busy;
+      runBtn.textContent = busy ? s.running : s.runButton;
+      state.busy = busy;
+    },
+    pasteEl,
+    urlEl,
+    fileEl,
+    runBtn,
+    resetBtn,
+  };
+}
+
+/* ------------------------------------------------------------------------ */
+/* enablePathA                                                              */
+/* ------------------------------------------------------------------------ */
+
+export async function enablePathA(opts: PathAOptions): Promise<void> {
+  const mountSelector = opts.mountSelector ?? "#path-a-mount";
+  const mount = document.querySelector<HTMLElement>(mountSelector);
+  if (!mount) {
+    // Recipe page didn't include the mount-point — silently no-op so a
+    // typo in the recipe HTML doesn't tank the entire page.
+    console.warn(
+      `path_a: mount-point "${mountSelector}" not found; Path A panel not rendered.`,
+    );
+    return;
+  }
+
+  const s: PathAStrings = { ...DEFAULT_STRINGS, ...(opts.strings ?? {}) };
+
+  const state: RuntimeState = {
+    baseline: opts.baseline,
+    baselineSource: opts.baselineSource,
+    branchSource: null,
+    branchRun: null,
+    busy: false,
+  };
+
+  const originalVerdict = await captureToVerdict(
+    opts.slug,
+    opts.baselineSource,
+    opts.baseline,
+  );
+
+  const panel = buildPanel(mount, s, state, originalVerdict, opts.slug);
+
+  const setBranch = async (source: string) => {
+    panel.setBusy(true);
+    panel.setStatus(s.running, "info");
+    try {
+      const run = await opts.runFix(source);
+      const verdict = await captureToVerdict(opts.slug, source, run);
+      state.branchSource = source;
+      state.branchRun = run;
+      panel.setBranchRun(run, verdict);
+      panel.setStatus(`${run.verdict} — ${run.message}`, "ok");
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      panel.setStatus(`${s.errorRunFailed} ${message}`, "error");
+      state.branchSource = null;
+      state.branchRun = null;
+      panel.resetBranch();
+    } finally {
+      panel.setBusy(false);
+    }
+  };
+
+  const fetchAndSet = async (url: string) => {
+    panel.setBusy(true);
+    panel.setStatus(s.running, "info");
+    try {
+      const res = await fetch(url, { mode: "cors", credentials: "omit" });
+      if (!res.ok) {
+        panel.setStatus(`${s.errorFetchFailed} (HTTP ${res.status})`, "error");
+        panel.setBusy(false);
+        return;
+      }
+      const text = await res.text();
+      panel.pasteEl.value = text;
+      await setBranch(text);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      panel.setStatus(`${s.errorFetchFailed} (${message})`, "error");
+      panel.setBusy(false);
+    }
+  };
+
+  // Wiring — paste / URL / file pick / Run / Reset.
+  panel.runBtn.addEventListener("click", async () => {
+    const pasteValue = panel.pasteEl.value.trim();
+    const urlValue = panel.urlEl.value.trim();
+    if (!pasteValue && !urlValue) {
+      panel.setStatus(s.errorEmpty, "error");
+      return;
+    }
+    if (pasteValue) {
+      await setBranch(pasteValue);
+    } else if (urlValue) {
+      await fetchAndSet(urlValue);
+    }
+  });
+
+  panel.resetBtn.addEventListener("click", () => {
+    panel.pasteEl.value = "";
+    panel.urlEl.value = "";
+    state.branchSource = null;
+    state.branchRun = null;
+    panel.resetBranch();
+    panel.setStatus("", "info");
+  });
+
+  panel.fileEl.addEventListener("change", async () => {
+    const file = panel.fileEl.files?.[0];
+    if (!file) return;
+    panel.setBusy(true);
+    try {
+      const text = await file.text();
+      panel.pasteEl.value = text;
+      await setBranch(text);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      panel.setStatus(`${s.errorRunFailed} ${message}`, "error");
+    } finally {
+      panel.setBusy(false);
+    }
+    panel.fileEl.value = "";
+  });
+
+  // URL-param auto-trigger: `?fix=<base64url>` (≤4 KiB) or `?fix_url=<url>`.
+  const loc = opts.locationOverride ?? (typeof window !== "undefined" ? window.location : null);
+  if (loc) {
+    const params = new URLSearchParams(loc.search);
+    const inlineFix = params.get("fix");
+    const fixUrl = params.get("fix_url");
+    if (inlineFix) {
+      try {
+        const decoded = base64UrlDecode(inlineFix);
+        if (decoded.length > FIX_PARAM_LIMIT_BYTES) {
+          panel.setStatus(s.errorTooLarge, "info");
+        }
+        panel.pasteEl.value = decoded;
+        await setBranch(decoded);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        panel.setStatus(`${s.errorRunFailed} ${message}`, "error");
+      }
+    } else if (fixUrl) {
+      panel.urlEl.value = fixUrl;
+      await fetchAndSet(fixUrl);
+    }
+  }
+}
+
+/** Pre-bundled Japanese strings — recipes serving a `lang="ja"` page can
+ *  pass `enablePathA({ strings: PATH_A_STRINGS_JA, ... })`. */
+export const PATH_A_STRINGS_JA: Partial<PathAStrings> = DEFAULT_STRINGS_JA;

--- a/src/layer1_wasm/_shared/style.css
+++ b/src/layer1_wasm/_shared/style.css
@@ -557,3 +557,243 @@ main > footer code {
 .vh-footer__msg a:hover {
   border-bottom-color: var(--vh-accent-teal);
 }
+
+/* ---------- Path A — Layer 1 source-substitution branch-fix panel ----------
+ *
+ * Mounted by `_shared/path_a.ts` into a `<section id="path-a-mount">` that
+ * recipes opt into. Shares the same teal/violet token language as the rest
+ * of the recipe page chrome.
+ */
+
+.vh-path-a {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border: 1px solid var(--vh-hairline);
+  border-radius: 8px;
+  background: var(--vh-card-bg);
+}
+
+.vh-path-a__eyebrow {
+  margin: 0 0 0.5rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  color: var(--vh-accent-teal);
+}
+
+.vh-path-a__heading {
+  margin: 0 0 0.5rem;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.4rem;
+  letter-spacing: -0.01em;
+}
+
+.vh-path-a__lead {
+  margin: 0 0 1.25rem;
+  color: var(--vh-text-muted);
+  font-size: 0.95rem;
+}
+
+.vh-path-a__field {
+  display: block;
+  margin-bottom: 1rem;
+}
+
+.vh-path-a__field-label {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--vh-text-muted);
+}
+
+.vh-path-a__textarea,
+.vh-path-a__input {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--vh-hairline);
+  border-radius: 6px;
+  background: var(--vh-bg-deep);
+  color: var(--vh-text);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.vh-path-a__textarea {
+  min-height: 12rem;
+  resize: vertical;
+}
+
+.vh-path-a__textarea:focus,
+.vh-path-a__input:focus {
+  outline: 2px solid var(--vh-accent-teal);
+  outline-offset: -1px;
+}
+
+.vh-path-a__file {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.85rem;
+  color: var(--vh-text-muted);
+}
+
+.vh-path-a__actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.vh-path-a__btn {
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 0.18s ease,
+    color 0.18s ease;
+}
+
+.vh-path-a__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.vh-path-a__btn--primary {
+  border: 0;
+  background: var(--vh-accent-teal);
+  color: #00110e;
+}
+
+.vh-path-a__btn--primary:not(:disabled):hover {
+  background: var(--vh-accent-teal-bright);
+}
+
+.vh-path-a__btn--ghost {
+  border: 1px solid var(--vh-hairline);
+  background: transparent;
+  color: var(--vh-text);
+}
+
+.vh-path-a__btn--ghost:not(:disabled):hover {
+  background: color-mix(in srgb, var(--vh-text) 8%, transparent);
+}
+
+.vh-path-a__status {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+}
+
+.vh-path-a__status--info {
+  color: var(--vh-text-muted);
+}
+
+.vh-path-a__status--ok {
+  color: var(--vh-reproduced-fg);
+}
+
+.vh-path-a__status--error {
+  color: var(--vh-unreproduced-fg);
+}
+
+.vh-path-a__result-heading {
+  margin: 1.5rem 0 0.5rem;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+  color: var(--vh-text-muted);
+}
+
+.vh-path-a__downloads {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.vh-path-a__download-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--vh-hairline);
+  border-radius: 6px;
+  background: var(--vh-bg-deep);
+  flex-wrap: wrap;
+}
+
+.vh-path-a__download-side {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--vh-text-muted);
+  min-width: 12rem;
+}
+
+.vh-path-a__verdict {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid;
+}
+
+.vh-path-a__verdict--reproduced {
+  background: var(--vh-reproduced-bg);
+  color: var(--vh-reproduced-fg);
+  border-color: var(--vh-reproduced-border);
+}
+
+.vh-path-a__verdict--unreproduced {
+  background: var(--vh-unreproduced-bg);
+  color: var(--vh-unreproduced-fg);
+  border-color: var(--vh-unreproduced-border);
+}
+
+.vh-path-a__download-link {
+  margin-left: auto;
+  font-size: 0.85rem;
+  color: var(--vh-accent-teal);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.18s ease;
+}
+
+.vh-path-a__download-link:hover {
+  border-bottom-color: var(--vh-accent-teal);
+}
+
+.vh-path-a__compare-link {
+  margin: 0.75rem 0 0;
+}
+
+.vh-path-a__compare-anchor {
+  font-size: 0.9rem;
+  color: var(--vh-accent-teal);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.18s ease;
+}
+
+.vh-path-a__compare-anchor:hover {
+  border-bottom-color: var(--vh-accent-teal);
+}
+
+.vh-path-a__semantics {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px dashed var(--vh-hairline);
+}
+
+.vh-path-a__semantics-heading {
+  margin: 0 0 0.35rem;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 0.95rem;
+  color: var(--vh-text-muted);
+}
+
+.vh-path-a__semantics-body {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--vh-text-muted);
+}

--- a/src/layer1_wasm/php-12167/index.html
+++ b/src/layer1_wasm/php-12167/index.html
@@ -53,6 +53,8 @@
         <pre id="output">(running)</pre>
       </section>
 
+      <section id="path-a-mount" hidden></section>
+
       <footer>
         <p class="meta">
           Runtime:

--- a/src/layer1_wasm/php-12167/repro.ts
+++ b/src/layer1_wasm/php-12167/repro.ts
@@ -14,8 +14,17 @@
 //   - "reproduced" — the bug REPRODUCES (PI string cast is empty).
 //   - "unreproduced" — the bug does NOT reproduce (the runtime ships a fix,
 //     or the runtime errored before producing a result).
+//
+// Phase 7 B3 (ADR-0030) — this recipe is the PoC for R.2 Path A
+// (Layer 1 source-substitution branch-fix). After the baseline run
+// captures the original verdict, we opt into the shared Path A panel
+// so visitors can paste an alternative reproduction script (typically a
+// userland fix proposed by an AI agent) and re-run it through the same
+// php-wasm runtime. The panel produces a Contract v1 verdict bundle
+// the visitor drops on /repro/compare for side-by-side review.
 
-import { loadVivariumPhp } from "../_shared/php_loader.js";
+import { enablePathA, type PathACapturedRun } from "../_shared/path_a.js";
+import { loadVivariumPhp, type PhpRunner } from "../_shared/php_loader.js";
 import {
   setResult,
   setVerdict,
@@ -46,6 +55,7 @@ interface ReproOutput {
 const outputEl = document.getElementById("output");
 const metaEl = document.getElementById("meta");
 const reproCodeEl = document.getElementById("repro-code");
+const pathAMountEl = document.getElementById("path-a-mount");
 
 if (!outputEl || !metaEl || !reproCodeEl) {
   throw new Error(
@@ -61,6 +71,70 @@ fetch("./repro.highlighted.html")
   })
   .catch(() => {});
 
+function evaluate(result: ReproOutput): {
+  verdict: "reproduced" | "unreproduced";
+  message: string;
+} {
+  // Bug reproduces iff xpath finds the PI node (count === 1) but
+  // string-casting it yields an empty string.
+  const reproduced = result.xpath_count === 1 && result.pi_text_empty;
+  if (reproduced) {
+    return {
+      verdict: "reproduced",
+      message:
+        "bug reproduced — SimpleXML xpath returns the processing-instruction node, but casting it to string yields an empty value.",
+    };
+  }
+  if (
+    result.xpath_count === 1 &&
+    !result.pi_text_empty &&
+    result.pi_text !== null
+  ) {
+    return {
+      verdict: "unreproduced",
+      message:
+        "bug not reproduced — SimpleXML now returns the PI content correctly (likely fixed upstream).",
+    };
+  }
+  return {
+    verdict: "unreproduced",
+    message: `bug not reproduced — unexpected outcome (xpath_count=${result.xpath_count}, pi_text=${JSON.stringify(result.pi_text)}).`,
+  };
+}
+
+async function captureRun(
+  php: PhpRunner,
+  source: string,
+): Promise<PathACapturedRun> {
+  const { exitCode, stdout } = await php.run(source);
+  if (exitCode !== 0) {
+    return {
+      exitCode,
+      verdict: "unreproduced",
+      message: `php-wasm exited non-zero (code=${exitCode}); stdout=${stdout}`,
+      stdout,
+    };
+  }
+  let parsed: ReproOutput;
+  try {
+    parsed = JSON.parse(stdout) as ReproOutput;
+  } catch (err: unknown) {
+    return {
+      exitCode,
+      verdict: "unreproduced",
+      message: `bug not reproduced — fix output was not valid JSON (${err instanceof Error ? err.message : String(err)})`,
+      stdout,
+    };
+  }
+  const ev = evaluate(parsed);
+  return {
+    exitCode,
+    verdict: ev.verdict,
+    message: ev.message,
+    stdout: JSON.stringify(parsed, null, 2),
+  };
+}
+
 const startedAt = new Date();
 
 try {
@@ -69,42 +143,22 @@ try {
   });
 
   setVerdict("pending", "Running reproduction script…");
-  const { exitCode, stdout } = await php.run(REPRO_CODE);
-  if (exitCode !== 0) {
+  const baseline = await captureRun(php, REPRO_CODE);
+
+  let baselineResult: ReproOutput;
+  try {
+    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
+  } catch {
     throw new Error(
-      `php-wasm exited non-zero (code=${exitCode}); stdout=${stdout}`,
+      `php-12167: baseline run produced unparseable stdout: ${baseline.stdout}`,
     );
   }
-  const result = JSON.parse(stdout) as ReproOutput;
 
   metaEl.textContent =
-    `PHP ${result.php_version} via php-wasm v${phpWasmVersion}.`;
-  outputEl.textContent = JSON.stringify(result, null, 2);
+    `PHP ${baselineResult.php_version} via php-wasm v${phpWasmVersion}.`;
+  outputEl.textContent = JSON.stringify(baselineResult, null, 2);
 
-  // Bug reproduces iff xpath finds the PI node (count === 1) but
-  // string-casting it yields an empty string.
-  const reproduced = result.xpath_count === 1 && result.pi_text_empty;
-
-  if (reproduced) {
-    setVerdict(
-      "reproduced",
-      "bug reproduced — SimpleXML xpath returns the processing-instruction node, but casting it to string yields an empty value.",
-    );
-  } else if (
-    result.xpath_count === 1 &&
-    !result.pi_text_empty &&
-    result.pi_text !== null
-  ) {
-    setVerdict(
-      "unreproduced",
-      "bug not reproduced — SimpleXML now returns the PI content correctly (likely fixed upstream).",
-    );
-  } else {
-    setVerdict(
-      "unreproduced",
-      `bug not reproduced — unexpected outcome (xpath_count=${result.xpath_count}, pi_text=${JSON.stringify(result.pi_text)}).`,
-    );
-  }
+  setVerdict(baseline.verdict, baseline.message);
 
   const finishedAt = new Date();
   const envelope: VivariumResultV1 = {
@@ -118,14 +172,14 @@ try {
       name: "php-wasm",
       version: phpWasmVersion,
       extras: {
-        php: result.php_version,
+        php: baselineResult.php_version,
       },
     },
     result: {
-      xpath_count: result.xpath_count,
-      pi_text: result.pi_text,
-      pi_text_empty: result.pi_text_empty,
-      reproduced,
+      xpath_count: baselineResult.xpath_count,
+      pi_text: baselineResult.pi_text,
+      pi_text_empty: baselineResult.pi_text_empty,
+      reproduced: baseline.verdict === "reproduced",
     },
     timing: {
       started_at: startedAt.toISOString(),
@@ -134,6 +188,19 @@ try {
     },
   };
   setResult(envelope);
+
+  // Phase 7 B3 — opt into Path A. The mount-point lives in the page
+  // markup (`<section id="path-a-mount" hidden>`); reveal it before
+  // mounting so the panel transitions from hidden to populated atomically.
+  if (pathAMountEl) {
+    pathAMountEl.removeAttribute("hidden");
+    void enablePathA({
+      slug: "php-12167",
+      baselineSource: REPRO_CODE,
+      baseline,
+      runFix: (source) => captureRun(php, source),
+    });
+  }
 } catch (err: unknown) {
   console.error(err);
   const errAny = err as { stack?: string; message?: string } | null;

--- a/src/layer1_wasm/tests/path_a.spec.ts
+++ b/src/layer1_wasm/tests/path_a.spec.ts
@@ -1,0 +1,202 @@
+// Phase 7 B3 — R.2 Path A regression suite.
+//
+// Asserts the Path A panel on the php-12167 PoC recipe:
+//  - Mounts after the baseline run completes.
+//  - Accepts a userland fix via the textarea + Run button and re-runs
+//    the substituted source through the same php-wasm runtime.
+//  - Captures a Contract v1 verdict bundle reflecting the substituted
+//    source's outcome.
+//  - Auto-triggers from `?fix=` (base64url) URL params.
+//
+// The Path A bundle is what /repro/compare consumes; this suite locks
+// the wire shape without depending on the docs site being up.
+
+import { expect, test, type Page } from "@playwright/test";
+
+const LAYER1 = "http://localhost:8767";
+const PHP_RECIPE = `${LAYER1}/php-12167/`;
+
+// A userland fix that sidesteps the SimpleXML PI string-cast bug by
+// parsing the PI content out of asXML() instead of casting the node
+// to string. With this fix, `pi_text` becomes "hello" and the recipe
+// page evaluates the run as `unreproduced`.
+const SIDESTEP_FIX = `<?php
+$xml = '<?xml version="1.0"?><foo><bar><?stylesheet hello ?></bar></foo>';
+$sxe = simplexml_load_string($xml);
+$pis = $sxe->xpath("//processing-instruction()");
+
+$pi_text = null;
+if (isset($pis[0])) {
+  $pi_xml = $pis[0]->asXML();
+  if (preg_match('#<\\?\\S+\\s+(.*?)\\s*\\?>#', $pi_xml, $m)) {
+    $pi_text = $m[1];
+  }
+}
+
+echo json_encode([
+  "php_version" => PHP_VERSION,
+  "xpath_count" => count($pis ?: []),
+  "pi_text" => $pi_text,
+  "pi_text_empty" => $pi_text === "",
+]);
+`;
+
+// A "broken fix" — looks like a fix but still reproduces the bug. The
+// userland workaround tries to cast through a no-op intermediate, but
+// the bug is in (string) coercion of the PI node itself, so casting
+// twice reproduces the same emptiness.
+const BROKEN_FIX = `<?php
+$xml = '<?xml version="1.0"?><foo><bar><?stylesheet hello ?></bar></foo>';
+$sxe = simplexml_load_string($xml);
+$pis = $sxe->xpath("//processing-instruction()");
+
+$pi_text = isset($pis[0]) ? trim((string) $pis[0]) : null;
+
+echo json_encode([
+  "php_version" => PHP_VERSION,
+  "xpath_count" => count($pis ?: []),
+  "pi_text" => $pi_text,
+  "pi_text_empty" => $pi_text === "",
+]);
+`;
+
+async function waitForBaselineVerdict(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const v = (
+        globalThis as unknown as { __VIVARIUM_VERDICT__?: string }
+      ).__VIVARIUM_VERDICT__;
+      return v === "reproduced" || v === "unreproduced";
+    },
+    undefined,
+    { timeout: 75_000 },
+  );
+}
+
+async function runPathA(page: Page, source: string): Promise<void> {
+  // Wait for the panel to render — enablePathA awaits sha256Hex before
+  // mounting.
+  await page.waitForSelector(".vh-path-a__heading", { timeout: 15_000 });
+  await page.fill(".vh-path-a__textarea", source);
+  await page.click(".vh-path-a__btn--primary");
+  // Wait for the second download row (branch) to appear.
+  await page.waitForFunction(
+    () =>
+      document.querySelectorAll(".vh-path-a__download-row").length >= 2,
+    undefined,
+    { timeout: 60_000 },
+  );
+}
+
+test("php-12167 Path A panel mounts after baseline run", async ({ page }) => {
+  await page.goto(PHP_RECIPE);
+  await waitForBaselineVerdict(page);
+
+  // Mount-point becomes visible (panel removes `hidden`) and the panel
+  // heading renders.
+  const heading = page.locator(".vh-path-a__heading");
+  await expect(heading).toBeVisible({ timeout: 15_000 });
+
+  // Original-side download row is present from the start.
+  const rows = page.locator(".vh-path-a__download-row");
+  await expect(rows).toHaveCount(1);
+
+  // Original verdict is `reproduced` (the bug fires by default).
+  const originalVerdict = page.locator(
+    ".vh-path-a__download-row .vh-path-a__verdict",
+  );
+  await expect(originalVerdict).toHaveText("reproduced");
+});
+
+test("php-12167 Path A — sidestep fix flips verdict to unreproduced", async ({
+  page,
+}) => {
+  await page.goto(PHP_RECIPE);
+  await waitForBaselineVerdict(page);
+  await runPathA(page, SIDESTEP_FIX);
+
+  // Two rows: original + branch. Original = reproduced, branch = unreproduced.
+  const verdicts = page.locator(
+    ".vh-path-a__download-row .vh-path-a__verdict",
+  );
+  await expect(verdicts).toHaveCount(2);
+  await expect(verdicts.nth(0)).toHaveText("reproduced");
+  await expect(verdicts.nth(1)).toHaveText("unreproduced");
+});
+
+test("php-12167 Path A — broken fix keeps verdict reproduced", async ({
+  page,
+}) => {
+  await page.goto(PHP_RECIPE);
+  await waitForBaselineVerdict(page);
+  await runPathA(page, BROKEN_FIX);
+
+  const verdicts = page.locator(
+    ".vh-path-a__download-row .vh-path-a__verdict",
+  );
+  await expect(verdicts).toHaveCount(2);
+  await expect(verdicts.nth(0)).toHaveText("reproduced");
+  await expect(verdicts.nth(1)).toHaveText("reproduced");
+});
+
+test("php-12167 Path A — captured branch-fix verdict matches Contract v1 shape", async ({
+  page,
+}) => {
+  await page.goto(PHP_RECIPE);
+  await waitForBaselineVerdict(page);
+  await runPathA(page, SIDESTEP_FIX);
+
+  // Read the branch-fix verdict from the download link's blob URL.
+  const branchHref = await page
+    .locator(".vh-path-a__download-link")
+    .nth(1)
+    .getAttribute("href");
+  expect(branchHref).toMatch(/^blob:/);
+
+  const verdictJson = await page.evaluate(async (href: string) => {
+    const res = await fetch(href);
+    return res.text();
+  }, branchHref!);
+
+  const parsed = JSON.parse(verdictJson) as Record<string, unknown>;
+  expect.soft(parsed["contract"], "contract").toBe("v1");
+  expect.soft(parsed["verdict"], "verdict").toBe("unreproduced");
+  expect.soft(parsed["exit_code"], "exit_code").toBe(0);
+  expect
+    .soft(parsed["image_tag"], "image_tag")
+    .toMatch(/^layer1:php-12167:[0-9a-f]{12}$/);
+  expect.soft(parsed["image_digest"], "image_digest").toBe("");
+  expect.soft(parsed["stderr_tail"], "stderr_tail").toBe("");
+  expect
+    .soft(parsed["captured_at"], "captured_at")
+    .toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+});
+
+test("php-12167 Path A — ?fix=<base64url> auto-triggers", async ({ page }) => {
+  // base64url-encode the sidestep fix.
+  const encoded = await page.evaluate((source: string) => {
+    const bytes = new TextEncoder().encode(source);
+    let bin = "";
+    for (const b of bytes) bin += String.fromCharCode(b);
+    return btoa(bin)
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  }, SIDESTEP_FIX);
+
+  await page.goto(`${PHP_RECIPE}?fix=${encoded}`);
+  await waitForBaselineVerdict(page);
+
+  // Wait for the branch row to populate via the URL-param auto-trigger.
+  await page.waitForFunction(
+    () =>
+      document.querySelectorAll(".vh-path-a__download-row").length >= 2,
+    undefined,
+    { timeout: 60_000 },
+  );
+
+  const verdicts = page.locator(
+    ".vh-path-a__download-row .vh-path-a__verdict",
+  );
+  await expect(verdicts.nth(1)).toHaveText("unreproduced");
+});


### PR DESCRIPTION

Wire R.2 Path A (Layer 1 source-substitution branch-fix), MCP
verify_branch_fix scaffolding tool, and D-5 walkthrough page into a
single end-to-end loop for verifying AI-suggested fixes against
Vivarium recipes.

R.2 Path A (Layer 1 source-substitution branch-fix):
- New shared module src/layer1_wasm/_shared/path_a.ts with the
  "Try a fix" panel, baseline+branch verdict capture, and download
  surface that emits Contract v1 verdicts /repro/compare consumes
  unchanged.
- php-12167 opts in as the PoC recipe; userland asXML() workarounds
  flip the verdict from reproduced to unreproduced.
- URL params: ?fix_url=<url> and ?fix=<base64url> (≤4 KiB) for
  agent-driven deep-linking.
- Synthesised Layer 1 image_tag keeps the wire format compatible
  with R.3 without schema changes.

MCP verify_branch_fix (5th tool):
- Scaffolding helper, not an execution engine — Layer 1 returns
  Path A (recipe-page compare_url with fix pre-loaded). Layer 2/3
  returns Path B (/repro/compare deep-link plus gh_command for
  branch-fix-verdict.yml).
- Mutually-exclusive fix_url xor fix_source inputs; ignored on
  Layer 2/3 with a note (image-as-input boundary).
- Server version literal stays at 0.1.0 — package is still
  pre-publish per project_mcp_publish_deferred.md, so the bump
  happens alongside the first publish.

D-5 walkthrough:
- New guide page compare-branch-fix.mdx (en + ja) covering pick a
  recipe, get a candidate fix, run via Path A or Path B, read the
  verdict.
- _meta.json updates slot it between use-from-ai-agent and
  fork-your-own.
- use-from-ai-agent and packages/mcp-server/README list the new
  5th tool.

Verification:
- ci:mcp — 38 tests pass (31 existing + 7 new for verify_branch_fix).
- ci:repro — typecheck + build OK; Path A Playwright suite 5/5 +
  php-12167 baseline still green.
- ci:docs build + Biome check pass; new pages render.

ADR-0030 (private memo, en+ja parallel) captures the design
decisions: PoC recipe choice (php-12167 vs ruby-21709),
substitution surface (REPRO_CODE not the runtime), Contract v1
wire-shape preservation, and the scaffolding-helper framing of the
MCP tool.
