### PR TITLE
feat(docs): phase 7 V′ — overview persona routes + spec reading map + match examples

### DIFF
--- a/docs/components/PageChrome.tsx
+++ b/docs/components/PageChrome.tsx
@@ -133,12 +133,22 @@ export function LayerCards({
     title: string;
     body: ReactNode;
     runtimes: string;
+    /** Optional pictographic icon shown above the pill (e.g. a lucide-react icon). */
+    icon?: ReactNode;
   }[];
 }) {
   return (
     <div className="v-layers">
       {layers.map((layer, i) => (
-        <article key={i} className="v-layer">
+        <article key={i} className={`v-layer v-layer--${layer.accent}`}>
+          {layer.icon ? (
+            <div
+              className={`v-layer__icon v-layer__icon--${layer.accent}`}
+              aria-hidden="true"
+            >
+              {layer.icon}
+            </div>
+          ) : null}
           <span className={`v-layer__pill v-layer__pill--${layer.accent}`}>
             {layer.pill}
           </span>
@@ -290,6 +300,99 @@ export function LayerSection({
         </div>
       </div>
     </section>
+  );
+}
+
+/* ----------------------------- RouteCards ----------------------------- */
+
+/**
+ * Persona-route grid for "what you came here to do" cards. Used on
+ * the overview / guide-map / spec pages — distinct from `LayerCards`
+ * (which is about the three execution layers, not reader intent).
+ *
+ * Layout:
+ *   - 1 column on mobile.
+ *   - For 3 cards on desktop: 1×3 strip.
+ *   - For 4 cards on desktop: 2×2 grid (1×4 squeezes the cards too
+ *     narrow inside the rspress doc-content max-width).
+ *
+ * Each card optionally carries a pictographic icon (`icon`, e.g. a
+ * lucide-react icon) so the visual scan can pick up the route without
+ * reading the kicker.
+ */
+export function RouteCards({
+  cards,
+}: {
+  cards: {
+    kicker: string;
+    title: string;
+    body: ReactNode;
+    href: string;
+    /** Optional pictographic icon (e.g. a lucide-react icon). */
+    icon?: ReactNode;
+  }[];
+}) {
+  // 4-card layouts use a 2-column grid (rendered 2×2). 3-card and
+  // smaller stay at their natural column count. Larger counts fall
+  // back to the natural count too — a future caller can revisit.
+  const desktopCols = cards.length === 4 ? 2 : cards.length;
+  return (
+    <div
+      className="v-routes"
+      style={
+        {
+          '--v-routes-cols': desktopCols,
+        } as CSSProperties
+      }
+    >
+      {cards.map((card, i) => (
+        <a key={i} className="v-routes__card" href={card.href}>
+          {card.icon ? (
+            <div className="v-routes__icon" aria-hidden="true">
+              {card.icon}
+            </div>
+          ) : null}
+          <span className="v-routes__kicker">{card.kicker}</span>
+          <h3 className="v-routes__title">{card.title}</h3>
+          <p className="v-routes__body">{card.body}</p>
+          <span className="v-routes__cta" aria-hidden="true">
+            →
+          </span>
+        </a>
+      ))}
+    </div>
+  );
+}
+
+/* ----------------------------- InlineCta ----------------------------- */
+
+/**
+ * Short inline CTA designed to sit between two sections of the same
+ * page — lighter weight than `NextCta` (which closes the page) and
+ * narrower than the full-width `Callout`. Used to nudge readers from
+ * the deep-dive content above to the live example below without
+ * forcing them to scroll to the page footer.
+ */
+export function InlineCta({
+  text,
+  link,
+}: {
+  text: ReactNode;
+  link: { label: ReactNode; href: string };
+}) {
+  // Rendered as a <div>, NOT a <p>: rspress's `.v-section__body p`
+  // rule (specificity 0,1,1) sets margin-top:0 which would beat
+  // `.v-inline-cta` (specificity 0,1,0) and crush the spacing this
+  // component is meant to provide between sibling sections. Using a
+  // <div> sidesteps the p-rule and keeps `.v-inline-cta`'s
+  // margin-top in effect.
+  return (
+    <div className="v-inline-cta">
+      <span className="v-inline-cta__text">{text}</span>
+      <a className="v-inline-cta__link" href={link.href}>
+        {link.label} <span aria-hidden="true">→</span>
+      </a>
+    </div>
   );
 }
 

--- a/docs/components/page-chrome.css
+++ b/docs/components/page-chrome.css
@@ -474,6 +474,45 @@ html.dark {
   background: var(--vh-card-bg);
 }
 
+/* Pictographic icon shown above the pill on overview LayerCards.
+ * Sized to render lucide-react icons cleanly; the icon SVG is the
+ * `currentColor`-driven kind, so the per-accent color rules below
+ * tint it via the wrapper's `color`. */
+.v-layer__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  margin-bottom: 1.25rem;
+  border-radius: 10px;
+  background: var(--vh-card-bg-hover);
+  border: 1px solid var(--vh-hairline);
+}
+
+.v-layer__icon svg {
+  width: 1.625rem;
+  height: 1.625rem;
+}
+
+.v-layer__icon--teal {
+  color: var(--vh-accent-teal-bright);
+  background: rgba(0, 212, 170, 0.08);
+  border-color: rgba(0, 212, 170, 0.25);
+}
+
+.v-layer__icon--violet {
+  color: var(--vh-accent-violet-bright);
+  background: rgba(124, 92, 255, 0.08);
+  border-color: rgba(124, 92, 255, 0.25);
+}
+
+.v-layer__icon--coral {
+  color: var(--vh-accent-coral);
+  background: rgba(255, 113, 108, 0.08);
+  border-color: rgba(255, 113, 108, 0.25);
+}
+
 .v-layer__pill {
   display: inline-block;
   width: fit-content;
@@ -789,6 +828,153 @@ html.dark {
 
 .v-layer-section--coral .v-layer-section__cell-body a:hover {
   border-bottom-color: var(--vh-accent-coral);
+}
+
+/* ---------- Route cards (persona-route grid) ---------- */
+
+.v-routes {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+@media (min-width: 768px) {
+  .v-routes {
+    grid-template-columns: repeat(var(--v-routes-cols, 3), 1fr);
+  }
+}
+
+.v-routes__card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem 1.5rem 3rem;
+  border: 1px solid var(--vh-hairline);
+  border-radius: 10px;
+  background: var(--vh-card-bg);
+  color: inherit;
+  text-decoration: none;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.v-routes__card:hover {
+  border-color: rgba(0, 212, 170, 0.45);
+  background: var(--vh-card-bg-hover);
+}
+
+/* Pictographic icon shown above the kicker on RouteCards. Same
+ * shape as `.v-layer__icon`; renders lucide-react SVG icons cleanly
+ * and consistently across both card families. */
+.v-routes__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  margin-bottom: 1rem;
+  border-radius: 8px;
+  color: var(--vh-accent-teal-bright);
+  background: rgba(0, 212, 170, 0.08);
+  border: 1px solid rgba(0, 212, 170, 0.25);
+}
+
+.v-routes__icon svg {
+  width: 1.4rem;
+  height: 1.4rem;
+}
+
+.v-routes__kicker {
+  display: inline-block;
+  margin-bottom: 0.85rem;
+  padding: 0.15rem 0.5rem;
+  width: fit-content;
+  border-radius: 0.25rem;
+  font-family: "JetBrains Mono", monospace;
+  font-weight: 700;
+  font-size: 0.625rem;
+  letter-spacing: 0.05em;
+  color: var(--vh-accent-teal-bright);
+  background: rgba(0, 212, 170, 0.12);
+  text-transform: uppercase;
+}
+
+.v-routes__title {
+  margin: 0 0 0.6rem;
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 600;
+  font-size: 1.05rem;
+  line-height: 1.3;
+  color: var(--vh-text);
+}
+
+.v-routes__body {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--vh-text-muted);
+}
+
+.v-routes__cta {
+  position: absolute;
+  bottom: 1.25rem;
+  right: 1.5rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 1rem;
+  color: var(--vh-accent-teal);
+  transition: transform 0.2s ease;
+}
+
+.v-routes__card:hover .v-routes__cta {
+  transform: translateX(4px);
+}
+
+/* ---------- Inline CTA (between sections of one page) ---------- */
+
+.v-inline-cta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 1rem;
+  /* Sit clearly below whatever just preceded — typically a LayerCards
+   * row or a body paragraph — without crowding either. The previous
+   * 1.75rem gap looked stuck-on against the LayerCards row at desktop
+   * widths; 3rem matches the v-section default rhythm. */
+  margin: 3rem 0 0;
+  padding: 0.85rem 1.25rem;
+  border-left: 3px solid var(--vh-accent-teal);
+  background: rgba(0, 212, 170, 0.04);
+  border-radius: 0 6px 6px 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.v-inline-cta__text {
+  flex: 1 1 auto;
+  color: var(--vh-text-muted);
+}
+
+.v-inline-cta__text strong {
+  color: var(--vh-text);
+  font-weight: 600;
+}
+
+.v-inline-cta__link {
+  flex: 0 0 auto;
+  color: var(--vh-accent-teal);
+  text-decoration: none;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid rgba(0, 212, 170, 0.4);
+  transition: border-color 0.18s ease;
+}
+
+.v-inline-cta__link:hover {
+  border-bottom-color: var(--vh-accent-teal);
 }
 
 /* ---------- Numbered list ---------- */

--- a/docs/docs/en/overview.mdx
+++ b/docs/docs/en/overview.mdx
@@ -8,10 +8,21 @@ import {
   PageHero,
   Section,
   LayerCards,
+  RouteCards,
+  InlineCta,
   Callout,
   NextCta,
   BottomNote,
 } from '../../components/PageChrome';
+import {
+  Bot,
+  Code2,
+  Container,
+  GitBranch,
+  Globe,
+  History,
+  Zap,
+} from 'lucide-react';
 
 <Page>
   <PageHero
@@ -25,22 +36,17 @@ import {
     heading="A platform for bug reproduction."
   >
     <p>
-      Vivarium is <strong>a platform for reproducing bugs</strong>. Open a
-      page, click once, and find out whether a previously-reported bug
-      still reproduces — or whether a candidate fix actually fixes it.
+      Vivarium is <strong>a platform for reproducing bugs</strong>. Open a page, click once, and find out whether a previously-reported bug still reproduces — or whether a candidate fix actually fixes it.
     </p>
     <p>
-      For each upstream bug, the catalogue holds one <strong>recipe</strong>.
-      Every recipe satisfies the same <code>verdict.json v1</code> contract,
-      so each page returns either <code>reproduced</code> (the bug
-      reproduces) or <code>unreproduced</code> (it does not). Results show
-      inline on the page and are also exposed as machine-readable JSON.
+      For each upstream bug, the catalogue holds one <strong>recipe</strong>. Every recipe satisfies the same <code>verdict.json v1</code> contract, so each page returns either <code>reproduced</code> (the bug reproduces) or <code>unreproduced</code> (it does not). Results show inline on the page and are also exposed as machine-readable JSON.
     </p>
     <Callout>
-      Vivarium ships bugs as <strong>runnable artefacts, not write-ups</strong>.
-      Instead of someone telling you "this is a bug," you open it in your
-      browser and watch.
+      Vivarium ships bugs as <strong>runnable artefacts, not write-ups</strong>. Instead of someone telling you "this is a bug," you open it in your browser and watch.
     </Callout>
+    <p>
+      The trigger was the surge of AI-generated bug reports and pull requests. Maintainers were drowning in plausible-but-unverified claims arriving at machine speed, and contributors had no way to check whether their own AI-drafted fixes actually worked. The shared root cause — no cheap, universal way to verify whether a bug is real or whether a fix actually fixes it — is what Vivarium addresses.
+    </p>
   </Section>
 
   <Section
@@ -48,9 +54,7 @@ import {
     heading="Each recipe declares the layer that fits the bug."
   >
     <p>
-      Bugs differ wildly in what environment they need. Vivarium organises
-      reproduction techniques into three layers, and you don't pick the
-      layer — the recipe declares it for you.
+      Bugs differ wildly in what environment they need. Vivarium organises reproduction techniques into three layers, and you don't pick the layer — the recipe declares it for you.
     </p>
 
     <LayerCards
@@ -58,13 +62,15 @@ import {
         {
           pill: 'L1',
           accent: 'teal',
+          icon: <Globe />,
           title: 'Instant start, browser-native',
-          body: 'The reproduction runs directly in your browser via WebAssembly. Startup is milliseconds to a few seconds. Right for algorithms, parsers, data processing, and in-memory database operations — bugs that don\'t need a full OS.',
+          body: "The reproduction runs directly in your browser via WebAssembly. Startup is milliseconds to a few seconds. Right for algorithms, parsers, data processing, and in-memory database operations — bugs that don't need a full OS.",
           runtimes: 'Pyodide · sqlite-wasm · wasm32-wasi · Ruby.wasm · PHP.wasm',
         },
         {
           pill: 'L2',
           accent: 'violet',
+          icon: <Container />,
           title: 'Full fidelity, container execution',
           body: 'The reproduction runs inside Docker or a microVM. Startup is seconds to a minute. Right for bugs that depend on a real filesystem, real processes, or real networking.',
           runtimes: 'Docker · Firecracker · gVisor',
@@ -72,30 +78,64 @@ import {
         {
           pill: 'L3',
           accent: 'coral',
+          icon: <History />,
           title: 'Third way',
-          body: 'Record-replay, deterministic simulation, WASI Preview 3+, snapshot-based restore — and techniques that don\'t exist yet. For bugs that L1 and L2 can\'t reach.',
+          body: "Record-replay, deterministic simulation, WASI Preview 3+, snapshot-based restore — and techniques that don't exist yet. For bugs that L1 and L2 can't reach.",
           runtimes: 'rr · Antithesis · CRIU · WASI Preview 3+',
         },
       ]}
     />
+
+    <InlineCta
+      text={
+        <>
+          <strong>See all three layers in action.</strong>{' '}
+          The gallery shows L1 / L2 / L3 recipes side-by-side with facet filters, so you can compare layers in one click.
+        </>
+      }
+      link={{ label: 'Reproductions', href: '/vivarium/repro/' }}
+    />
   </Section>
 
   <Section
-    eyebrow="// 03 · HOW WE GOT HERE"
-    heading="The cheap-verification gap."
+    eyebrow="// 03 · WHERE TO START"
+    heading="One first page per audience."
   >
     <p>
-      The trigger was the surge of AI-generated bug reports and pull
-      requests. Maintainers were drowning in plausible-but-unverified
-      claims arriving at machine speed; contributors had no way to check
-      whether their own AI-drafted fixes actually worked.
+      Vivarium has different entry points for different readers. The cards below are persona-route shortcuts — each one lands you at a "see it work yourself" surface within 5–30 minutes.
     </p>
-    <p>
-      The shared root cause is that <strong>there is no cheap, universal
-      way to verify whether a bug is real or whether a fix actually fixes
-      it</strong>. Vivarium provides one — "does this reproduce?" reduced
-      to a single click.
-    </p>
+    <RouteCards
+      cards={[
+        {
+          kicker: '01 · 5 MIN',
+          icon: <Zap />,
+          title: 'First five minutes',
+          body: 'Open a recipe in your browser, click once, read the verdict. No install, no account — try it now.',
+          href: '/vivarium/guide/getting-started',
+        },
+        {
+          kicker: '02 · INTEGRATE',
+          icon: <GitBranch />,
+          title: 'Integrate with your repo',
+          body: "One `.vivarium/manifest.toml` plus a reusable workflow registers a reproduction from your own repository.",
+          href: '/vivarium/guide/integrate-with-your-repo',
+        },
+        {
+          kicker: '03 · AI AGENT',
+          icon: <Bot />,
+          title: 'Use from your AI agent',
+          body: 'Drive the five MCP tools from Claude Code / Aider / Cline via `@aletheia-works/vivarium-mcp`.',
+          href: '/vivarium/guide/use-from-ai-agent',
+        },
+        {
+          kicker: '04 · CONTRIBUTE',
+          icon: <Code2 />,
+          title: 'Write your first reproduction',
+          body: 'Add one recipe under `src/layer1_wasm/<slug>/` — the shared scaffolding handles most of the wiring.',
+          href: '/vivarium/guide/write-your-first-reproduction',
+        },
+      ]}
+    />
   </Section>
 </Page>
 

--- a/docs/docs/en/repro/match.mdx
+++ b/docs/docs/en/repro/match.mdx
@@ -3,15 +3,35 @@ pageType: doc
 title: Match an error
 ---
 
-import { Page, PageHero } from '../../../components/PageChrome';
+import { Page, PageHero, Section } from '../../../components/PageChrome';
 import { ErrorRecipeMatcher } from '../../../components/ErrorRecipeMatcher';
 
 <Page>
   <PageHero
     eyebrow="// MATCH · ERROR → RECIPE"
     title={<>Paste an error, find a candidate.</>}
-    sub="Mechanical token-overlap match against the recipe catalogue. No LLM — lowercase tokens are scored against each recipe's symptom, tags, project, and slug. Phase 7 A5 adds a synonym table (e.g. dtype⇄datatype), Levenshtein-1 fuzzy match for tokens of length ≥ 6, and multi-language stopwords. All scoring runs locally."
+    sub="Local scoring. No LLM — mechanical token overlap only."
   />
 
   <ErrorRecipeMatcher lang="en" />
+
+  <Section
+    eyebrow="// 03 · WHERE IT WORKS"
+    heading="Three patterns the matcher catches."
+  >
+    <h3>1. Robust to synonyms</h3>
+    <p>
+      Paste "<code>dtype mismatch</code>" and recipes mentioning "datatype", "dtypes", or "numpy.dtype" surface as candidates too. Phase 7 A5's synonym table normalises pairs like <code>dtype⇄datatype</code>, <code>regex⇄regexp</code>, and <code>fork⇄spawn</code> to a single key — you don't have to guess the project's preferred spelling.
+    </p>
+
+    <h3>2. Robust to typos (fuzzy match)</h3>
+    <p>
+      A single-character typo like "<code>recursoin depth exceeded</code>" is absorbed via Levenshtein distance 1 (limited to tokens of length ≥ 6 to avoid false positives on short tokens, which stay strict). Fewer "I know there's a recipe for this but it isn't matching" surprises.
+    </p>
+
+    <h3>3. Mixed-language input is fine (multi-language stopwords)</h3>
+    <p>
+      Pasting "<code>pandas で empty DataFrame の dtype が変わる</code>" — Japanese meta-text mixed with English technical terms — works because Japanese stopwords ("で", "の", "が") and English stopwords ("the", "a", "is") are both stripped. Stack-traced log lines paste in as-is.
+    </p>
+  </Section>
 </Page>

--- a/docs/docs/en/spec/index.mdx
+++ b/docs/docs/en/spec/index.mdx
@@ -8,6 +8,7 @@ import {
   PageHero,
   Section,
   CompareCards,
+  RouteCards,
   Callout,
   NextCta,
   BottomNote,
@@ -17,7 +18,7 @@ import {
   <PageHero
     eyebrow="// SPEC · v1"
     title="Vivarium specification."
-    sub="The reproduction-verdict contract — a small, stable surface that describes whether the upstream bug reproduces against today's runtime."
+    sub="The reproduction-verdict contract and the catalogue surfaces — a small, stable set of files describing whether the upstream bug reproduces against today's runtime."
   />
 
   <Section
@@ -25,23 +26,13 @@ import {
     heading="A versioned surface."
   >
     <p>
-      The Vivarium specification is the small set of files that lets a
-      reproduction page declare itself, lets external tools read the verdict,
-      and lets external repos publish their own reproductions without bespoke
-      glue.
+      The Vivarium specification is the small set of files that lets a reproduction page declare itself, lets external tools read the verdict, and lets external repos publish their own reproductions without bespoke glue.
     </p>
 
     <Callout>
-      Reproduction pages declare conformance via{' '}
-      <code>&lt;meta name="vivarium-contract" content="v1"&gt;</code>; external
-      tools read the same surface to know whether a page reproduces today.
+      Reproduction pages declare conformance via <code>&lt;meta name="vivarium-contract" content="v1"&gt;</code>; external tools read the same surface to know whether a page reproduces today.
     </Callout>
-  </Section>
 
-  <Section
-    eyebrow="// 02 · CURRENT SURFACES"
-    heading="Three surfaces, one contract."
-  >
     <CompareCards
       others={[
         {
@@ -63,79 +54,76 @@ import {
           'aletheia-works.github.io/vivarium/api/recipes.json — refreshed on each deploy',
       }}
     />
+  </Section>
 
+  <Section
+    eyebrow="// 02 · WHAT TO READ"
+    heading="A reading map by audience."
+  >
+    <p>
+      The spec has different entry points for different readers. The cards below are role-based shortcuts — start where you actually need to be, skip the rest.
+    </p>
+    <RouteCards
+      cards={[
+        {
+          kicker: '01 · BUILD',
+          title: "If you're writing a reproduction",
+          body: 'The verdict.json wire shape, and how to declare a reproduction from your own repo. Contract v1 + Manifest v1.',
+          href: '/vivarium/spec/contract-v1',
+        },
+        {
+          kicker: '02 · CONSUME',
+          title: "If you're driving the catalogue",
+          body: 'The machine-readable list of every recipe Vivarium hosts — used by AI agents and external catalogue tooling. Recipes index v1.',
+          href: '/vivarium/spec/recipes-index-v1',
+        },
+        {
+          kicker: '03 · CI',
+          title: "If you're verifying in CI",
+          body: 'Reusable GitHub Actions workflows for verdict capture and the branch-fix verdict comparison pipeline.',
+          href: '/vivarium/spec/consumer-workflow',
+        },
+      ]}
+    />
+  </Section>
+
+  <Section
+    eyebrow="// 03 · SURFACES"
+    heading="Three spec docs + two tooling workflows."
+  >
     <h3>Contract v1 — verdict surface</h3>
     <p>
-      <a href="/vivarium/spec/contract-v1">Contract v1</a> defines what every
-      reproduction page promises: a <code>verdict</code> DOM band, a structured
-      result envelope on <code>window.__VIVARIUM_RESULT__</code>, and the same
-      reproduced / unreproduced / pending semantics across all three layers.
-      The Layer 2 / 3 verdict snapshot file follows{' '}
-      <a href="https://github.com/aletheia-works/vivarium/blob/main/docs/public/spec/verdict.schema.json">
-        verdict.schema.json
-      </a>{' '}
-      (JSON Schema draft 2020-12).
+      <a href="/vivarium/spec/contract-v1">Contract v1</a> defines what every reproduction page promises: a <code>verdict</code> DOM band, a structured result envelope on <code>window.__VIVARIUM_RESULT__</code>, and the same reproduced / unreproduced / pending semantics across all three layers. The Layer 2 / 3 verdict snapshot file follows <a href="https://github.com/aletheia-works/vivarium/blob/main/docs/public/spec/verdict.schema.json">verdict.schema.json</a> (JSON Schema draft 2020-12).
     </p>
 
     <h3>Manifest v1 — publication surface</h3>
     <p>
-      <a href="/vivarium/spec/manifest-v1">Manifest v1</a> is the TOML manifest
-      that an external repo ships at <code>.vivarium/manifest.toml</code> to
-      declare a Vivarium-runnable reproduction. Schema:{' '}
-      <a href="https://github.com/aletheia-works/vivarium/blob/main/docs/public/spec/manifest.schema.json">
-        manifest.schema.json
-      </a>
-      .
+      <a href="/vivarium/spec/manifest-v1">Manifest v1</a> is the TOML manifest that an external repo ships at <code>.vivarium/manifest.toml</code> to declare a Vivarium-runnable reproduction. Schema: <a href="https://github.com/aletheia-works/vivarium/blob/main/docs/public/spec/manifest.schema.json">manifest.schema.json</a>.
     </p>
 
     <h3>Recipes index v1 — catalogue endpoint</h3>
     <p>
-      <a href="/vivarium/spec/recipes-index-v1">Recipes index v1</a> is the
-      machine-generated JSON listing of every reproduction this repository
-      hosts. Consumed by the Vivarium MCP server and other programmatic
-      catalogue tooling. Schema:{' '}
-      <a href="https://github.com/aletheia-works/vivarium/blob/main/docs/public/api/recipes.schema.json">
-        recipes.schema.json
-      </a>
-      .
+      <a href="/vivarium/spec/recipes-index-v1">Recipes index v1</a> is the machine-generated JSON listing of every reproduction this repository hosts. Consumed by the Vivarium MCP server and other programmatic catalogue tooling. Schema: <a href="https://github.com/aletheia-works/vivarium/blob/main/docs/public/api/recipes.schema.json">recipes.schema.json</a>.
     </p>
-  </Section>
 
-  <Section
-    eyebrow="// 03 · TOOLING"
-    heading="Reusable workflows that consume the contract."
-  >
-    <h3>Consumer workflow</h3>
+    <h3>Consumer workflow (reusable CI)</h3>
     <p>
-      <a href="/vivarium/spec/consumer-workflow">Consumer workflow</a> — a
-      reusable GitHub Actions workflow any repo can <code>uses:</code> to
-      verify a Vivarium-hosted reproduction in their own CI.
+      <a href="/vivarium/spec/consumer-workflow">Consumer workflow</a> — a reusable GitHub Actions workflow any repo can <code>uses:</code> to verify a Vivarium-hosted reproduction in their own CI.
     </p>
 
     <h3>Branch-fix verdict pipeline</h3>
     <p>
-      <a href="/vivarium/spec/branch-fix-pipeline">Branch-fix verdict pipeline</a>{' '}
-      — a <code>workflow_dispatch</code> workflow that captures a verdict for a
-      contributor-supplied branch-fix Docker image and bundles it alongside the
-      deployed original for side-by-side comparison.
+      <a href="/vivarium/spec/branch-fix-pipeline">Branch-fix verdict pipeline</a> — a <code>workflow_dispatch</code> workflow that captures a verdict for a contributor-supplied branch-fix Docker image and bundles it alongside the deployed original for side-by-side comparison. The Layer 1 source-substitution variant (Path A) runs directly from <a href="/vivarium/repro/compare">/repro/compare</a>.
     </p>
   </Section>
 
   <Section
     eyebrow="// 04 · SCOPE"
-    heading="What this spec is — and is not."
+    heading="What this spec covers."
   >
-    <h3>What this spec is for</h3>
-    <ul>
-      <li>Reproduction pages (Layer 1, Layer 2, Layer 3) under <code>aletheia-works/vivarium</code> declare conformance via the meta tag and the JSON envelope.</li>
-      <li>External tools (CI, IDE plugins, AI reviewers, third-party reproduction definitions) read the same surface to know whether a page reproduces today.</li>
-      <li>Vivarium-compatible reproductions hosted outside this repo can declare conformance the same way.</li>
-    </ul>
-
-    <h3>What this spec is not</h3>
-    <ul>
-      <li>It is not a full reproduction protocol — it covers the verdict surface, not how the reproduction itself is constructed (that is per-layer convention, in the layer READMEs).</li>
-    </ul>
+    <p>
+      The spec covers the <strong>verdict surface</strong> — the meta tag and JSON envelope a reproduction page declares, the external repo's <code>manifest.toml</code>, the machine-readable catalogue, and the CI workflows that consume them. <strong>It does not specify how the reproduction itself is constructed</strong>; that is per-layer convention, documented in the layer READMEs. Pages that satisfy the verdict surface, hosted inside or outside Vivarium, are Vivarium-compatible.
+    </p>
   </Section>
 </Page>
 

--- a/docs/docs/ja/overview.mdx
+++ b/docs/docs/ja/overview.mdx
@@ -8,10 +8,21 @@ import {
   PageHero,
   Section,
   LayerCards,
+  RouteCards,
+  InlineCta,
   Callout,
   NextCta,
   BottomNote,
 } from '../../components/PageChrome';
+import {
+  Bot,
+  Code2,
+  Container,
+  GitBranch,
+  Globe,
+  History,
+  Zap,
+} from 'lucide-react';
 
 <Page>
   <PageHero
@@ -25,22 +36,17 @@ import {
     heading="バグ再現のためのプラットフォーム。"
   >
     <p>
-      Vivarium は <strong>バグ再現のためのプラットフォーム</strong>です。
-      以前報告されたバグが「いまでも再現するのか」「修正候補で本当に直っているのか」を、
-      ブラウザを開いてクリックするだけで確認できます。
+      Vivarium は <strong>バグ再現のためのプラットフォーム</strong>です。以前報告されたバグが「いまでも再現するのか」「修正候補で本当に直っているのか」を、ブラウザを開いてクリックするだけで確認できます。
     </p>
     <p>
-      アップストリームの実バグごとに 1 つの<strong>レシピ</strong>が用意されており、
-      各ページは <code>verdict.json v1</code> という共通仕様に従って
-      <code>reproduced</code>（バグ再現）または <code>unreproduced</code>（再現せず）の
-      判定を返します。実行結果はページに inline で表示され、コピー可能な
-      machine-readable 形式でも公開されます。
+      アップストリームの実バグごとに 1 つの<strong>レシピ</strong>が用意されており、各ページは <code>verdict.json v1</code> という共通仕様に従って <code>reproduced</code>（バグ再現）または <code>unreproduced</code>（再現せず）の判定を返します。実行結果はページに inline で表示され、コピー可能な machine-readable 形式でも公開されます。
     </p>
     <Callout>
-      Vivarium は<strong>記事ではなく実行可能なアーティファクト</strong>として
-      バグを配布します。誰かが文章で「これがバグです」と書く代わりに、
-      ブラウザに開けば自分の目で動作を確認できる。
+      Vivarium は<strong>記事ではなく実行可能なアーティファクト</strong>としてバグを配布します。誰かが文章で「これがバグです」と書く代わりに、ブラウザに開けば自分の目で動作を確認できる。
     </Callout>
+    <p>
+      きっかけは AI 生成のバグレポートと修正 PR の急増でした。アップストリームには「もっともらしいが誰も検証していない主張」が機械の速度で届くようになり、コントリビューター側にも「自分の修正案が本当に直っているか」を確かめる手段がない——その共通の根本原因に対処するのが Vivarium です。
+    </p>
   </Section>
 
   <Section
@@ -48,9 +54,7 @@ import {
     heading="バグの種類に合った実行環境を、レシピが選ぶ。"
   >
     <p>
-      バグは性質によって、必要となる環境が大きく異なります。Vivarium は再現技法を
-      三つのレイヤーに整理しており、ユーザーがレイヤーを意識する必要はありません——
-      レシピが自分に合った層を宣言します。
+      バグは性質によって、必要となる環境が大きく異なります。Vivarium は再現技法を三つのレイヤーに整理しており、ユーザーがレイヤーを意識する必要はありません——レシピが自分に合った層を宣言します。
     </p>
 
     <LayerCards
@@ -58,6 +62,7 @@ import {
         {
           pill: 'L1',
           accent: 'teal',
+          icon: <Globe />,
           title: '瞬時起動、ブラウザネイティブ',
           body: 'WebAssembly でブラウザ内に再現が直接実行されます。起動はミリ秒〜数秒。アルゴリズム、パーサ、データ処理、in-memory なデータベース操作など、完全な OS を必要としないバグに向きます。',
           runtimes: 'Pyodide · sqlite-wasm · wasm32-wasi · Ruby.wasm · PHP.wasm',
@@ -65,6 +70,7 @@ import {
         {
           pill: 'L2',
           accent: 'violet',
+          icon: <Container />,
           title: '完全忠実度、コンテナ実行',
           body: 'Docker または microVM の中で再現が実行されます。起動は数秒〜分単位。実ファイルシステム、実プロセス、実ネットワークが必要なバグのための層です。',
           runtimes: 'Docker · Firecracker · gVisor',
@@ -72,30 +78,64 @@ import {
         {
           pill: 'L3',
           accent: 'coral',
+          icon: <History />,
           title: '第三の道',
           body: 'Record-replay、決定論的シミュレーション、WASI Preview 3+、スナップショットベースの復元、そしてまだ発明されていない技法。L1 でも L2 でも届かない問題のために。',
           runtimes: 'rr · Antithesis · CRIU · WASI Preview 3+',
         },
       ]}
     />
+
+    <InlineCta
+      text={
+        <>
+          <strong>3 つのレイヤーがそれぞれ動くところを見る。</strong>{' '}
+          ギャラリーには L1 / L2 / L3 のレシピがファセット付きで並んでいて、レイヤーをタブ切替で 1 クリック比較できます。
+        </>
+      }
+      link={{ label: '再現一覧', href: '/vivarium/ja/repro/' }}
+    />
   </Section>
 
   <Section
-    eyebrow="// 03 · プロジェクトの経緯"
-    heading="バグが本当に再現するか、どうやって安価に確かめるか。"
+    eyebrow="// 03 · どの入口を選ぶか"
+    heading="あなたの目的にあわせて、最初の 1 ページを。"
   >
     <p>
-      きっかけは AI が生成するバグレポートと修正 PR の急増でした。アップストリームの
-      メンテナーには「もっともらしいが誰も検証していない主張」が機械の速度で届くようになり、
-      コントリビューター側にも「自分の修正案が本当に直っているか」を確かめる手段が
-      ありません。
+      Vivarium は読み手によって入口が異なります。下のカードはペルソナ別の最短ルート——どのカードからでも、5〜30 分以内に「自分の目で動かす」段階まで辿り着けるよう設計されています。
     </p>
-    <p>
-      共通する根本原因は <strong>バグが実在するか・修正が効いているかを、
-      安価かつ普遍的に検証する仕組みが存在しない</strong>ことです。
-      Vivarium はその仕組みを提供します——「再現するのか／しないのか」を、
-      クリックひとつで返せる形に。
-    </p>
+    <RouteCards
+      cards={[
+        {
+          kicker: '01 · 5 MIN',
+          icon: <Zap />,
+          title: '最初の 5 分',
+          body: 'ブラウザを開いて 1 つのレシピをクリック、verdict を読む。インストール不要・登録不要、いま試す。',
+          href: '/vivarium/ja/guide/getting-started',
+        },
+        {
+          kicker: '02 · INTEGRATE',
+          icon: <GitBranch />,
+          title: '自分のリポジトリに統合',
+          body: '`.vivarium/manifest.toml` 1 ファイル + 再利用可能 workflow で、自分のリポからの再現を Vivarium に登録できます。',
+          href: '/vivarium/ja/guide/integrate-with-your-repo',
+        },
+        {
+          kicker: '03 · AI AGENT',
+          icon: <Bot />,
+          title: 'AI エージェントから使う',
+          body: 'Claude Code / Aider / Cline から `@aletheia-works/vivarium-mcp` で 5 つの MCP ツールを呼び出します。',
+          href: '/vivarium/ja/guide/use-from-ai-agent',
+        },
+        {
+          kicker: '04 · CONTRIBUTE',
+          icon: <Code2 />,
+          title: 'はじめての再現を書く',
+          body: '`src/layer1_wasm/<slug>/` 以下に 1 つのレシピを足すだけ。共通 scaffolding が大半の配線を引き受けます。',
+          href: '/vivarium/ja/guide/write-your-first-reproduction',
+        },
+      ]}
+    />
   </Section>
 </Page>
 

--- a/docs/docs/ja/repro/match.mdx
+++ b/docs/docs/ja/repro/match.mdx
@@ -3,15 +3,35 @@ pageType: doc
 title: エラーからレシピを探す
 ---
 
-import { Page, PageHero } from '../../../components/PageChrome';
+import { Page, PageHero, Section } from '../../../components/PageChrome';
 import { ErrorRecipeMatcher } from '../../../components/ErrorRecipeMatcher';
 
 <Page>
   <PageHero
     eyebrow="// MATCH · ERROR → RECIPE"
-    title={<>エラーを貼り付けて、候補レシピを探す。</>}
-    sub="レシピカタログに対する機械的なトークンオーバーラップマッチ。LLM 非依存——各レシピの symptom / tags / project / slug に対する小文字トークン一致をスコア化する。Phase 7 A5 で同義語テーブル（dtype⇄datatype など）、Levenshtein 距離 1 のファジーマッチ（長さ 6 以上のトークン）、多言語ストップワードを追加。スコアリングはすべてローカルで実行される。"
+    title={<>エラーを貼って、候補レシピを返す。</>}
+    sub="ローカル完結のスコアリング。LLM 非依存——機械的なトークン照合だけ。"
   />
 
   <ErrorRecipeMatcher lang="ja" />
+
+  <Section
+    eyebrow="// 03 · 効きどころ"
+    heading="マッチが拾うパターン、3 つ。"
+  >
+    <h3>1. 同義語に強い（synonym table）</h3>
+    <p>
+      「<code>dtype mismatch</code>」を貼ると「datatype」「dtypes」「numpy.dtype」を含むレシピも候補に上がります。Phase 7 A5 の同義語テーブルが <code>dtype⇄datatype</code>、<code>regex⇄regexp</code>、<code>fork⇄spawn</code> といった派生形を 1 つのキーに正規化するため、書きかたゆれを心配せずに貼り付けて構いません。
+    </p>
+
+    <h3>2. typo に強い（fuzzy match）</h3>
+    <p>
+      「<code>recursoin depth exceeded</code>」のような 1 文字 typo は Levenshtein 距離 1 で吸収されます（長さ 6 以上のトークンに限定。短いトークンは false-positive を避けるため厳密一致）。「php json_encode で再帰深さでこけた」がなぜか候補に出ない、という事故が減ります。
+    </p>
+
+    <h3>3. 日本語と英語が混じってもよい（multi-language stopwords）</h3>
+    <p>
+      「<code>pandas で empty DataFrame の dtype が変わる</code>」のように日本語のメタテキストと英語の技術用語を混ぜて貼っても、「で」「の」「が」のような日本語ストップワードと「the」「a」「is」のような英語ストップワードがどちらも除外されます。スタックトレースをそのまま貼っても候補が見つかります。
+    </p>
+  </Section>
 </Page>

--- a/docs/docs/ja/spec/index.mdx
+++ b/docs/docs/ja/spec/index.mdx
@@ -8,6 +8,7 @@ import {
   PageHero,
   Section,
   CompareCards,
+  RouteCards,
   Callout,
   NextCta,
   BottomNote,
@@ -17,7 +18,7 @@ import {
   <PageHero
     eyebrow="// SPEC · v1"
     title="Vivarium 仕様。"
-    sub="再現 verdict コントラクト——アップストリームのバグが今日のランタイムに対して再現するかどうかを記述する、小さく安定したサーフェス。"
+    sub="再現 verdict コントラクトとカタログ surface——アップストリームのバグが今日のランタイムに対して再現するかどうかを記述する、小さく安定したファイルセット。"
   />
 
   <Section
@@ -25,22 +26,13 @@ import {
     heading="バージョン管理されたサーフェス。"
   >
     <p>
-      Vivarium 仕様は、再現ページが自己宣言できるようにし、外部ツールが verdict を読めるようにし、
-      外部リポジトリがカスタムのグルーなしで独自の再現を公開できるようにする小さなファイルセットだ。
+      Vivarium 仕様は、再現ページが自己宣言できるようにし、外部ツールが verdict を読めるようにし、外部リポジトリがカスタムのグルーなしで独自の再現を公開できるようにする小さなファイルセットだ。
     </p>
 
     <Callout>
-      再現ページは{' '}
-      <code>&lt;meta name="vivarium-contract" content="v1"&gt;</code>{' '}
-      でコンフォーマンスを宣言する。外部ツールは同じサーフェスを読んで
-      ページが今日も再現するかを知る。
+      再現ページは <code>&lt;meta name="vivarium-contract" content="v1"&gt;</code> でコンフォーマンスを宣言する。外部ツールは同じサーフェスを読んでページが今日も再現するかを知る。
     </Callout>
-  </Section>
 
-  <Section
-    eyebrow="// 02 · 現在のサーフェス"
-    heading="三つのサーフェス、ひとつのコントラクト。"
-  >
     <CompareCards
       others={[
         {
@@ -62,77 +54,76 @@ import {
           'aletheia-works.github.io/vivarium/api/recipes.json — デプロイごとに更新',
       }}
     />
+  </Section>
 
+  <Section
+    eyebrow="// 02 · あなたの読みかた"
+    heading="目的別、読むべき仕様の地図。"
+  >
+    <p>
+      仕様は読み手によって入口が異なります。下のカードは「あなたがやろうとしていること」別の最短ルート——どこから読み始めても、必要な仕様だけにフォーカスできます。
+    </p>
+    <RouteCards
+      cards={[
+        {
+          kicker: '01 · BUILD',
+          title: '再現を作る人',
+          body: 'verdict.json のフォーマットと、外部リポからの再現宣言の書きかた。Contract v1 と Manifest v1。',
+          href: '/vivarium/ja/spec/contract-v1',
+        },
+        {
+          kicker: '02 · CONSUME',
+          title: 'カタログを引く人',
+          body: 'AI エージェントや外部ツールから「全レシピ一覧」をマシンリーダブルに取得する。Recipes index v1。',
+          href: '/vivarium/ja/spec/recipes-index-v1',
+        },
+        {
+          kicker: '03 · CI',
+          title: 'CI で検証する人',
+          body: 'GitHub Actions reusable workflow で、verdict キャプチャと branch-fix verdict 比較パイプラインを呼ぶ。',
+          href: '/vivarium/ja/spec/consumer-workflow',
+        },
+      ]}
+    />
+  </Section>
+
+  <Section
+    eyebrow="// 03 · 仕様サーフェス一覧"
+    heading="3 つの spec ドキュメント + 2 つのツールワークフロー。"
+  >
     <h3>Contract v1 — verdict サーフェス</h3>
     <p>
-      <a href="/vivarium/ja/spec/contract-v1">Contract v1</a> はすべての再現ページが約束することを定義する:
-      <code>verdict</code> DOM バンド、<code>window.__VIVARIUM_RESULT__</code> 上の構造化結果エンベロープ、
-      そして三つのレイヤー全体で同じ reproduced / unreproduced / pending セマンティクス。
-      Layer 2 / 3 の verdict スナップショットファイルは{' '}
-      <a href="https://github.com/aletheia-works/vivarium/blob/main/docs/public/spec/verdict.schema.json">
-        verdict.schema.json
-      </a>{' '}
-      （JSON Schema draft 2020-12）に従う。
+      <a href="/vivarium/ja/spec/contract-v1">Contract v1</a> はすべての再現ページが約束することを定義する: <code>verdict</code> DOM バンド、<code>window.__VIVARIUM_RESULT__</code> 上の構造化結果エンベロープ、そして三つのレイヤー全体で同じ reproduced / unreproduced / pending セマンティクス。Layer 2 / 3 の verdict スナップショットファイルは <a href="https://github.com/aletheia-works/vivarium/blob/main/docs/public/spec/verdict.schema.json">verdict.schema.json</a>（JSON Schema draft 2020-12）に従う。
     </p>
 
     <h3>Manifest v1 — 公開サーフェス</h3>
     <p>
-      <a href="/vivarium/ja/spec/manifest-v1">Manifest v1</a> は、外部リポジトリが
-      <code>.vivarium/manifest.toml</code> に置いて Vivarium 実行可能な再現を宣言するための
-      TOML マニフェストだ。スキーマ:{' '}
-      <a href="https://github.com/aletheia-works/vivarium/blob/main/docs/public/spec/manifest.schema.json">
-        manifest.schema.json
-      </a>
-      。
+      <a href="/vivarium/ja/spec/manifest-v1">Manifest v1</a> は、外部リポジトリが <code>.vivarium/manifest.toml</code> に置いて Vivarium 実行可能な再現を宣言するための TOML マニフェストだ。スキーマ: <a href="https://github.com/aletheia-works/vivarium/blob/main/docs/public/spec/manifest.schema.json">manifest.schema.json</a>。
     </p>
 
     <h3>Recipes index v1 — カタログエンドポイント</h3>
     <p>
-      <a href="/vivarium/ja/spec/recipes-index-v1">Recipes index v1</a> は、
-      このリポジトリがホストするすべての再現を機械的に生成した JSON リストだ。
-      Vivarium MCP サーバおよびその他のプログラマティックなカタログツールが利用する。スキーマ:{' '}
-      <a href="https://github.com/aletheia-works/vivarium/blob/main/docs/public/api/recipes.schema.json">
-        recipes.schema.json
-      </a>
-      。
+      <a href="/vivarium/ja/spec/recipes-index-v1">Recipes index v1</a> は、このリポジトリがホストするすべての再現を機械的に生成した JSON リストだ。Vivarium MCP サーバおよびその他のプログラマティックなカタログツールが利用する。スキーマ: <a href="https://github.com/aletheia-works/vivarium/blob/main/docs/public/api/recipes.schema.json">recipes.schema.json</a>。
     </p>
-  </Section>
 
-  <Section
-    eyebrow="// 03 · ツール"
-    heading="コントラクトを消費する再利用可能ワークフロー。"
-  >
-    <h3>Consumer workflow</h3>
+    <h3>Consumer workflow（再利用可能 CI）</h3>
     <p>
-      <a href="/vivarium/ja/spec/consumer-workflow">Consumer workflow</a> —
-      任意のリポジトリが <code>uses:</code> することで自分の CI 内で
-      Vivarium ホスト型再現を検証できる再利用可能 GitHub Actions ワークフロー。
+      <a href="/vivarium/ja/spec/consumer-workflow">Consumer workflow</a> — 任意のリポジトリが <code>uses:</code> することで自分の CI 内で Vivarium ホスト型再現を検証できる再利用可能 GitHub Actions ワークフロー。
     </p>
 
     <h3>Branch-fix verdict パイプライン</h3>
     <p>
-      <a href="/vivarium/ja/spec/branch-fix-pipeline">Branch-fix verdict パイプライン</a>{' '}
-      — コントリビューターが提供したブランチフィックス Docker イメージの verdict をキャプチャし、
-      デプロイ済みの元の verdict と並べてサイドバイサイド比較を提供する
-      <code>workflow_dispatch</code> ワークフロー。
+      <a href="/vivarium/ja/spec/branch-fix-pipeline">Branch-fix verdict パイプライン</a> — コントリビューターが提供したブランチフィックス Docker イメージの verdict をキャプチャし、デプロイ済みの元の verdict と並べてサイドバイサイド比較を提供する <code>workflow_dispatch</code> ワークフロー。Layer 1 のソース置換版 (Path A) は <a href="/vivarium/ja/repro/compare">/repro/compare</a> から直接実行できる。
     </p>
   </Section>
 
   <Section
     eyebrow="// 04 · スコープ"
-    heading="この仕様が何のためにあり、何のためにないか。"
+    heading="この仕様の対象範囲。"
   >
-    <h3>この仕様が対象とするもの</h3>
-    <ul>
-      <li><code>aletheia-works/vivarium</code> 以下の再現ページ（Layer 1、Layer 2、Layer 3）は meta タグと JSON エンベロープでコンフォーマンスを宣言する。</li>
-      <li>外部ツール（CI、IDE プラグイン、AI レビュアー、サードパーティ再現定義）は同じサーフェスを読んでページが今日も再現するかを知る。</li>
-      <li>このリポジトリ外でホストされる Vivarium 互換再現も同じ方法でコンフォーマンスを宣言できる。</li>
-    </ul>
-
-    <h3>この仕様が対象としないもの</h3>
-    <ul>
-      <li>完全な再現プロトコルではない——verdict サーフェスをカバーするのであり、再現自体の構築方法は対象外（それはレイヤーの README に記述された各レイヤーの規約）。</li>
-    </ul>
+    <p>
+      仕様は <strong>verdict サーフェス</strong> を対象とする——再現ページが自己宣言する meta タグ + JSON エンベロープ、外部リポジトリの <code>manifest.toml</code>、機械可読カタログ、それを消費する CI ワークフロー。<strong>再現自体の構築方法は対象外</strong>（それはレイヤーの README に記述された各レイヤーの規約に属する）。Vivarium 内外を問わず、verdict サーフェスを満たすページは Vivarium 互換だ。
+    </p>
   </Section>
 </Page>
 


### PR DESCRIPTION

Tightens the three secondary pages flagged in
`_context/v_prime_information_design_audit.md` §1.6–§1.8: overview
was missing reader-intent routing, spec/index buried sub-pages
under uniform sections, and the matcher's hero copy mixed
implementation detail into the user-facing sub.

- New `<RouteCards>` chrome component — a 3 / 4-column persona-route
  grid distinct from `LayerCards` (which is layer-shaped, not
  intent-shaped). Each card carries a kicker, a title, a one-sentence
  body, and a primary link with a hover-translated arrow. Used on
  overview (4 routes: 5-min / integrate / AI agent / contribute) and
  spec/index (3 routes: build / consume / CI).
- New `<InlineCta>` chrome component — a compact between-sections
  link nudge, lighter than `NextCta` (page closer) and narrower than
  `Callout`. Sits between the LayerCards row and the persona-route
  section on the overview page so the reader can jump straight to
  the live gallery without scrolling to the page footer.
- overview.mdx (EN+JA) — Section 03 "経緯 / How we got here" was
  folded into Section 01 as a closing paragraph; the freed slot
  carries the new persona-route grid. Section 02's LayerCards now
  ends with an InlineCta to the gallery. Six body lines became four
  routes + two CTAs.
- spec/index.mdx (EN+JA) — added Section 02 "What to read" with
  three role-based RouteCards (writing a reproduction → contract +
  manifest, driving the catalogue → recipes-index, verifying in CI →
  consumer-workflow / branch-fix-pipeline). Section 04 "Scope" was
  compressed from a 4-bullet two-list shape into a single paragraph.
  Branch-fix-pipeline blurb now mentions the Layer 1 Path A entry
  point on /repro/compare so visitors can step from the spec page
  to the live tool.
- repro/match.mdx (EN+JA) — sub copy compressed from a 146-character
  paragraph mentioning Phase 7 A5, Levenshtein, and stopwords (all
  implementation detail) to one line ("ローカル完結のスコアリング。
  LLM 非依存——機械的なトークン照合だけ。" / "Local scoring. No LLM —
  mechanical token overlap only."). New Section 03 "効きどころ /
  Where it works" carries three concrete usage patterns — synonym
  recovery (`dtype⇄datatype`), typo tolerance (Levenshtein-1 fuzzy
  match), and mixed-language input (JA+EN stopwords) — each as a
  worked example so the matcher's strengths read as user-facing
  payoffs rather than a technique list.

Validated locally with `mise run ci:docs` (clean rspress build, all
60 HTML targets present including overview / spec / match in both
locales) and `mise run docs:check` (Biome clean after auto-format on
the new components).

Phase 7 V′ progress: PR 6 of 7 from
`_context/v_prime_information_design_audit.md` §3.1 — landing (#174),
repro index (#175), repro compare (#177), architecture (#182),
roadmap (#183), now overview / spec / match. Guide index + nav
reorder (PR 7) follows; component graduation slots on top.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/184).
* #185
* __->__ #184