### PR TITLE
fix(ci): restore rust components + wasm target on cache hit so lint passes

### DIFF
--- a/.github/workflows/lint-autofix.yml
+++ b/.github/workflows/lint-autofix.yml
@@ -93,6 +93,18 @@ jobs:
           cache: true
           experimental: true
 
+      # `cargo fmt` needs the rustfmt component and `cargo clippy`
+      # needs the wasm32-wasip1 target — both declared in mise.toml
+      # but not preserved by `jdx/mise-action`'s cache (it caches
+      # `~/.local/share/mise/installs`, not `~/.rustup`). See
+      # test-lint-check.yml for the full rationale; the same guard
+      # applies here so cache-hit autofix runs do not silently skip
+      # the cargo fmt / clippy steps.
+      - name: Ensure Rust components and target (mise post-install)
+        run: |
+          rustup component add rustfmt clippy
+          rustup target add wasm32-wasip1
+
       # `mise run lint:all:fix` chains the autofix variant of every
       # tool (mago format, mago lint --fix --unsafe, ruff format,
       # ruff check --fix, tombi format, rumdl fmt, cargo fmt). Each

--- a/.github/workflows/test-lint-check.yml
+++ b/.github/workflows/test-lint-check.yml
@@ -79,6 +79,26 @@ jobs:
           cache: true
           experimental: true
 
+      # mise.toml declares `components = "rustfmt,clippy"` and
+      # `targets = "wasm32-wasip1"` for the rust toolchain, but
+      # `jdx/mise-action`'s cache only persists
+      # `~/.local/share/mise/installs`, not `~/.rustup`. On a cache
+      # miss, mise install runs `rustup component add` / `rustup
+      # target add` per the mise.toml directives and they land in
+      # `~/.rustup`. On a cache hit, mise install is a no-op (the
+      # rust symlink is already present), so the components AND
+      # the wasm target are absent — `cargo fmt` fails with
+      # `'cargo-fmt' is not installed for the toolchain '1.84.0'`,
+      # and `cargo clippy --target wasm32-wasip1` fails with
+      # `can't find crate for 'core' — the wasm32-wasip1 target may
+      # not be installed`. Re-add both explicitly so cache-hit and
+      # cache-miss runs converge. `RUSTUP_TOOLCHAIN=1.84.0` is
+      # already exported by the mise setup step.
+      - name: Ensure Rust components and target (mise post-install)
+        run: |
+          rustup component add rustfmt clippy
+          rustup target add wasm32-wasip1
+
       # `mise run ci:lint` chains php:check, python:check, toml:check,
       # markdown:check, rust:check (cargo fmt --check + clippy -D
       # warnings). Any failure is reported as a CI error.


### PR DESCRIPTION

Phase 7 V′ PR stack (#183 / #184 / #185) all started failing the
Polyglot lint job after the cache from PR #181 / #182 warmed up:

  step 1 — cargo fmt:
    error: 'cargo-fmt' is not installed for the toolchain '1.84.0'

  step 2 (after rustfmt restored) — cargo clippy --target wasm32-wasip1:
    error[E0463]: can't find crate for `core`
    note: the `wasm32-wasip1` target may not be installed

The job's mise install reports `rust 1.84.0 (symlink)`, then the
follow-up rustup invocation logs `info: downloading 3 components`
before failing — both the rustfmt component and the wasm32-wasip1
target are missing, even though `mise.toml` has
`rust = { version = "1.84.0", components = "rustfmt,clippy",
targets = "wasm32-wasip1" }`.

Root cause: `jdx/mise-action`'s built-in cache only persists
`~/.local/share/mise/installs` and `~/.local/share/mise/cache`, NOT
`~/.rustup`. On a cache miss the rust install is fresh, mise runs
`rustup component add rustfmt clippy` and `rustup target add
wasm32-wasip1` per the mise.toml directives, and everything works
(PR #181 / #182 — both cache misses, both passed). On a cache hit
(#183 onward) `mise install` is a no-op because the rust symlink
is already present, but `~/.rustup` is empty, so rustup later
provisions only the default profile (rustc + cargo + rust-std for
the host target) and the rustfmt component + wasm32-wasip1 target
are silently skipped. The cache key is unchanged across runs, so
this fails deterministically once the cache is populated.

Fix: add an explicit `rustup component add rustfmt clippy` +
`rustup target add wasm32-wasip1` step right after the mise setup.
`RUSTUP_TOOLCHAIN=1.84.0` is already exported by the mise step, so
rustup operates on the right toolchain without hardcoding the
version in the workflow YAML — mise.toml stays the single source
of truth for tool versions, the guard step only ensures CI
converges on the same component + target set whether the cache
hits or misses. Inline comment on the workflow explains why this
guard exists so a future maintainer doesn't try to delete it as
redundant with the mise.toml `components` / `targets` fields.

Applied to both `test-lint-check.yml` (the failing strict check) and
`lint-autofix.yml` (the autofix companion that runs cargo fmt /
clippy without `--check`); the autofix path was hit by the same
skip when caches warmed up, just silently — without the guard it
would have left source unformatted with no signal.

First attempt of this fix only restored the rustfmt + clippy
components and missed the wasm32-wasip1 target; CI exposed that
oversight on PR #186 itself, so this revision adds the target.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/186).
* #185
* #184
* #183
* __->__ #186