### PR TITLE
chore(infra): close Phase 7 milestone + open Phase 8

### DIFF
--- a/infra/github/main.tf
+++ b/infra/github/main.tf
@@ -379,6 +379,11 @@ locals {
     }
     "Phase 7 — First-30-minutes onboarding" = {
       description = "Turn the Phase 6 surface from 'primitives are usable' into 'a stranger can pick this up cold'. UI brush-up (V′) + onboarding documentation (D) co-defined; AI-slop verification flow (B3) wires R.2 Path A + R.3 + MCP into one walkthrough; A-tail clears Phase 6 deferred items (ajv-standalone migration, match_error v2). Closes when V′ + D + B3 ship; A-tail items are optional. EN+JA same-PR is the i18n default."
+      state       = "closed"
+      due_date    = "2026-05-08"
+    }
+    "Phase 8 — Recipe-page desktop layout & self-dogfooding" = {
+      description = "Take the usability lens one layer deeper than Phase 7: the reproduction page itself (V″, recipe-page desktop layout — sidebar / multi-pane / horizontal real-estate) plus first real-world validation (W, self-dogfooding by filing upstream PRs / issue comments linking Vivarium reproductions). A-tail watches Phase 7 carry-forward (A3 ajv-standalone trigger, V′ component graduation YAGNI, A4 Pagefind, B1 outreach, B2 catalogue expansion). Closes when V″ + W ship; A-tail items are optional. Upstream PR submission is human-only per AGENTS.md §2. ADR-0032's filing exhausts the AGENTS.md §4.11 pre-adoption carve-out — future v1-internal breaking changes route through v2."
       state       = "open"
     }
   }


### PR DESCRIPTION

Close Phase 7 (First-30-Minutes Onboarding): closure rule
"V′ + D + B3" satisfied, A5 + A6 also shipped. A3 (ajv-standalone
migration) and V′ component graduation slip to Phase 8 with their
triggers preserved (ADR-0031).

Open Phase 8 (Recipe-Page Desktop Layout & Self-Dogfooding):
V″ (recipe-page desktop layout — sidebar / multi-pane / horizontal
real-estate) + W (real-world reproduction validation via upstream
PRs / issue comments linking Vivarium reproductions; submission stays
human-only per AGENTS.md §2) required for closure; A-tail watches
Phase 7 carry-forward (ADR-0032).

ADR-0032's filing exhausts the AGENTS.md §4.11 pre-adoption
carve-out (single invocation: ADR-0029); future v1-internal
breaking changes route through v2 per the strict two-tier policy.

Related ADRs (private memos under _context/decisions/):
- ADR-0031 — Phase 7 close
- ADR-0032 — Phase 8 opener
