### PR TITLE
feat(docs): phase 7 V′ — roadmap as a coarse "what works now" surface

### DIFF
--- a/docs/docs/en/roadmap.mdx
+++ b/docs/docs/en/roadmap.mdx
@@ -6,8 +6,8 @@ title: Roadmap
 import {
   Page,
   PageHero,
+  KpiStrip,
   Section,
-  NumberedList,
   Callout,
   NextCta,
   BottomNote,
@@ -15,91 +15,71 @@ import {
 
 <Page>
   <PageHero
-    eyebrow="// ROADMAP · v1"
-    title="Phases, not deadlines."
-    sub="The per-phase plan — what a visitor should expect to see land, in what order, framed in terms of the reproduction primitive."
+    eyebrow="// ROADMAP"
+    title="What's working now, and what's next."
+    sub="A coarse map of what Vivarium currently provides toward the goal of reproducing bugs in a browser. The forward-looking direction is being written up separately and will land here later."
+  />
+
+  <KpiStrip
+    items={[
+      { value: '11', label: 'Recipes shipped', accent: 'teal' },
+      { value: '3', label: 'Execution layers', accent: 'violet' },
+      { value: '5', label: 'MCP tools', accent: 'coral' },
+      { value: '2', label: 'Locales (EN / JA)', accent: 'teal' },
+    ]}
   />
 
   <Section
-    eyebrow="// 00 · A NOTE ON DATES"
-    heading="No due-date column."
+    eyebrow="// 01 · NOW"
+    heading="What's working today."
   >
     <p>
-      Phase durations on this project are directional — months to years — not
-      commitments. Inventing calendar targets for a lifelong project would
-      trade honesty for the appearance of progress, and would drive every later
-      decision toward hitting a number rather than reproducing bugs correctly.
+      Roughly in the order features were added. Each works independently — the fastest way to try something is to open the Reproductions, Guide, or Spec pages.
     </p>
+
+    <h3>Three execution layers</h3>
+    <ul>
+      <li><strong>Layer 1 — in-browser WebAssembly</strong>. Python (Pyodide) / Ruby.wasm / php-wasm / Rust (wasm32-wasip1). No account, no install — open the page and it runs.</li>
+      <li><strong>Layer 2 — Docker catalogue</strong>. Pinned Dockerfile + GHCR-published image. Visitor reproduces locally with one <code>docker run</code>.</li>
+      <li><strong>Layer 3 — record-replay</strong>. Self-contained GHCR images with the <code>rr</code> trace baked in. <code>rr replay</code> rewinds deterministically.</li>
+    </ul>
+
+    <h3>Reproduction catalogue</h3>
+    <ul>
+      <li>11 recipes shipped across the three layers (pandas / numpy / cpython / regex / ruby / php / postgres / flock / find-xargs / bash / pthread).</li>
+      <li>Faceted gallery, paste-an-error candidate matcher, project-level landing pages.</li>
+    </ul>
+
+    <h3>Public spec + CI integration</h3>
+    <ul>
+      <li><strong>Contract v1</strong> — the verdict.json wire shape published as JSON Schema.</li>
+      <li><strong>Manifest v1</strong> — TOML manifest letting an external repo declare a Vivarium-runnable reproduction with one <code>.vivarium/manifest.toml</code> file.</li>
+      <li>Reusable verdict-capture GitHub Actions workflow, weekly cron drift detection, interactive manifest scaffolder.</li>
+    </ul>
+
+    <h3>AI agent integration</h3>
+    <ul>
+      <li><strong>Vivarium MCP server</strong> — five tools (<code>list_recipes</code> / <code>get_recipe</code> / <code>lookup_verdict</code> / <code>match_error</code> / <code>verify_branch_fix</code>).</li>
+      <li><strong>AI-slop verification flow</strong> — match the error → open a recipe → paste a candidate fix → re-run → compare verdicts side-by-side, end-to-end.</li>
+    </ul>
+
+    <h3>User interface</h3>
+    <ul>
+      <li>Full EN ⇄ JA i18n with a symmetric URL tree and locale switcher.</li>
+      <li>Persona-route guide (5 minutes / repo integration / AI agent / write a reproduction / verify a branch fix / run on a fork / glossary).</li>
+      <li>Branch-fix verdict capture pipeline + side-by-side comparison page.</li>
+    </ul>
+  </Section>
+
+  <Section
+    eyebrow="// 02 · NEXT"
+    heading="What's next."
+  >
     <Callout>
-      When a phase acquires a real deadline, the date will land alongside the
-      phase, explained. Until then, the ordering and the "what shipped"
-      signals are the roadmap.
+      The forward-looking direction is being written up by the maintainer; details will land here at a separate moment.
     </Callout>
     <p>
-      Phase titles mirror the GitHub Milestones; the Milestones are the
-      canonical planning surface, and this page is the user-facing translation.
-    </p>
-  </Section>
-
-  <Section
-    eyebrow="// PHASES"
-    heading="What has shipped, what is shipping, what is queued."
-  >
-    <NumberedList
-      items={[
-        {
-          lead: 'Phase 0 — Bootstrap. CLOSED 2026-04-26.',
-          body: 'Infrastructure-as-Code foundations (GitHub Settings, labels, milestones, branch protection). The AI-delegated development workflow. Vision, architecture stub, roadmap. Initial src/ tree representing the three-layer architecture — scaffolding only, no product code.',
-        },
-        {
-          lead: 'Phase 1 — Layer 1: data processing.',
-          body: 'The first real reproduction vertical: Python + SQLite over WebAssembly via Pyodide. A handful of hand-picked upstream bugs (pandas / numpy / sqlite behavioural regressions) reproducible from a single browser tab. Bug description → linked reproduction page → click → pass/fail verdict.',
-        },
-        {
-          lead: 'Phase 2 — Layer 1: multi-language.',
-          body: 'Layer 1 broadens: Rust (wasm32-wasi), JavaScript/TypeScript, Ruby (Ruby.wasm), PHP (php-wasm). Common browser-side scaffolding extracted so adding a language is a small per-runtime adapter, not a greenfield rewrite.',
-        },
-        {
-          lead: 'Phase 3 — Layer 2: Docker.',
-          body: 'Full-fidelity container-based reproduction for bugs needing real fork, real sockets, real filesystems. Catalogue model (not hosted execution): pinned Dockerfile + repro.sh + GHCR-published image. Visitor reproduces locally with one `docker run`, optionally one-click via "Open in Codespaces". CI-snapshot verdict on each gallery page.',
-        },
-        {
-          lead: 'Phase 4 — Layer 3: record-replay & deterministic. CLOSED 2026-04-28.',
-          body: 'Third layer for bugs Layers 1 and 2 cannot reach: record-replay (rr) and deterministic simulation (Antithesis-style). Trace-shipped catalogue: trace baked into a GHCR image, replayed on the visitor’s machine. One recipe shipped (lost-update data race); further entries deferred until a concrete bug forces them.',
-        },
-        {
-          lead: 'Phase 5 — Ecosystem. CLOSED 2026-04-29.',
-          body: 'Contract v1 published as an external standard with JSON Schema and CI enforcement. Manifest v1 + three reference TOML manifests so external repos can declare a Vivarium-runnable reproduction with a single .vivarium/manifest.toml. Reusable verdict-capture GitHub Actions workflow. Verdict drift detection on the weekly cron. Issue-triage tooling deferred without adoption.',
-        },
-        {
-          lead: 'Phase 6 — Usability and visual layer. CLOSED 2026-05-02.',
-          body: 'Visual redesign + reusable component library landed (Stitch-driven mocks substituting for Claude Design after quota constraints). Full Japanese ⇄ English i18n with symmetric URL trees and translated spec pages. Reproduction comparison: Contract v1 evidence surface, branch-fix verdict capture pipeline, side-by-side comparison page. Faceted recipe gallery + paste-an-error → ranked-candidates matcher. Interactive manifest scaffolder. Vivarium MCP server with four tools (list_recipes, get_recipe, lookup_verdict, match_error). All six sub-streams (V, R, S, M, X, L) shipped at v1 scope; the closure rule (V + R + ≥1 of S/M/X/L) was satisfied four-times-over.',
-        },
-        {
-          lead: 'Phase 7 — First-30-minutes onboarding. ACTIVE.',
-          body: 'Turn "primitives are usable" (Phase 6) into "a stranger can pick this up cold". UI brush-up (V′ — information design, layout flow, visual-token revisit, component graduation) and onboarding documentation (D — getting started, integration guide, AI-agent setup, glossary) are co-defined: where the docs hit a wall, the UI is wrong. AI-slop verification (B3) wires the existing R.2 Path A + R.3 comparison + MCP match_error into one end-to-end walkthrough so an AI agent can drive "did my candidate fix actually work?" cold. A-tail clears Phase 6 leftovers: ajv-standalone migration for the verdict + manifest validators, and match_error v2 (synonym table, fuzzy match, language-specific stopwords). Phase closes when V′ + D + B3 ship; the A-tail is optional.',
-        },
-      ]}
-    />
-  </Section>
-
-  <Section
-    eyebrow="// MEASUREMENT"
-    heading="Closure rule: partial completion is acceptable."
-  >
-    <p>
-      Phase closure on this project follows a deliberate pattern set by the
-      Phase 4 close ADR (ADR-0012). When the shape of the phase is{' '}
-      <strong>proven by partial completion</strong> — one Layer 3 recipe,
-      one MCP tool, one external adopter — the phase closes and remaining work
-      is requeued. This protects the lifelong project from the slow-creep of
-      incomplete phases that never close.
-    </p>
-    <p>
-      The decisions that did <em>not</em> ship are recorded with the same care
-      as the ones that did. Public phase-close briefs cite the private ADRs
-      that captured the trade-offs, so future contributors understand{' '}
-      <em>why</em> a path was rejected, not just <em>that</em> it was.
+      For now this page captures "what's been built so far." If you have a use case or a "this is how I'd want to use it" request, drop it on <a href="https://github.com/aletheia-works/vivarium/issues">GitHub Issues</a> — those become the inputs when the forward map gets drawn up.
     </p>
   </Section>
 </Page>
@@ -112,12 +92,12 @@ import {
       <span className="v-next-cta__heading-arrow">→</span>
     </>
   }
-  sub="Once the phase shape is clear, the fastest way forward is to open one recipe in a browser tab and read the verdict."
+  sub="Opening one recipe in a browser tab and reading the verdict is the fastest way to see how Vivarium feels."
   primary={{ label: 'First five minutes →', href: '/vivarium/guide/getting-started' }}
-  ghost={{ label: 'Architecture', href: '/vivarium/architecture' }}
+  ghost={{ label: 'Reproductions', href: '/vivarium/repro/' }}
 />
 
 <BottomNote
-  text="VIVARIUM IS PART OF ALETHEIA-WORKS · OPEN THE SOURCE ON GITHUB →"
+  text="VIVARIUM is part of ALETHEIA-WORKS · See the source on GitHub →"
   href="https://github.com/aletheia-works/vivarium"
 />

--- a/docs/docs/ja/roadmap.mdx
+++ b/docs/docs/ja/roadmap.mdx
@@ -6,8 +6,8 @@ title: ロードマップ
 import {
   Page,
   PageHero,
+  KpiStrip,
   Section,
-  NumberedList,
   Callout,
   NextCta,
   BottomNote,
@@ -15,89 +15,71 @@ import {
 
 <Page>
   <PageHero
-    eyebrow="// ROADMAP · v1"
-    title="締め切りではなく、フェーズで。"
-    sub="フェーズごとの計画——何がいつ、どのような順序でリリースされるか。再現プリミティブという観点で語る。"
+    eyebrow="// ROADMAP"
+    title="いま動いているもの、これから。"
+    sub="ブラウザでバグを再現するという目標に対して、いま提供できているもののざっくりした地図。将来の方向性は別途整理して追記する予定です。"
+  />
+
+  <KpiStrip
+    items={[
+      { value: '11', label: 'Recipes shipped', accent: 'teal' },
+      { value: '3', label: 'Execution layers', accent: 'violet' },
+      { value: '5', label: 'MCP tools', accent: 'coral' },
+      { value: '2', label: 'Locales (EN / JA)', accent: 'teal' },
+    ]}
   />
 
   <Section
-    eyebrow="// 00 · 日付についての注記"
-    heading="期限の列はない。"
+    eyebrow="// 01 · NOW"
+    heading="いま動いているもの。"
   >
     <p>
-      このプロジェクトのフェーズ期間は方向性を示すもの——数ヶ月〜数年——であり、
-      コミットメントではない。終わりのないプロジェクトにカレンダー上の目標を設定することは、
-      正直さを犠牲にして進捗の外観を作るだけであり、以降のあらゆる決断を
-      「正しくバグを再現する」ではなく「数字を達成する」方向に歪める。
+      おおむね機能が積み上がった順。それぞれは独立に触れます——「再現一覧」「ガイド」「仕様」のページから入って試すのが一番速いです。
     </p>
+
+    <h3>3 つの実行レイヤー</h3>
+    <ul>
+      <li><strong>Layer 1 — ブラウザ内 WebAssembly</strong>。Python (Pyodide) / Ruby.wasm / php-wasm / Rust (wasm32-wasip1)。アカウント不要、ページを開けば動く。</li>
+      <li><strong>Layer 2 — Docker カタログ</strong>。ピン留めされた Dockerfile + GHCR 公開イメージ。訪問者の <code>docker run</code> でローカル再現。</li>
+      <li><strong>Layer 3 — record-replay</strong>。<code>rr</code> トレースを焼き込んだ自己完結 GHCR イメージ。<code>rr replay</code> だけで決定論的に巻き戻る。</li>
+    </ul>
+
+    <h3>再現カタログ</h3>
+    <ul>
+      <li>11 件のレシピを 3 つのレイヤーにわたって出荷（pandas / numpy / cpython / regex / ruby / php / postgres / flock / find-xargs / bash / pthread）。</li>
+      <li>ファセット付きギャラリー、エラーメッセージ貼付による候補レシピ検索、プロジェクト別ランディングページ。</li>
+    </ul>
+
+    <h3>公開仕様 + CI 連携</h3>
+    <ul>
+      <li><strong>Contract v1</strong> — verdict.json の wire shape を JSON Schema として公開。</li>
+      <li><strong>Manifest v1</strong> — 外部リポジトリが <code>.vivarium/manifest.toml</code> 1 ファイルで再現を宣言できる TOML マニフェスト。</li>
+      <li>再利用可能な verdict キャプチャ用 GitHub Actions ワークフロー、週次 cron による drift 検知、対話的なマニフェストスキャフォルダー。</li>
+    </ul>
+
+    <h3>AI エージェント連携</h3>
+    <ul>
+      <li><strong>Vivarium MCP サーバ</strong> — 5 つのツール (<code>list_recipes</code> / <code>get_recipe</code> / <code>lookup_verdict</code> / <code>match_error</code> / <code>verify_branch_fix</code>)。</li>
+      <li><strong>AI-slop 検証フロー</strong> — エラーをマッチ → レシピを開く → 修正候補を貼って再実行 → verdict をサイドバイサイドで比較するエンドツーエンドの動線。</li>
+    </ul>
+
+    <h3>ユーザーインターフェース</h3>
+    <ul>
+      <li>EN ⇄ JA 完全 i18n。対称な URL ツリー + ロケール切替。</li>
+      <li>ペルソナ別ガイド（最初の 5 分 / リポ統合 / AI エージェントから / 再現を書く / branch-fix 検証 / フォークで動かす / 用語集）。</li>
+      <li>branch-fix verdict キャプチャパイプライン + サイドバイサイド比較ページ。</li>
+    </ul>
+  </Section>
+
+  <Section
+    eyebrow="// 02 · NEXT"
+    heading="これから。"
+  >
     <Callout>
-      フェーズに本当の締め切りが生まれたとき、日付はフェーズとともに説明付きで掲載される。
-      それまでは、順序と「出荷した内容」のシグナルがロードマップだ。
+      将来的に何を目指していくかは、メンテナーが現在整理中。詳細は別タイミングで追記します。
     </Callout>
     <p>
-      フェーズタイトルは GitHub Milestones に対応する。Milestones が正式な計画サーフェスであり、
-      このページはユーザー向けの翻訳だ。
-    </p>
-  </Section>
-
-  <Section
-    eyebrow="// フェーズ"
-    heading="出荷済み、出荷中、キューにあるもの。"
-  >
-    <NumberedList
-      items={[
-        {
-          lead: 'Phase 0 — Bootstrap。2026-04-26 CLOSED。',
-          body: 'Infrastructure-as-Code の基盤（GitHub 設定、ラベル、マイルストーン、ブランチ保護）。AI 委譲開発ワークフロー。ビジョン、アーキテクチャスタブ、ロードマップ。三層アーキテクチャを表す初期 src/ ツリー——製品コードなし、スキャフォールドのみ。',
-        },
-        {
-          lead: 'Phase 1 — Layer 1: データ処理。',
-          body: '初の本格的な再現実装: Pyodide による Python + SQLite over WebAssembly。手選びのアップストリームバグ数件（pandas / numpy / sqlite の動作リグレッション）が、ブラウザのタブ 1 枚から再現可能になる。バグの説明 → リンク先の再現ページ → クリック → pass/fail verdict。',
-        },
-        {
-          lead: 'Phase 2 — Layer 1: 多言語。',
-          body: 'Layer 1 の拡張: Rust (wasm32-wasi)、JavaScript/TypeScript、Ruby (Ruby.wasm)、PHP (php-wasm)。言語を追加する作業がゼロからの書き直しではなく小さなランタイムアダプタになるよう、共通のブラウザサイドスキャフォールドを抽出。',
-        },
-        {
-          lead: 'Phase 3 — Layer 2: Docker。',
-          body: '本物の fork、本物のソケット、本物のファイルシステムが必要なバグのための完全忠実度コンテナ再現。カタログモデル（ホスト実行ではない）: ピン留めされた Dockerfile + repro.sh + GHCR 公開イメージ。訪問者は 1 回の `docker run` でローカル再現。必要に応じて「Open in Codespaces」でワンクリック。CI スナップショット verdict が各ギャラリーページに掲載。',
-        },
-        {
-          lead: 'Phase 4 — Layer 3: record-replay & deterministic。2026-04-28 CLOSED。',
-          body: 'Layer 1 と Layer 2 では届かないバグのための第三のレイヤー: record-replay (rr) と決定論的シミュレーション (Antithesis スタイル)。トレース同梱カタログ: トレースを GHCR イメージに焼き込み、訪問者のマシン上で replay。1 つのレシピ出荷（lost-update データレース）。以降のエントリは具体的なバグが生まれるまで保留。',
-        },
-        {
-          lead: 'Phase 5 — Ecosystem。2026-04-29 CLOSED。',
-          body: 'Contract v1 を JSON Schema と CI 強制付きの外部標準として公開。Manifest v1 と 3 つのリファレンス TOML マニフェストにより、外部リポジトリが `.vivarium/manifest.toml` 1 ファイルで Vivarium 実行可能な再現を宣言できるようになった。再利用可能な verdict キャプチャ用 GitHub Actions ワークフロー。週次 cron による verdict ドリフト検出。Issue トリアージツールは採用がないため保留。',
-        },
-        {
-          lead: 'Phase 6 — ユーザビリティとビジュアルレイヤー。2026-05-02 CLOSED。',
-          body: 'ビジュアルリデザイン + 再利用可能コンポーネントライブラリ出荷（Claude Design の利用枠制限を回避するため Stitch 駆動のモックで代替）。対称 URL ツリーと翻訳済み仕様ページを伴う完全な日本語 ⇄ 英語 i18n。再現比較: Contract v1 evidence サーフェス、branch-fix verdict キャプチャパイプライン、横並び比較ページ。ファセット付きレシピギャラリー + エラーを貼り付けると候補レシピがランク順に出るマッチャー。対話的なマニフェストスキャフォルダー。Vivarium MCP サーバには 4 つのツール（list_recipes、get_recipe、lookup_verdict、match_error）。6 つすべてのサブストリーム（V, R, S, M, X, L）が v1 スコープで出荷され、クローズルール（V + R + S/M/X/L のうち少なくとも 1 つ）は 4 重に充足された。',
-        },
-        {
-          lead: 'Phase 7 — はじめの 30 分のオンボーディング。ACTIVE。',
-          body: 'Phase 6 の「プリミティブは使える」状態を「初見の人が冷めた状態から拾える」状態へ引き上げる。UI ブラッシュアップ（V′ — 情報設計、レイアウト動線、ビジュアルトークン磨き込み、コンポーネント graduation）とオンボーディングドキュメント（D — getting started、統合ガイド、AI エージェント設定、用語集）は表裏一体: ドキュメントが壁に当たるところは UI が間違っている証拠。AI-slop 検証（B3）は既存の R.2 Path A + R.3 比較ページ + MCP match_error を一本のエンドツーエンドウォークスルーに繋ぎ、AI エージェントが「自分の候補修正は本当に機能しているのか?」を冷めた状態から駆動できるようにする。A-tail は Phase 6 の残作業を片付ける: verdict + manifest validator の ajv-standalone マイグレ、および match_error v2（同義語テーブル、ファジーマッチ、言語別 stopword）。V′ + D + B3 が出荷したらクローズ。A-tail は optional。',
-        },
-      ]}
-    />
-  </Section>
-
-  <Section
-    eyebrow="// 計測"
-    heading="クローズルール: 部分的な完成でよい。"
-  >
-    <p>
-      このプロジェクトのフェーズクローズは、Phase 4 クローズ ADR (ADR-0012) で定めた
-      意図的なパターンに従う。フェーズの輪郭が
-      <strong>部分的な完成によって証明</strong>されたとき——1 つの Layer 3 レシピ、
-      1 つの MCP ツール、1 人の外部採用者——フェーズはクローズし、
-      残作業は再キューイングされる。これにより、いつまでも閉じない「未完フェーズ」が
-      じわじわと累積していく事態からプロジェクトを守っている。
-    </p>
-    <p>
-      出荷しなかった決断も、出荷した決断と同じ丁寧さで記録される。
-      公開のフェーズクローズ要約は、トレードオフを捉えたプライベート ADR を参照しているため、
-      将来のコントリビューターは「なぜそのパスが却下されたのか」まで理解できるようになっている。
+      現段階では「ここまで来た」を共有できる段階で、その先の方向性は別の場でまとめる予定です。気になることや「こう使いたい」というユースケースがあれば、<a href="https://github.com/aletheia-works/vivarium/issues">GitHub Issues</a> にリクエストや提案として残しておいてください。先の地図を描くときの材料になります。
     </p>
   </Section>
 </Page>
@@ -110,9 +92,9 @@ import {
       <span className="v-next-cta__heading-arrow">→</span>
     </>
   }
-  sub="フェーズの全体像を把握したら、ブラウザのタブ 1 枚で 1 つのレシピを動かして verdict を読むのが一番速い。"
+  sub="ブラウザのタブ 1 枚で 1 つのレシピを動かして verdict を読むのが、一番速い「触ってみる」。"
   primary={{ label: 'はじめての 5 分 →', href: '/vivarium/ja/guide/getting-started' }}
-  ghost={{ label: 'アーキテクチャ', href: '/vivarium/ja/architecture' }}
+  ghost={{ label: '再現一覧', href: '/vivarium/ja/repro/' }}
 />
 
 <BottomNote


### PR DESCRIPTION

Reviewing the original roadmap rewrite (timeline cards, phase
numbering, status badges, ADR references, closure-rule explainer)
the maintainer flagged it as wrong-audience: ADRs are gitignored
private memos, so naming them on a public page is meaningless to
readers; phase numbering / closure rules / "no due-date column"
disclaimers are internal-process concerns visitors do not come to
the roadmap to read; and the per-phase shipped-bullets surface was
too granular for the actual reader, who comes to the roadmap to
ask "what does this project provide today, and where is it going?"
not "what did sub-stream V.1 ship in Phase 6 in March."

This commit re-targets the page at the visitor:

- Hero re-centered: "いま動いているもの、これから。" / "What's
  working now, and what's next." Frames the page as a snapshot of
  current capability + a placeholder for future direction, instead
  of a per-phase ledger.
- KpiStrip swapped from phase-counter metrics (8 queued / 7 closed)
  to feature-shape metrics: 11 recipes, 3 execution layers, 5 MCP
  tools, 2 locales. Same component, different reading.
- "What's working today" section restructured by feature area, not
  by phase: three execution layers, the reproduction catalogue,
  the public spec + CI integration, AI agent integration, and the
  user interface. Each gets one short paragraph + a 2–3 item bullet
  list of concrete deliverables. Reading order roughly follows
  build order without numbering anything as "Phase N".
- "What's next" section is honest placeholder copy + a Callout that
  the forward-looking direction is being written up separately.
  Closes by inviting use-case feedback on GitHub Issues, since
  those are the real input when the forward map gets drawn.
- Removed the "no due-date column" preamble, the closure-rule
  Section, the ADR-0012 reference, and every per-phase
  `RoadmapTimeline` / `StatusBadge` invocation. The two components
  added in the original draft of this commit (`RoadmapTimeline`,
  `StatusBadge` + their CSS) are now unused so they are also
  removed from `PageChrome.tsx` / `page-chrome.css` — YAGNI; if a
  later page needs a phase-card visual it can be re-added with a
  concrete consumer.

i18n DoD respected (EN + JA same-PR). Validated locally with
`mise run docs:check` (Biome clean) and `mise exec -- bun run
build` from `docs/` (rspress build clean, all 60 HTML targets
present including roadmap.html and ja/roadmap.html).

Phase 7 V′ progress: PR 5 of 7 from
`_context/v_prime_information_design_audit.md` §3.1, but the
audit's recommendation ("StatusBadge / TimelineMarker, ACTIVE
phase highlight, KPI strip") is now a partial follow — KpiStrip
adopted, the timeline + status-badge visuals dropped per
maintainer feedback as too internal-jargon-heavy for the
intended audience.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/183).
* #185
* #184
* __->__ #183