### PR TITLE
feat(docs): phase 7 V′ — guide/ map page + reorder docs nav for value-first

### DIFF
--- a/docs/docs/en/_meta.json
+++ b/docs/docs/en/_meta.json
@@ -6,13 +6,13 @@
   },
   {
     "type": "dir",
-    "name": "guide",
-    "label": "Guide"
+    "name": "repro",
+    "label": "Reproductions"
   },
   {
     "type": "dir",
-    "name": "repro",
-    "label": "Reproductions"
+    "name": "guide",
+    "label": "Guide"
   },
   {
     "type": "file",

--- a/docs/docs/en/guide/_meta.json
+++ b/docs/docs/en/guide/_meta.json
@@ -1,6 +1,11 @@
 [
   {
     "type": "file",
+    "name": "index",
+    "label": "Guide map"
+  },
+  {
+    "type": "file",
     "name": "getting-started",
     "label": "First five minutes"
   },

--- a/docs/docs/en/guide/index.mdx
+++ b/docs/docs/en/guide/index.mdx
@@ -1,0 +1,126 @@
+---
+pageType: doc
+title: Guide
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  RouteCards,
+  InlineCta,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+import {
+  Bot,
+  Code2,
+  GitBranch,
+  GitCompareArrows,
+  GitFork,
+  Zap,
+} from 'lucide-react';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · MAP"
+    title="A reading map by audience."
+    sub="What you read first depends on what you're trying to do with Vivarium. Pick one card below and you're 5–30 minutes from running something yourself."
+  />
+
+  <Section
+    eyebrow="// 01 · MAIN ROUTES"
+    heading="Four persona routes."
+  >
+    <p>
+      The four most common entry points: try it now, integrate it with your repo, drive it from an AI agent, or contribute one reproduction.
+    </p>
+    <RouteCards
+      cards={[
+        {
+          kicker: '01 · 5 MIN',
+          icon: <Zap />,
+          title: 'First five minutes',
+          body: 'Open one recipe in your browser, click once, read the verdict. No install, no account — try it now.',
+          href: '/vivarium/guide/getting-started',
+        },
+        {
+          kicker: '02 · INTEGRATE',
+          icon: <GitBranch />,
+          title: 'Integrate with your own repo',
+          body: "One `.vivarium/manifest.toml` plus a reusable workflow registers a reproduction from your own repository.",
+          href: '/vivarium/guide/integrate-with-your-repo',
+        },
+        {
+          kicker: '03 · AI AGENT',
+          icon: <Bot />,
+          title: 'Use from your AI agent',
+          body: 'Drive the five MCP tools from Claude Code / Aider / Cline via `@aletheia-works/vivarium-mcp`.',
+          href: '/vivarium/guide/use-from-ai-agent',
+        },
+        {
+          kicker: '04 · CONTRIBUTE',
+          icon: <Code2 />,
+          title: 'Write your first reproduction',
+          body: 'Add one recipe under `src/layer1_wasm/<slug>/` — the shared scaffolding handles most of the wiring.',
+          href: '/vivarium/guide/write-your-first-reproduction',
+        },
+      ]}
+    />
+  </Section>
+
+  <Section
+    eyebrow="// 02 · ADVANCED"
+    heading="One step past the main routes."
+  >
+    <p>
+      Guides for specific intents that build on the four main routes.
+    </p>
+    <RouteCards
+      cards={[
+        {
+          kicker: '05 · BRANCH FIX',
+          icon: <GitCompareArrows />,
+          title: 'Verify a branch fix',
+          body: "End-to-end flow for verifying an AI agent's candidate fix against a Vivarium recipe. The `verify_branch_fix` MCP tool integrates with this.",
+          href: '/vivarium/guide/compare-branch-fix',
+        },
+        {
+          kicker: '06 · FORK',
+          icon: <GitFork />,
+          title: 'Run on your own fork',
+          body: 'For managing private bug recipes inside your org, or trying your own tuning. Includes the GitHub Pages deploy.',
+          href: '/vivarium/guide/fork-your-own',
+        },
+      ]}
+    />
+
+    <InlineCta
+      text={
+        <>
+          <strong>Lost on a term?</strong>{' '}
+          Layer 1/2/3, verdict, manifest, contract, recipe, slug — all collected in the glossary.
+        </>
+      }
+      link={{ label: 'Glossary', href: '/vivarium/guide/glossary' }}
+    />
+  </Section>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      Run something in 5 minutes{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="Whichever route you pick, the fastest first step is running one recipe in your browser."
+  primary={{ label: 'First five minutes →', href: '/vivarium/guide/getting-started' }}
+  ghost={{ label: 'Reproductions', href: '/vivarium/repro/' }}
+/>
+
+<BottomNote
+  text="VIVARIUM is part of ALETHEIA-WORKS · See the source on GitHub →"
+  href="https://github.com/aletheia-works/vivarium"
+/>

--- a/docs/docs/ja/_meta.json
+++ b/docs/docs/ja/_meta.json
@@ -6,13 +6,13 @@
   },
   {
     "type": "dir",
-    "name": "guide",
-    "label": "ガイド"
+    "name": "repro",
+    "label": "再現一覧"
   },
   {
     "type": "dir",
-    "name": "repro",
-    "label": "再現一覧"
+    "name": "guide",
+    "label": "ガイド"
   },
   {
     "type": "file",

--- a/docs/docs/ja/guide/_meta.json
+++ b/docs/docs/ja/guide/_meta.json
@@ -1,6 +1,11 @@
 [
   {
     "type": "file",
+    "name": "index",
+    "label": "ガイド地図"
+  },
+  {
+    "type": "file",
     "name": "getting-started",
     "label": "はじめての 5 分"
   },

--- a/docs/docs/ja/guide/index.mdx
+++ b/docs/docs/ja/guide/index.mdx
@@ -1,0 +1,126 @@
+---
+pageType: doc
+title: ガイド
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  RouteCards,
+  InlineCta,
+  NextCta,
+  BottomNote,
+} from '../../../components/PageChrome';
+import {
+  Bot,
+  Code2,
+  GitBranch,
+  GitCompareArrows,
+  GitFork,
+  Zap,
+} from 'lucide-react';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · MAP"
+    title="目的別ガイド地図。"
+    sub="あなたが Vivarium で何をしようとしているかで、最初に読むページが変わります。下のカードから 1 枚選べば、5〜30 分で「自分の目で動かす」段階まで到達できます。"
+  />
+
+  <Section
+    eyebrow="// 01 · 主要ルート"
+    heading="4 つのペルソナルート。"
+  >
+    <p>
+      最も典型的な 4 つの入口です。Vivarium の触りかたを「いま試す」「自分のレポに統合する」「AI エージェントから使う」「再現を 1 つ書いて貢献する」の 4 つに分解しています。
+    </p>
+    <RouteCards
+      cards={[
+        {
+          kicker: '01 · 5 MIN',
+          icon: <Zap />,
+          title: 'はじめての 5 分',
+          body: 'ブラウザでレシピを 1 つ動かして verdict を読む。インストール不要・登録不要、いま試す。',
+          href: '/vivarium/ja/guide/getting-started',
+        },
+        {
+          kicker: '02 · INTEGRATE',
+          icon: <GitBranch />,
+          title: '自分のリポジトリに統合する',
+          body: '`.vivarium/manifest.toml` 1 ファイル + 再利用可能 workflow で、自分のレポからの再現を Vivarium に登録できます。',
+          href: '/vivarium/ja/guide/integrate-with-your-repo',
+        },
+        {
+          kicker: '03 · AI AGENT',
+          icon: <Bot />,
+          title: 'AI エージェントから使う',
+          body: 'Claude Code / Aider / Cline から `@aletheia-works/vivarium-mcp` で 5 つの MCP ツールを呼び出します。',
+          href: '/vivarium/ja/guide/use-from-ai-agent',
+        },
+        {
+          kicker: '04 · CONTRIBUTE',
+          icon: <Code2 />,
+          title: 'はじめての再現を書く',
+          body: '`src/layer1_wasm/<slug>/` 以下に 1 つのレシピを足すだけ。共通 scaffolding が大半の配線を引き受けます。',
+          href: '/vivarium/ja/guide/write-your-first-reproduction',
+        },
+      ]}
+    />
+  </Section>
+
+  <Section
+    eyebrow="// 02 · 高度なワークフロー"
+    heading="一歩進んだ使いかた。"
+  >
+    <p>
+      主要ルートを抜けたあと、特定の目的のために必要になるガイドです。
+    </p>
+    <RouteCards
+      cards={[
+        {
+          kicker: '05 · BRANCH FIX',
+          icon: <GitCompareArrows />,
+          title: 'ブランチ修正を検証する',
+          body: 'AI エージェントが提案した修正候補を、Vivarium のレシピに対して検証する end-to-end フロー。`verify_branch_fix` MCP ツールも併用可。',
+          href: '/vivarium/ja/guide/compare-branch-fix',
+        },
+        {
+          kicker: '06 · FORK',
+          icon: <GitFork />,
+          title: '自分のフォークで動かす',
+          body: '組織内の private なバグレシピを管理したい場合や、独自のチューニングを試したい場合に。GitHub Pages デプロイ込み。',
+          href: '/vivarium/ja/guide/fork-your-own',
+        },
+      ]}
+    />
+
+    <InlineCta
+      text={
+        <>
+          <strong>用語が分からなくなったら。</strong>{' '}
+          Layer 1/2/3、verdict、manifest、contract、recipe、slug などのキーワードは用語集に集約されています。
+        </>
+      }
+      link={{ label: '用語集', href: '/vivarium/ja/guide/glossary' }}
+    />
+  </Section>
+</Page>
+
+<NextCta
+  eyebrow="// 次のページ"
+  heading={
+    <>
+      まずは 5 分で動かす{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="どのルートを選んでも、最短は「ブラウザで 1 つレシピを動かす」ことから始めるのが速い。"
+  primary={{ label: 'はじめての 5 分 →', href: '/vivarium/ja/guide/getting-started' }}
+  ghost={{ label: '再現一覧', href: '/vivarium/ja/repro/' }}
+/>
+
+<BottomNote
+  text="VIVARIUM は ALETHEIA-WORKS の一部 · GitHub でソースを見る →"
+  href="https://github.com/aletheia-works/vivarium"
+/>


### PR DESCRIPTION

Closes the last V′ structural gap from
`_context/v_prime_information_design_audit.md` §1.9 + §2.2: the
`guide/` directory had no entry page (visiting `/guide/` redirected
into `getting-started`, leaving the seven guide pages flat-listed
with no overall map), and the top-level nav buried the catalogue —
the project's core value — three slots deep.

- New `docs/docs/{en,ja}/guide/index.mdx` (`Guide map` / `ガイド地
  図`) — a persona-route landing for the guide tree. Section 01
  surfaces the four main routes (5-min / integrate-with-your-repo /
  use-from-ai-agent / write-your-first-reproduction) as `RouteCards`;
  Section 02 carries the two advanced flows (compare-branch-fix /
  fork-your-own) plus an `InlineCta` to the glossary so reference
  material is one click away without owning a top-level slot. The
  guide tree's seven pages were already shipped; this page is the
  map that makes them legible.
- Top-level `_meta.json` (EN+JA) reordered:
  Overview → Reproductions → Guide → Architecture → Spec → Roadmap.
  The previous order (Overview → Guide → Reproductions → …) put a
  read-the-manual surface ahead of the project's core value; the
  audit explicitly recommends "概要 → すぐ実物 → 文章を読む" as the
  natural reading order. Guide stays second-tier — adjacent to
  Reproductions so a visitor who clicked "see real examples" first
  can pivot into the docs without backtracking.
- `guide/_meta.json` (EN+JA) — added the new `index` entry as the
  first sidebar item under "Guide map / ガイド地図". The seven
  per-route pages keep their previous slugs and labels; only the
  new map page is inserted at the top.

Validated locally with `mise run ci:docs` (clean rspress build —
both `doc_build/guide/index.html` and `doc_build/ja/guide/index.html`
generated for the first time, all sibling guide pages still build)
and `mise run docs:check` (Biome clean, no fixes needed).

Phase 7 V′ closure: PR 7 of 7 from
`_context/v_prime_information_design_audit.md` §3.1. With this PR,
all seven page-level redesigns the audit prescribed have shipped —
landing (#174), repro index (#175), repro compare (#177),
architecture (#182), roadmap (#183), overview/spec/match (#184), and
now guide map + nav order. Component graduation
(`VerdictBadge` / `LayerPill`) remains as opportunistic follow-up;
ADR-0030 status promotion (Proposed → Accepted) and the Phase 7
close ADR are the next housekeeping items.
