### PR TITLE
feat(docs): phase 7 V′ — architecture page with layer matrix + per-layer cells

### DIFF
--- a/docs/components/PageChrome.tsx
+++ b/docs/components/PageChrome.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect } from 'react';
+import { type CSSProperties, type ReactNode, useEffect } from 'react';
 import './page-chrome.css';
 
 /* ----------------------------- PageHero ----------------------------- */
@@ -148,6 +148,148 @@ export function LayerCards({
         </article>
       ))}
     </div>
+  );
+}
+
+/* ----------------------------- LayerMatrix ----------------------------- */
+
+/**
+ * Architecture-page comparison strip. Each column is one of the three
+ * execution layers; each row is one attribute (起動 / 向くバグ / 届かない
+ * こと / ランタイム). Optimised for at-a-glance comparison — narrower than
+ * the deep-dive Sections that follow it on the architecture page.
+ *
+ * Distinct from LayerCards (overview page): LayerCards is a tagline-level
+ * 3-card row, LayerMatrix is a row-per-attribute scannable grid that pays
+ * off when the reader has already decided to compare in detail.
+ */
+export function LayerMatrix({
+  rowLabels,
+  layers,
+}: {
+  /** Row label for each attribute, top-to-bottom (length must match layers[*].cells). */
+  rowLabels: string[];
+  /** One column per layer. Cells align positionally with rowLabels. */
+  layers: {
+    pill: string;
+    accent: LayerAccent;
+    title: string;
+    cells: ReactNode[];
+  }[];
+}) {
+  return (
+    <div
+      className="v-layer-matrix"
+      style={
+        {
+          '--v-layer-matrix-cols': layers.length,
+        } as CSSProperties
+      }
+    >
+      <div className="v-layer-matrix__head">
+        <div className="v-layer-matrix__row-label" aria-hidden="true" />
+        {layers.map((layer, i) => (
+          <div key={i} className="v-layer-matrix__col-head">
+            <span className={`v-layer__pill v-layer__pill--${layer.accent}`}>
+              {layer.pill}
+            </span>
+            <h3 className="v-layer-matrix__col-title">{layer.title}</h3>
+          </div>
+        ))}
+      </div>
+      {rowLabels.map((rowLabel, r) => (
+        <div key={r} className="v-layer-matrix__row">
+          <div className="v-layer-matrix__row-label">{rowLabel}</div>
+          {layers.map((layer, c) => (
+            <div key={c} className="v-layer-matrix__cell">
+              {layer.cells[r]}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ----------------------------- LayerSection ----------------------------- */
+
+/**
+ * Architecture-page deep-dive section for a single layer. Replaces the
+ * Section + h3 hand-rolling that the architecture page previously did
+ * per layer; gives every layer the same 4-row structure
+ * (向くバグ / 起動 or 使い方 / 届かないこと / ランタイム or 例) so the
+ * reader can compare in parallel without re-orienting.
+ *
+ * Two-column on wide screens (left = explanation, right = examples /
+ * runtimes), single-column on mobile.
+ */
+export function LayerSection({
+  pill,
+  accent,
+  eyebrow,
+  heading,
+  intro,
+  cellLabels,
+  fits,
+  startup,
+  cantReach,
+  runtimes,
+}: {
+  pill: string;
+  accent: LayerAccent;
+  eyebrow: string;
+  heading: ReactNode;
+  intro: ReactNode;
+  /** Locale-specific labels for the four cells, top-left → bottom-right. */
+  cellLabels: {
+    fits: string;
+    startup: string;
+    cantReach: string;
+    runtimes: string;
+  };
+  fits: ReactNode;
+  /** "Startup time" for L1; "How to use it" prose for L2/L3 — same slot. */
+  startup: ReactNode;
+  cantReach: ReactNode;
+  /** "Supported runtimes" or "Examples in the catalogue" — same slot. */
+  runtimes: ReactNode;
+}) {
+  const headingId = slugifyHeading(heading);
+  return (
+    <section className={`v-layer-section v-layer-section--${accent}`}>
+      <div className="v-layer-section__head">
+        <span className={`v-layer__pill v-layer__pill--${accent}`}>{pill}</span>
+        <p className="v-layer-section__eyebrow">{eyebrow}</p>
+        <h2 id={headingId} className="v-layer-section__heading rp-toc-include">
+          {heading}
+        </h2>
+        <div className="v-layer-section__intro">{intro}</div>
+      </div>
+      <div className="v-layer-section__grid">
+        <div className="v-layer-section__cell">
+          <h3 className="v-layer-section__cell-heading">{cellLabels.fits}</h3>
+          <div className="v-layer-section__cell-body">{fits}</div>
+        </div>
+        <div className="v-layer-section__cell">
+          <h3 className="v-layer-section__cell-heading">
+            {cellLabels.startup}
+          </h3>
+          <div className="v-layer-section__cell-body">{startup}</div>
+        </div>
+        <div className="v-layer-section__cell">
+          <h3 className="v-layer-section__cell-heading">
+            {cellLabels.cantReach}
+          </h3>
+          <div className="v-layer-section__cell-body">{cantReach}</div>
+        </div>
+        <div className="v-layer-section__cell">
+          <h3 className="v-layer-section__cell-heading">
+            {cellLabels.runtimes}
+          </h3>
+          <div className="v-layer-section__cell-body">{runtimes}</div>
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/docs/components/page-chrome.css
+++ b/docs/components/page-chrome.css
@@ -527,6 +527,270 @@ html.dark {
   color: var(--vh-text-dim);
 }
 
+/* ---------- Layer matrix (architecture page comparison strip) ---------- */
+
+.v-layer-matrix {
+  margin-top: 2rem;
+  border-top: 1px solid var(--vh-hairline);
+  border-bottom: 1px solid var(--vh-hairline);
+}
+
+.v-layer-matrix__head,
+.v-layer-matrix__row {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  padding: 1.25rem 0;
+  border-bottom: 1px solid var(--vh-hairline);
+}
+
+.v-layer-matrix__row:last-child {
+  border-bottom: none;
+}
+
+@media (min-width: 768px) {
+  .v-layer-matrix__head,
+  .v-layer-matrix__row {
+    grid-template-columns: 7rem repeat(var(--v-layer-matrix-cols, 3), 1fr);
+    gap: 1.5rem;
+    align-items: start;
+  }
+}
+
+.v-layer-matrix__row-label {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vh-text-dim);
+  font-weight: 600;
+  padding-top: 0.15rem;
+}
+
+.v-layer-matrix__col-head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.v-layer-matrix__col-title {
+  margin: 0;
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.3;
+  color: var(--vh-text);
+}
+
+.v-layer-matrix__cell {
+  font-size: 0.92rem;
+  line-height: 1.55;
+  color: var(--vh-text-muted);
+}
+
+.v-layer-matrix__cell strong {
+  color: var(--vh-text);
+  font-weight: 600;
+}
+
+.v-layer-matrix__cell code {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.85em;
+  padding: 0.08em 0.32em;
+  background: var(--vh-card-bg);
+  border-radius: 4px;
+  color: var(--vh-text);
+}
+
+/* On mobile, repeat the row label inline above each cell so the meaning
+ * doesn't get lost when columns stack vertically. The row-label div in
+ * the head row is kept aria-hidden and visually empty there. */
+@media (max-width: 767px) {
+  .v-layer-matrix__head .v-layer-matrix__row-label {
+    display: none;
+  }
+}
+
+/* ---------- Layer section (architecture page deep-dive) ---------- */
+
+.v-layer-section {
+  position: relative;
+  margin-bottom: 4rem;
+  padding-top: 2.5rem;
+  border-top: 1px solid var(--vh-hairline);
+}
+
+.v-layer-section:last-of-type {
+  margin-bottom: 0;
+}
+
+.v-layer-section__head {
+  margin-bottom: 2rem;
+}
+
+.v-layer-section__head .v-layer__pill {
+  margin-bottom: 1rem;
+}
+
+.v-layer-section__eyebrow {
+  display: block;
+  margin: 0 0 0.75rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--vh-text-dim);
+}
+
+.v-layer-section__heading {
+  margin: 0 0 1.25rem;
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 600;
+  font-size: clamp(1.5rem, 2.6vw, 2rem);
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+  color: var(--vh-text);
+  text-wrap: balance;
+}
+
+.v-layer-section__intro {
+  font-size: 1.0625rem;
+  line-height: 1.65;
+  color: var(--vh-text-muted);
+  max-width: 60ch;
+}
+
+.v-layer-section__intro p {
+  margin: 0;
+}
+
+.v-layer-section__intro strong {
+  color: var(--vh-text);
+  font-weight: 600;
+}
+
+.v-layer-section__intro code {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.92em;
+  padding: 0.1em 0.35em;
+  background: var(--vh-card-bg);
+  border-radius: 4px;
+  color: var(--vh-text);
+}
+
+.v-layer-section__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .v-layer-section__grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 2rem 2.25rem;
+  }
+}
+
+.v-layer-section__cell {
+  padding: 1.25rem 1.5rem;
+  border: 1px solid var(--vh-hairline);
+  border-radius: 10px;
+  background: var(--vh-card-bg);
+}
+
+.v-layer-section__cell-heading {
+  margin: 0 0 0.75rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vh-text-dim);
+  font-weight: 600;
+}
+
+.v-layer-section__cell-body {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--vh-text-muted);
+}
+
+.v-layer-section__cell-body p {
+  margin: 0 0 0.75rem;
+}
+
+.v-layer-section__cell-body p:last-child {
+  margin-bottom: 0;
+}
+
+.v-layer-section__cell-body strong {
+  color: var(--vh-text);
+  font-weight: 600;
+}
+
+.v-layer-section__cell-body code {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.85em;
+  padding: 0.1em 0.35em;
+  background: var(--vh-card-bg);
+  border-radius: 4px;
+  color: var(--vh-text);
+}
+
+.v-layer-section__cell-body ul {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.v-layer-section__cell-body ul li {
+  margin-bottom: 0.45rem;
+  line-height: 1.55;
+}
+
+.v-layer-section__cell-body ul li::marker {
+  color: var(--vh-accent-teal);
+}
+
+.v-layer-section__cell-body ul li:last-child {
+  margin-bottom: 0;
+}
+
+.v-layer-section--violet .v-layer-section__cell-body ul li::marker {
+  color: var(--vh-accent-violet);
+}
+
+.v-layer-section--coral .v-layer-section__cell-body ul li::marker {
+  color: var(--vh-accent-coral);
+}
+
+.v-layer-section__cell-body a {
+  color: var(--vh-accent-teal);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(0, 212, 170, 0.4);
+  transition: border-color 0.18s ease;
+}
+
+.v-layer-section__cell-body a:hover {
+  border-bottom-color: var(--vh-accent-teal);
+}
+
+.v-layer-section--violet .v-layer-section__cell-body a {
+  color: var(--vh-accent-violet-bright);
+  border-bottom-color: rgba(124, 92, 255, 0.4);
+}
+
+.v-layer-section--violet .v-layer-section__cell-body a:hover {
+  border-bottom-color: var(--vh-accent-violet);
+}
+
+.v-layer-section--coral .v-layer-section__cell-body a {
+  color: var(--vh-accent-coral);
+  border-bottom-color: rgba(255, 113, 108, 0.4);
+}
+
+.v-layer-section--coral .v-layer-section__cell-body a:hover {
+  border-bottom-color: var(--vh-accent-coral);
+}
+
 /* ---------- Numbered list ---------- */
 
 .v-numlist {

--- a/docs/docs/en/architecture.mdx
+++ b/docs/docs/en/architecture.mdx
@@ -6,7 +6,8 @@ title: Architecture
 import {
   Page,
   PageHero,
-  Section,
+  LayerMatrix,
+  LayerSection,
   Callout,
   NextCta,
   BottomNote,
@@ -15,132 +16,215 @@ import {
 <Page>
   <PageHero
     eyebrow="// ARCHITECTURE"
-    title="Three execution layers."
-    sub="Which layer fits your bug — Layer 1 browser-native WebAssembly, Layer 2 containers, Layer 3 record-replay. Each is good at a different kind of bug."
+    title="Three execution layers — one per bug."
+    sub="Layer 1 browser-native WebAssembly, Layer 2 containers, Layer 3 record-replay. The recipe declares which layer it runs on — you don't pick. The matrix below scans the trade-offs at a glance; the deep-dive sections follow."
   />
 
-  <Section
+  <LayerMatrix
+    rowLabels={['Startup', 'Bugs it fits', "Can't reach", 'Runtimes']}
+    layers={[
+      {
+        pill: 'L1 / WASM',
+        accent: 'teal',
+        title: 'In the browser, instantly.',
+        cells: [
+          <>
+            <strong>ms to a few seconds</strong>. First load 1–10 s for the runtime download (Pyodide ≈ 10 MB); cached loads under 1 s.
+          </>,
+          <>
+            Algorithms, data processing, DB queries, library-internal logic.
+          </>,
+          <>
+            Memory ceiling <code>~4 GB</code>, real <code>fork</code>/<code>exec</code>, data races, building the compiler itself.
+          </>,
+          <>
+            Pyodide / Ruby.wasm / php-wasm / <code>wasm32-wasip1</code> / sqlite-wasm.
+          </>,
+        ],
+      },
+      {
+        pill: 'L2 / DOCKER',
+        accent: 'violet',
+        title: 'Docker / microVM, for fidelity.',
+        cells: [
+          <>
+            <strong>Seconds to minutes</strong>. Catalogue distribution — runs on the visitor's Docker or Codespaces.
+          </>,
+          <>
+            Whole-project repros, syscall-dependent, toolchain-specific, multi-process.
+          </>,
+          <>
+            Cannot run on the page itself; needs Docker or Codespaces; heisenbug reliability is L3 territory.
+          </>,
+          <>
+            Pinned <code>Dockerfile</code> + <code>ghcr.io/aletheia-works/vivarium-&lt;slug&gt;</code> + Codespaces badge.
+          </>,
+        ],
+      },
+      {
+        pill: 'L3 / RECORD-REPLAY',
+        accent: 'coral',
+        title: 'Trace bundled, replay anywhere.',
+        cells: [
+          <>
+            <strong>Seconds to minutes (replay only)</strong>. Recording is offline-only on the Vivarium side; visitors just <code>rr replay</code>.
+          </>,
+          <>
+            Data races, memory ordering, long-replay scenarios, distributed bugs depending on a specific interleave.
+          </>,
+          <>
+            Linux/x86_64 only (ARM/Windows fall back to Codespaces or WSL2); traces from tens of MB to single-digit GB.
+          </>,
+          <>
+            Self-contained GHCR images with the <code>rr</code> trace baked in.
+          </>,
+        ],
+      },
+    ]}
+  />
+
+  <LayerSection
+    pill="L1 / WASM"
+    accent="teal"
     eyebrow="// 01 · LAYER 1"
     heading="WebAssembly, in the page."
-  >
-    <p>
-      Reproductions run directly inside your browser tab. No account, no install
-      — open the page and it starts.
-    </p>
+    intro={
+      <p>
+        Reproductions run directly inside your browser tab. No account, no install — open the page and it starts. Phases 0–2 built up Python / Ruby / PHP / Rust recipes like <a href="/vivarium/repro/cpython/137205/">cpython#137205</a> and <a href="/vivarium/repro/pandas/56679/">pandas#56679</a>; this layer is the most "browser-only" surface Vivarium ships.
+      </p>
+    }
+    cellLabels={{
+      fits: 'Bugs this layer fits',
+      startup: 'Startup time',
+      cantReach: "What this layer can't reach",
+      runtimes: 'Runtimes and live examples',
+    }}
+    fits={
+      <ul>
+        <li>Algorithmic bugs (sorting, parsing, text processing).</li>
+        <li>Data-processing regressions (pandas / polars / numpy shape bugs).</li>
+        <li>Database behavioural bugs (SQLite query anomalies, JSON path edge cases).</li>
+        <li>Library-internal logic where the repro doesn't touch the filesystem, network, or process model.</li>
+      </ul>
+    }
+    startup={
+      <ul>
+        <li><strong>Cold load (no cache)</strong>: 1–10 seconds. Dominated by runtime download (Pyodide ≈ 10 MB compressed) and instantiation.</li>
+        <li><strong>Warm load (cached)</strong>: under a second.</li>
+        <li><strong>Per-run execution</strong>: milliseconds to a few seconds.</li>
+      </ul>
+    }
+    cantReach={
+      <ul>
+        <li><strong>Memory.</strong> A browser tab degrades past ~1 GB peak; ~4 GB is the practical ceiling. Production-scale data goes to Layer 2.</li>
+        <li><strong>System calls.</strong> No real <code>fork</code>/<code>exec</code> or real sockets. The WASI shim covers common cases, not all.</li>
+        <li><strong>Concurrency bugs.</strong> Single-threaded by default — data races and heisenbugs go to Layer 3.</li>
+        <li><strong>Compiler builds.</strong> A Rust bug reproduces fine in-browser, but building the Rust compiler itself is Layer 2.</li>
+      </ul>
+    }
+    runtimes={
+      <ul>
+        <li><strong>Python</strong>: <a href="https://pyodide.org">Pyodide</a> — e.g. <a href="/vivarium/repro/numpy/28287/">numpy#28287</a>, <a href="/vivarium/repro/pandas/56679/">pandas#56679</a>.</li>
+        <li><strong>SQLite</strong>: <a href="https://sqlite.org/wasm/">sqlite-wasm</a> (via Pyodide) — e.g. <a href="/vivarium/repro/cpython/137205/">cpython#137205</a>.</li>
+        <li><strong>Rust</strong>: <code>wasm32-wasip1</code> — e.g. <a href="/vivarium/repro/regex/779/">regex#779</a>.</li>
+        <li><strong>Ruby</strong>: <a href="https://github.com/ruby/ruby.wasm">Ruby.wasm</a> — e.g. <a href="/vivarium/repro/ruby/21709/">ruby#21709</a>.</li>
+        <li><strong>PHP</strong>: <a href="https://github.com/WordPress/wordpress-playground">php-wasm</a> — e.g. <a href="/vivarium/repro/php/12167/">php#12167</a>.</li>
+      </ul>
+    }
+  />
 
-    <h3>Bugs this layer fits</h3>
-    <ul>
-      <li>Algorithmic bugs (sorting, parsing, text processing).</li>
-      <li>Data-processing regressions (pandas / polars / numpy shape bugs).</li>
-      <li>Database behavioural bugs (SQLite query anomalies, JSON path edge cases).</li>
-      <li>Library-internal logic where the repro doesn't touch the filesystem, network, or process model.</li>
-    </ul>
-
-    <h3>Startup time</h3>
-    <ul>
-      <li><strong>Cold load (no cache)</strong>: 1–10 seconds. Dominated by runtime download (Pyodide ≈ 10 MB compressed) and instantiation.</li>
-      <li><strong>Warm load (cached)</strong>: under a second.</li>
-      <li><strong>Per-run execution</strong>: milliseconds to a few seconds.</li>
-    </ul>
-
-    <h3>What this layer can't reach</h3>
-    <ul>
-      <li><strong>Memory.</strong> A browser tab degrades past ~1 GB peak; ~4 GB is the practical ceiling. Production-scale data goes to Layer 2.</li>
-      <li><strong>System calls.</strong> No real <code>fork</code>/<code>exec</code> or real sockets. The WASI shim covers common cases, not all.</li>
-      <li><strong>Concurrency bugs.</strong> Single-threaded by default — data races and heisenbugs go to Layer 3.</li>
-      <li><strong>Compiler builds.</strong> A Rust bug reproduces fine in-browser, but building the Rust compiler itself is Layer 2.</li>
-    </ul>
-
-    <h3>Supported runtimes</h3>
-    <table>
-      <thead>
-        <tr><th>Language</th><th>Runtime</th></tr>
-      </thead>
-      <tbody>
-        <tr><td>Python</td><td><a href="https://pyodide.org">Pyodide</a></td></tr>
-        <tr><td>SQLite</td><td><a href="https://sqlite.org/wasm/">sqlite-wasm</a> (via Pyodide)</td></tr>
-        <tr><td>Rust</td><td><code>wasm32-wasip1</code></td></tr>
-        <tr><td>Ruby</td><td><a href="https://github.com/ruby/ruby.wasm">Ruby.wasm</a></td></tr>
-        <tr><td>PHP</td><td><a href="https://github.com/WordPress/wordpress-playground">php-wasm</a></td></tr>
-      </tbody>
-    </table>
-  </Section>
-
-  <Section
+  <LayerSection
+    pill="L2 / DOCKER"
+    accent="violet"
     eyebrow="// 02 · LAYER 2"
     heading="Docker / microVM, on your own machine."
-  >
-    <p>
-      For bugs that need a real filesystem, real processes, and real networking.
-      Vivarium does not host execution; recipes are <strong>distributed as a
-      catalogue</strong> that runs on your own Docker (or Codespaces).
-    </p>
+    intro={
+      <p>
+        For bugs that need a real filesystem, real processes, and real networking. Vivarium does not host execution; recipes are <strong>distributed as a catalogue</strong> that runs on your own Docker (or Codespaces).
+      </p>
+    }
+    cellLabels={{
+      fits: 'Bugs this layer fits',
+      startup: 'How to use it',
+      cantReach: "What this layer can't reach",
+      runtimes: 'Live examples',
+    }}
+    fits={
+      <ul>
+        <li>Whole-project reproductions — bugs that require dependency resolution against real package indexes.</li>
+        <li>Syscall-dependent bugs — real <code>fork</code>, real sockets, real file locks, real signals.</li>
+        <li>Toolchain-specific bugs — quirks of a specific GCC, glibc, or kernel ABI.</li>
+        <li>Multi-process bugs where the interaction between processes is the bug.</li>
+      </ul>
+    }
+    startup={
+      <p>
+        Each recipe page ships a pinned <code>Dockerfile</code>, a copy-pasteable <code>docker run …</code> command, and a link to a published image at <code>ghcr.io/aletheia-works/vivarium-&lt;slug&gt;</code>. The page also shows the latest CI verdict snapshot — your own <code>docker run</code> becomes the live confirmation. Where applicable an "Open in Codespaces" badge is provided.
+      </p>
+    }
+    cantReach={
+      <ul>
+        <li><strong>No in-page execution.</strong> The repro runs locally or in Codespaces, not on the gallery page.</li>
+        <li><strong>Docker (or Codespaces) required.</strong> Without either, you can still browse recipes and verdict snapshots.</li>
+        <li><strong>Concurrency itself.</strong> Layer 2 runs on real threads, but reproducing heisenbugs reliably is Layer 3 territory.</li>
+      </ul>
+    }
+    runtimes={
+      <ul>
+        <li><a href="/vivarium/repro/postgres/lost-update/">postgres-lost-update</a> — lost updates straddling a transaction boundary.</li>
+        <li><a href="/vivarium/repro/flock/is-advisory/">flock-is-advisory</a> — file locks are advisory, not mandatory.</li>
+        <li><a href="/vivarium/repro/find/xargs-whitespace/">find-xargs-whitespace</a> — whitespace handling across the pipeline boundary.</li>
+        <li><a href="/vivarium/repro/bash/local-shadows-exit/">bash-local-shadows-exit</a> — <code>local</code> shadows the parent shell's <code>$?</code>.</li>
+      </ul>
+    }
+  />
 
-    <h3>Bugs this layer fits</h3>
-    <ul>
-      <li>Whole-project reproductions — bugs that require dependency resolution against real package indexes.</li>
-      <li>Syscall-dependent bugs — real <code>fork</code>, real sockets, real file locks, real signals.</li>
-      <li>Toolchain-specific bugs — quirks of a specific GCC, glibc, or kernel ABI.</li>
-      <li>Multi-process bugs where the interaction between processes is the bug.</li>
-    </ul>
-
-    <h3>How to use it</h3>
-    <p>
-      Each recipe page ships a pinned <code>Dockerfile</code>, a copy-pasteable
-      <code> docker run …</code> command, and a link to a published image at
-      <code>ghcr.io/aletheia-works/vivarium-&lt;slug&gt;</code>. The page also
-      shows the latest CI verdict snapshot — your own <code>docker run</code>
-      becomes the live confirmation. Where applicable an "Open in Codespaces"
-      badge is provided.
-    </p>
-
-    <h3>What this layer can't reach</h3>
-    <ul>
-      <li><strong>No in-page execution.</strong> The repro runs locally or in Codespaces, not on the gallery page.</li>
-      <li><strong>Docker (or Codespaces) required.</strong> Without either, you can still browse recipes and verdict snapshots.</li>
-      <li><strong>Concurrency itself.</strong> Layer 2 runs on real threads, but reproducing heisenbugs reliably is Layer 3 territory.</li>
-    </ul>
-  </Section>
-
-  <Section
+  <LayerSection
+    pill="L3 / RECORD-REPLAY"
+    accent="coral"
     eyebrow="// 03 · LAYER 3"
     heading="Trace bundled, replay anywhere."
-  >
-    <p>
-      For <strong>heisenbugs</strong> — bugs that don't reliably reproduce on a
-      fresh re-run. Vivarium pre-records the trace, bakes it into a GHCR image,
-      and you only have to <strong>replay</strong>.
-    </p>
-
-    <h3>Bugs this layer fits</h3>
-    <ul>
-      <li>Data races, memory ordering bugs, use-after-frees that resist a fresh re-run.</li>
-      <li>Long-replay scenarios: rewind hours of captured execution in minutes.</li>
-      <li>Distributed-system bugs that depend on a specific message interleaving.</li>
-      <li>Post-mortem forensic analysis — stepping backwards through a recorded trace.</li>
-    </ul>
-
-    <h3>How to use it</h3>
-    <p>
-      Each Layer 3 recipe ships as a self-contained GHCR image with the trace
-      baked in. <code>rr replay</code> doesn't need a PMU, so replay runs on
-      <strong>commodity Linux hosts</strong> — both for visitors and for CI.
-      The recording itself does need a PMU-equipped Linux/x86_64 host, but that
-      is done offline by Vivarium when the recipe is added — not something you
-      have to repeat.
-    </p>
-
-    <h3>What this layer can't reach</h3>
-    <ul>
-      <li><strong>Environment.</strong> Visitors need Linux/x86_64. ARM Mac or Windows users fall back to Codespaces or WSL2 + Docker.</li>
-      <li><strong>Coverage shape.</strong> <code>rr</code> targets single-process Linux x86_64; distributed-simulation tools target distributed systems — neither covers the other's territory.</li>
-      <li><strong>Trace size.</strong> Tens of MB to single-digit GB per recipe.</li>
-    </ul>
-  </Section>
+    intro={
+      <p>
+        For <strong>heisenbugs</strong> — bugs that don't reliably reproduce on a fresh re-run. Vivarium pre-records the trace, bakes it into a GHCR image, and you only have to <strong>replay</strong>.
+      </p>
+    }
+    cellLabels={{
+      fits: 'Bugs this layer fits',
+      startup: 'How to use it',
+      cantReach: "What this layer can't reach",
+      runtimes: 'Live examples',
+    }}
+    fits={
+      <ul>
+        <li>Data races, memory ordering bugs, use-after-frees that resist a fresh re-run.</li>
+        <li>Long-replay scenarios: rewind hours of captured execution in minutes.</li>
+        <li>Distributed-system bugs that depend on a specific message interleaving.</li>
+        <li>Post-mortem forensic analysis — stepping backwards through a recorded trace.</li>
+      </ul>
+    }
+    startup={
+      <p>
+        Each Layer 3 recipe ships as a self-contained GHCR image with the trace baked in. <code>rr replay</code> doesn't need a PMU, so replay runs on <strong>commodity Linux hosts</strong> — both for visitors and for CI. The recording itself does need a PMU-equipped Linux/x86_64 host, but that is done offline by Vivarium when the recipe is added — not something you have to repeat.
+      </p>
+    }
+    cantReach={
+      <ul>
+        <li><strong>Environment.</strong> Visitors need Linux/x86_64. ARM Mac or Windows users fall back to Codespaces or WSL2 + Docker.</li>
+        <li><strong>Coverage shape.</strong> <code>rr</code> targets single-process Linux x86_64; distributed-simulation tools target distributed systems — neither covers the other's territory.</li>
+        <li><strong>Trace size.</strong> Tens of MB to single-digit GB per recipe.</li>
+      </ul>
+    }
+    runtimes={
+      <ul>
+        <li><a href="/vivarium/repro/pthread/lost-update/">pthread lost-update</a> — a real pthread race captured deterministically; visitors only <code>rr replay</code>.</li>
+        <li>New Layer 3 recipes need offline PMU recording, so the cadence is slower than L1 / L2.</li>
+      </ul>
+    }
+  />
 
   <Callout>
-    Which layer a recipe runs on is declared by the recipe itself. You don't
-    pick — opening the page runs it on the right layer automatically.
+    Which layer a recipe runs on is declared by the recipe itself. You don't pick — opening the page runs it on the right layer automatically.
   </Callout>
 </Page>
 

--- a/docs/docs/ja/architecture.mdx
+++ b/docs/docs/ja/architecture.mdx
@@ -6,7 +6,8 @@ title: アーキテクチャ
 import {
   Page,
   PageHero,
-  Section,
+  LayerMatrix,
+  LayerSection,
   Callout,
   NextCta,
   BottomNote,
@@ -15,132 +16,215 @@ import {
 <Page>
   <PageHero
     eyebrow="// ARCHITECTURE"
-    title="3 つの実行レイヤー。"
-    sub="あなたのバグに合うレイヤーはどれか——Layer 1 のブラウザネイティブ WebAssembly、Layer 2 のコンテナ、Layer 3 の record-replay。それぞれ得意なバグの種類が違います。"
+    title="3 つの実行レイヤー、1 つのバグに 1 つだけ。"
+    sub="Layer 1 のブラウザ内 WebAssembly、Layer 2 のコンテナ、Layer 3 の record-replay。どのレイヤーで動くかはレシピが宣言します——あなたが選ぶ必要はありません。下表で 3 層を一望してから、深掘りに進めます。"
   />
 
-  <Section
+  <LayerMatrix
+    rowLabels={['起動時間', '向くバグ', '届かないこと', '対応ランタイム']}
+    layers={[
+      {
+        pill: 'L1 / WASM',
+        accent: 'teal',
+        title: 'ブラウザの中で、瞬時に。',
+        cells: [
+          <>
+            <strong>ms 〜 数秒</strong>。初回はランタイム DL（Pyodide ≈ 10 MB）で 1〜10 秒、2 回目以降はブラウザキャッシュで 1 秒未満。
+          </>,
+          <>
+            アルゴリズム、データ処理、DB クエリ、ライブラリ内部のロジックバグ。
+          </>,
+          <>
+            メモリ <code>~4 GB</code> 上限、本物の <code>fork</code>/<code>exec</code>、データレース、コンパイラ自体のビルド。
+          </>,
+          <>
+            Pyodide / Ruby.wasm / php-wasm / <code>wasm32-wasip1</code> / sqlite-wasm。
+          </>,
+        ],
+      },
+      {
+        pill: 'L2 / DOCKER',
+        accent: 'violet',
+        title: 'Docker / microVM で、忠実度を。',
+        cells: [
+          <>
+            <strong>秒〜分</strong>。訪問者の Docker か Codespaces で動かすカタログ配信。
+          </>,
+          <>
+            プロジェクト全体の再現、syscall 依存、ツールチェーン固有、マルチプロセス。
+          </>,
+          <>
+            ページ内では実行不可、Docker か Codespaces が必要、ハイゼンバグ自体の再現性確保。
+          </>,
+          <>
+            ピン留め <code>Dockerfile</code> + <code>ghcr.io/aletheia-works/vivarium-&lt;slug&gt;</code> + Codespaces バッジ。
+          </>,
+        ],
+      },
+      {
+        pill: 'L3 / RECORD-REPLAY',
+        accent: 'coral',
+        title: 'トレース同梱で、どこでも再生。',
+        cells: [
+          <>
+            <strong>秒〜分（再生のみ）</strong>。録音は Vivarium 側でオフライン済み、訪問者は <code>rr replay</code> だけ。
+          </>,
+          <>
+            データレース、メモリ順序、長時間 replay、特定の interleave に依存する分散バグ。
+          </>,
+          <>
+            Linux/x86_64 が前提（ARM/Windows は Codespaces or WSL2）、トレース数十 MB〜数 GB。
+          </>,
+          <>
+            <code>rr</code> トレースを焼き込んだ自己完結 GHCR イメージ。
+          </>,
+        ],
+      },
+    ]}
+  />
+
+  <LayerSection
+    pill="L1 / WASM"
+    accent="teal"
     eyebrow="// 01 · LAYER 1"
     heading="WebAssembly、ページの中で。"
-  >
-    <p>
-      ユーザーのブラウザタブの中で再現が直接実行される層です。
-      アカウントもインストールも不要、ページを開けばすぐ動きます。
-    </p>
+    intro={
+      <p>
+        ユーザーのブラウザタブの中で再現が直接実行される層です。アカウントもインストールも不要、ページを開けばすぐ動きます。Phase 0〜2 で <a href="/vivarium/repro/cpython/137205/">cpython#137205</a> や <a href="/vivarium/repro/pandas/56679/">pandas#56679</a> のように複数の Python / Ruby / PHP / Rust レシピを揃え、現在は最も「ブラウザだけで完結する」surface です。
+      </p>
+    }
+    cellLabels={{
+      fits: '向くバグ',
+      startup: '起動時間',
+      cantReach: '届かないこと',
+      runtimes: '対応ランタイムと実例',
+    }}
+    fits={
+      <ul>
+        <li>アルゴリズムバグ（ソート、パース、テキスト処理）。</li>
+        <li>データ処理のリグレッション（pandas / polars / numpy のシェイプバグなど）。</li>
+        <li>データベースの動作バグ（SQLite のクエリ異常、JSON パスのエッジケース）。</li>
+        <li>ファイルシステム・ネットワーク・プロセスモデルに触れない、ライブラリ内部のロジックバグ。</li>
+      </ul>
+    }
+    startup={
+      <ul>
+        <li><strong>初回（キャッシュなし）</strong>: 1〜10 秒。ランタイムのダウンロード（Pyodide ≈ 10 MB 圧縮）とインスタンス化が支配的。</li>
+        <li><strong>2 回目以降</strong>: ブラウザのキャッシュが効いて 1 秒未満で起動。</li>
+        <li><strong>再現スクリプトの実行自体</strong>: ミリ秒〜数秒。</li>
+      </ul>
+    }
+    cantReach={
+      <ul>
+        <li><strong>メモリ。</strong> ブラウザタブはピーク 1 GB 超で性能が劣化、4 GB が実質上限。本番規模のデータは Layer 2 へ。</li>
+        <li><strong>システムコール。</strong> 本物の <code>fork</code>/<code>exec</code>、本物のソケットは使えない。WASI シムが一般的なケースをカバー。</li>
+        <li><strong>並行性バグ。</strong> デフォルトはシングルスレッド。データレースやハイゼンバグは Layer 3 へ。</li>
+        <li><strong>コンパイラ自体のビルド。</strong> Rust のバグはブラウザ内で再現できますが、Rust コンパイラ自体のビルドは Layer 2。</li>
+      </ul>
+    }
+    runtimes={
+      <ul>
+        <li><strong>Python</strong>: <a href="https://pyodide.org">Pyodide</a> — 例: <a href="/vivarium/repro/numpy/28287/">numpy#28287</a>、<a href="/vivarium/repro/pandas/56679/">pandas#56679</a>。</li>
+        <li><strong>SQLite</strong>: <a href="https://sqlite.org/wasm/">sqlite-wasm</a>（Pyodide 経由）— 例: <a href="/vivarium/repro/cpython/137205/">cpython#137205</a>。</li>
+        <li><strong>Rust</strong>: <code>wasm32-wasip1</code> — 例: <a href="/vivarium/repro/regex/779/">regex#779</a>。</li>
+        <li><strong>Ruby</strong>: <a href="https://github.com/ruby/ruby.wasm">Ruby.wasm</a> — 例: <a href="/vivarium/repro/ruby/21709/">ruby#21709</a>。</li>
+        <li><strong>PHP</strong>: <a href="https://github.com/WordPress/wordpress-playground">php-wasm</a> — 例: <a href="/vivarium/repro/php/12167/">php#12167</a>。</li>
+      </ul>
+    }
+  />
 
-    <h3>このレイヤーが向くバグ</h3>
-    <ul>
-      <li>アルゴリズムバグ（ソート、パース、テキスト処理）。</li>
-      <li>データ処理のリグレッション（pandas / polars / numpy のシェイプバグなど）。</li>
-      <li>データベースの動作バグ（SQLite のクエリ異常、JSON パスのエッジケースなど）。</li>
-      <li>ファイルシステム・ネットワーク・プロセスモデルに触れない、ライブラリ内部のロジックバグ。</li>
-    </ul>
-
-    <h3>起動時間</h3>
-    <ul>
-      <li><strong>初回（キャッシュなし）</strong>: 1〜10 秒。ランタイムのダウンロード（Pyodide なら ≈ 10 MB 圧縮）とインスタンス化が支配的。</li>
-      <li><strong>2 回目以降</strong>: ブラウザのキャッシュが効いて 1 秒未満で起動。</li>
-      <li><strong>再現スクリプトの実行自体</strong>: ミリ秒〜数秒。</li>
-    </ul>
-
-    <h3>このレイヤーで届かないこと</h3>
-    <ul>
-      <li><strong>メモリ。</strong> ブラウザタブはピーク 1 GB 超で性能が劣化、4 GB が実質上限。本番規模のデータは Layer 2 へ。</li>
-      <li><strong>システムコール。</strong> 本物の <code>fork</code>/<code>exec</code>、本物のソケットは使えない。WASI シムが一般的なケースをカバー。</li>
-      <li><strong>並行性バグ。</strong> デフォルトはシングルスレッド。データレースやハイゼンバグは Layer 3 へ。</li>
-      <li><strong>コンパイラ自体のビルド。</strong> Rust のバグはブラウザ内で再現できますが、Rust コンパイラ自体のビルドは Layer 2。</li>
-    </ul>
-
-    <h3>対応ランタイム</h3>
-    <table>
-      <thead>
-        <tr><th>言語</th><th>ランタイム</th></tr>
-      </thead>
-      <tbody>
-        <tr><td>Python</td><td><a href="https://pyodide.org">Pyodide</a></td></tr>
-        <tr><td>SQLite</td><td><a href="https://sqlite.org/wasm/">sqlite-wasm</a>（Pyodide 経由）</td></tr>
-        <tr><td>Rust</td><td><code>wasm32-wasip1</code></td></tr>
-        <tr><td>Ruby</td><td><a href="https://github.com/ruby/ruby.wasm">Ruby.wasm</a></td></tr>
-        <tr><td>PHP</td><td><a href="https://github.com/WordPress/wordpress-playground">php-wasm</a></td></tr>
-      </tbody>
-    </table>
-  </Section>
-
-  <Section
+  <LayerSection
+    pill="L2 / DOCKER"
+    accent="violet"
     eyebrow="// 02 · LAYER 2"
     heading="Docker / microVM、訪問者のマシン上で。"
-  >
-    <p>
-      本物のファイルシステム、本物のプロセス、本物のネットワークが必要なバグのための層です。
-      Vivarium 側で再現を実行するのではなく、訪問者自身の Docker（または Codespaces）で動かす
-      <strong>カタログ型</strong>の配信モデルを採用しています。
-    </p>
+    intro={
+      <p>
+        本物のファイルシステム、本物のプロセス、本物のネットワークが必要なバグのための層です。Vivarium 側で再現を実行するのではなく、訪問者自身の Docker（または Codespaces）で動かす<strong>カタログ型</strong>の配信モデルを採用しています。
+      </p>
+    }
+    cellLabels={{
+      fits: '向くバグ',
+      startup: '使い方',
+      cantReach: '届かないこと',
+      runtimes: '実例',
+    }}
+    fits={
+      <ul>
+        <li>プロジェクト全体の再現——実際のパッケージインデックスへの依存解決を要するバグ。</li>
+        <li>システムコール依存のバグ——本物の <code>fork</code>、ソケット、ファイルロック、シグナル。</li>
+        <li>ツールチェーン固有のバグ——特定の GCC、glibc、カーネル ABI の癖。</li>
+        <li>プロセス間の相互作用が原因のマルチプロセスバグ。</li>
+      </ul>
+    }
+    startup={
+      <p>
+        各レシピページにはピン留めされた <code>Dockerfile</code> と、コピペ可能な <code>docker run …</code> コマンド、そして <code>ghcr.io/aletheia-works/vivarium-&lt;slug&gt;</code> に公開されたビルド済みイメージへのリンクが揃っています。CI で取得した verdict スナップショットがページ上に表示され、訪問者自身の <code>docker run</code> がライブ再現になります。Codespaces 対応のレシピには「Open in Codespaces」バッジも提供されます。
+      </p>
+    }
+    cantReach={
+      <ul>
+        <li><strong>ページ内では実行されない。</strong> 訪問者がローカルか Codespaces で実行します。</li>
+        <li><strong>Docker（または Codespaces アカウント）が必要。</strong> どちらもない場合は、レシピと verdict スナップショットの閲覧のみ可能。</li>
+        <li><strong>並行性そのものをデバッグするバグ。</strong> Layer 2 は本物のスレッドで動きますが、ハイゼンバグの再現性確保は Layer 3 の領分。</li>
+      </ul>
+    }
+    runtimes={
+      <ul>
+        <li><a href="/vivarium/repro/postgres/lost-update/">postgres-lost-update</a> — トランザクション境界をまたぐロスト・アップデート。</li>
+        <li><a href="/vivarium/repro/flock/is-advisory/">flock-is-advisory</a> — ファイルロックの advisory な性質。</li>
+        <li><a href="/vivarium/repro/find/xargs-whitespace/">find-xargs-whitespace</a> — パイプライン経由のホワイトスペース取り扱い。</li>
+        <li><a href="/vivarium/repro/bash/local-shadows-exit/">bash-local-shadows-exit</a> — ローカル変数が <code>$?</code> を覆う罠。</li>
+      </ul>
+    }
+  />
 
-    <h3>このレイヤーが向くバグ</h3>
-    <ul>
-      <li>プロジェクト全体の再現——実際のパッケージインデックスへの依存解決を要するバグ。</li>
-      <li>システムコール依存のバグ——本物の <code>fork</code>、ソケット、ファイルロック、シグナル。</li>
-      <li>ツールチェーン固有のバグ——特定の GCC、特定の glibc、特定のカーネル ABI の癖。</li>
-      <li>プロセス間の相互作用が原因のマルチプロセスバグ。</li>
-    </ul>
-
-    <h3>使い方</h3>
-    <p>
-      各レシピページにはピン留めされた <code>Dockerfile</code> と、コピペ可能な
-      <code>docker run …</code> コマンド、そして
-      <code>ghcr.io/aletheia-works/vivarium-&lt;slug&gt;</code> に公開された
-      ビルド済みイメージへのリンクが揃っています。CI で取得した verdict
-      スナップショットがページ上に表示され、訪問者自身の <code>docker run</code>
-      がライブ再現になります。Codespaces 対応のレシピには「Open in Codespaces」
-      バッジも提供されます。
-    </p>
-
-    <h3>このレイヤーで届かないこと</h3>
-    <ul>
-      <li><strong>ページ内では実行されない。</strong> 訪問者がローカルか Codespaces で実行します。</li>
-      <li><strong>Docker（または Codespaces アカウント）が必要。</strong> どちらもない場合は、レシピと verdict スナップショットの閲覧のみ可能。</li>
-      <li><strong>並行性そのものをデバッグするバグ。</strong> Layer 2 は本物のスレッドで動きますが、ハイゼンバグの再現性確保は Layer 3 の領分。</li>
-    </ul>
-  </Section>
-
-  <Section
+  <LayerSection
+    pill="L3 / RECORD-REPLAY"
+    accent="coral"
     eyebrow="// 03 · LAYER 3"
     heading="トレースを同梱、どこでも再生。"
-  >
-    <p>
-      数回再実行しても再現する保証がない<strong>ハイゼンバグ</strong>のための層です。
-      Vivarium 側であらかじめ録音したトレースを GHCR イメージに焼き込み、
-      訪問者は<strong>再生だけ</strong>すれば済むようにしています。
-    </p>
-
-    <h3>このレイヤーが向くバグ</h3>
-    <ul>
-      <li>データレース、メモリ順序バグ、単純な再実行では再現しない use-after-free。</li>
-      <li>長時間 replay シナリオ：何時間ものキャプチャ実行を数分で巻き戻す。</li>
-      <li>特定のメッセージインターリーブに依存する分散システムバグ。</li>
-      <li>事後フォレンジック分析——録音済みトレースを後ろに戻る形のデバッグ。</li>
-    </ul>
-
-    <h3>使い方</h3>
-    <p>
-      各 Layer 3 レシピは、トレースを焼き込んだ自己完結 GHCR イメージとして配布されます。
-      <code>rr replay</code> は PMU を必要としないため、訪問者と CI の再生はどちらも
-      <strong>コモディティな Linux ホストで動作</strong>します。録音そのものは PMU を
-      備えた Linux/x86_64 環境を要するため、レシピ追加時のオフライン作業として
-      Vivarium 側で済ませてあります。
-    </p>
-
-    <h3>このレイヤーで届かないこと</h3>
-    <ul>
-      <li><strong>環境制約。</strong> 訪問者のマシンは Linux/x86_64 が前提。ARM Mac や Windows の場合は Codespaces または WSL2 + Docker にフォールバック。</li>
-      <li><strong>カバレッジの形が違う。</strong> <code>rr</code> は単一プロセス Linux x86_64、分散シミュレーションツールは分散システムを対象。互いの領域はカバーしない。</li>
-      <li><strong>トレースが大きい。</strong> レシピあたり数十 MB から一桁 GB のオーダー。</li>
-    </ul>
-  </Section>
+    intro={
+      <p>
+        数回再実行しても再現する保証がない<strong>ハイゼンバグ</strong>のための層です。Vivarium 側であらかじめ録音したトレースを GHCR イメージに焼き込み、訪問者は<strong>再生だけ</strong>すれば済むようにしています。
+      </p>
+    }
+    cellLabels={{
+      fits: '向くバグ',
+      startup: '使い方',
+      cantReach: '届かないこと',
+      runtimes: '実例',
+    }}
+    fits={
+      <ul>
+        <li>データレース、メモリ順序バグ、単純な再実行では再現しない use-after-free。</li>
+        <li>長時間 replay シナリオ：何時間ものキャプチャ実行を数分で巻き戻す。</li>
+        <li>特定のメッセージインターリーブに依存する分散システムバグ。</li>
+        <li>事後フォレンジック分析——録音済みトレースを後ろに戻る形のデバッグ。</li>
+      </ul>
+    }
+    startup={
+      <p>
+        各 Layer 3 レシピは、トレースを焼き込んだ自己完結 GHCR イメージとして配布されます。<code>rr replay</code> は PMU を必要としないため、訪問者と CI の再生はどちらも<strong>コモディティな Linux ホストで動作</strong>します。録音そのものは PMU を備えた Linux/x86_64 環境を要するため、レシピ追加時のオフライン作業として Vivarium 側で済ませてあります。
+      </p>
+    }
+    cantReach={
+      <ul>
+        <li><strong>環境制約。</strong> 訪問者のマシンは Linux/x86_64 が前提。ARM Mac や Windows の場合は Codespaces または WSL2 + Docker にフォールバック。</li>
+        <li><strong>カバレッジの形が違う。</strong> <code>rr</code> は単一プロセス Linux x86_64、分散シミュレーションツールは分散システムを対象。互いの領域はカバーしない。</li>
+        <li><strong>トレースが大きい。</strong> レシピあたり数十 MB から一桁 GB のオーダー。</li>
+      </ul>
+    }
+    runtimes={
+      <ul>
+        <li><a href="/vivarium/repro/pthread/lost-update/">pthread lost-update</a> — 真のスレッド競合を <code>rr</code> で決定的に保存し、訪問者は <code>rr replay</code> で巻き戻すだけ。</li>
+        <li>新しい Layer 3 レシピは PMU 録音のオフラインフットワークを要するため、追加ペースは L1/L2 より緩やか。</li>
+      </ul>
+    }
+  />
 
   <Callout>
-    どのレイヤーで動くかは、レシピ側があらかじめ宣言しています。あなたが選ぶ必要はなく、
-    レシピを開けば自動的にそのレイヤーで動作します。
+    どのレイヤーで動くかは、レシピ側があらかじめ宣言しています。あなたが選ぶ必要はなく、レシピを開けば自動的にそのレイヤーで動作します。
   </Callout>
 </Page>
 


### PR DESCRIPTION

Replaces the plain `Section` + `<h3>` columns the architecture page
used through Phase 6 with two new chrome components, addressing the
two issues `_context/v_prime_information_design_audit.md` §1.4 raised:
overview was visually denser than architecture, and the three layers
weren't comparable in parallel because L1/L2/L3 had inconsistent
sub-section counts.

- New `<LayerMatrix>` chrome component — a 4-row × 3-column scannable
  comparison strip rendered immediately under the page hero. Rows are
  the four attributes (起動時間 / 向くバグ / 届かないこと / 対応ランタイム),
  columns are the three layers; cells are React nodes so inline
  `<code>` and `<strong>` keep working. CSS Grid with a CSS variable
  (`--v-layer-matrix-cols`) for the column count so the component
  generalises if more layers are ever added.
- New `<LayerSection>` chrome component — replaces the per-layer
  `Section` block. Every layer now renders the same 4-cell grid
  (向くバグ / 起動と使い方 / 届かないこと / ランタイムと実例), each cell
  with a constant heading slot and an accent-tinted bullet marker /
  link border drawn from the layer's pill colour. Cell labels are
  passed in as a prop so EN and JA pages can localise without a
  client-side detect.
- Architecture page (EN + JA same-PR per ADR-0028 i18n DoD) rewritten
  to consume the new components. The runtime/deep-dive prose is
  preserved verbatim — this is a layout move, not a rewrite — and now
  carries inline cross-links to specific recipe pages
  (`cpython#137205`, `numpy#28287`, `php#12167`, `postgres-lost-update`,
  `pthread lost-update`, etc.) so the reader can step from the
  architecture overview to a working example without navigating away.
- Hero copy was tightened on both pages to advertise the new matrix
  ("下表で 3 層を一望してから、深掘りに進めます。" / "The matrix below
  scans the trade-offs at a glance; the deep-dive sections follow.").

Validated locally with `mise run ci:docs` (rspress build clean, all 60
HTML targets present including `architecture.html` and
`ja/architecture.html`) and `mise run docs:check` (Biome clean after
auto-format on the new components).

Phase 7 V′ progress: PR 4 of 7 from
`_context/v_prime_information_design_audit.md` §3.1 — landing (#174),
repro index (#175), repro compare (#177), now architecture. Roadmap
(PR 5), overview/spec/match (PR 6), guide index + nav (PR 7) follow.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/182).
* #185
* #184
* #183
* __->__ #182