### PR TITLE
feat(wasm): phase 8 V″ — regex-779 desktop layout PoC (class-based opt-in)

### DIFF
--- a/src/layer1_wasm/_shared/style.css
+++ b/src/layer1_wasm/_shared/style.css
@@ -797,3 +797,75 @@ main > footer code {
   font-size: 0.85rem;
   color: var(--vh-text-muted);
 }
+
+/* ---------- Phase 8 V″ — desktop layout (class-based opt-in) ----------
+ *
+ * Recipes opt into the desktop layout by adding `class="vh-desktop-layout"`
+ * to their `<main>` and wrapping their existing children into the four
+ * slot containers below. Below 1024 px the recipe falls back to the
+ * existing single-column stack — V″ is additive, not a replacement.
+ *
+ * Slots:
+ *   .vh-desktop-layout__header  — kicker / h1 / lede block (full width)
+ *   .vh-desktop-layout__main    — reproduction script + output (left)
+ *   .vh-desktop-layout__side    — verdict pill + meta + runtime info (right, sticky)
+ *   .vh-desktop-layout__footer  — page footer (full width)
+ *
+ * See ADR-0033 (`_context/decisions/0033-phase8-vpp-poc-regex779.md`)
+ * for the boundary decisions (PoC recipe choice, breakpoint, sidebar
+ * width, sticky offset).
+ */
+
+@media (min-width: 1024px) {
+  main.vh-desktop-layout {
+    max-width: 1280px;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 280px;
+    grid-template-areas:
+      "header header"
+      "main   side"
+      "footer footer";
+    column-gap: 2rem;
+    row-gap: 1.5rem;
+  }
+
+  main.vh-desktop-layout > .vh-desktop-layout__header {
+    grid-area: header;
+  }
+
+  main.vh-desktop-layout > .vh-desktop-layout__main {
+    grid-area: main;
+    /* keep section spacing inside the slot at the existing rhythm */
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+  }
+
+  main.vh-desktop-layout > .vh-desktop-layout__main > section {
+    /* the slot's flex gap replaces the per-section margin-bottom */
+    margin-bottom: 0;
+  }
+
+  main.vh-desktop-layout > .vh-desktop-layout__side {
+    grid-area: side;
+    /* sticky offset clears rspress's 60px top nav plus a breathing line */
+    position: sticky;
+    top: calc(60px + 1rem);
+    align-self: start;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  main.vh-desktop-layout > .vh-desktop-layout__side > section {
+    margin-bottom: 0;
+  }
+
+  main.vh-desktop-layout > .vh-desktop-layout__footer {
+    grid-area: footer;
+    /* footer keeps its existing top-border treatment from `main > footer`
+     * — the selector still matches because <footer> is still a direct
+     * child of <main> in the slot wrapper structure. */
+  }
+}
+

--- a/src/layer1_wasm/regex-779/index.html
+++ b/src/layer1_wasm/regex-779/index.html
@@ -21,8 +21,8 @@
     <link rel="stylesheet" href="../_shared/style.css" />
   </head>
   <body>
-    <main>
-      <header>
+    <main class="vh-desktop-layout">
+      <header class="vh-desktop-layout__header">
         <p class="kicker">Vivarium · Layer 1 · Rust (wasm32-wasip1)</p>
         <h1>Reproducing <a href="https://github.com/rust-lang/regex/issues/779">rust-lang/regex#779</a></h1>
         <p class="lede">
@@ -38,25 +38,29 @@
         </p>
       </header>
 
-      <section>
-        <h2>Verdict</h2>
-        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
-          Loading Rust wasm32-wasip1 artefact via WASI shim…
-        </div>
-        <p class="meta" id="meta"></p>
-      </section>
+      <div class="vh-desktop-layout__main">
+        <section>
+          <h2>Reproduction script (Rust)</h2>
+          <pre><code id="repro-code"></code></pre>
+        </section>
 
-      <section>
-        <h2>Reproduction script (Rust)</h2>
-        <pre><code id="repro-code"></code></pre>
-      </section>
+        <section>
+          <h2>Output</h2>
+          <pre id="output">(running)</pre>
+        </section>
+      </div>
 
-      <section>
-        <h2>Output</h2>
-        <pre id="output">(running)</pre>
-      </section>
+      <aside class="vh-desktop-layout__side">
+        <section>
+          <h2>Verdict</h2>
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+            Loading Rust wasm32-wasip1 artefact via WASI shim…
+          </div>
+          <p class="meta" id="meta"></p>
+        </section>
+      </aside>
 
-      <footer>
+      <footer class="vh-desktop-layout__footer">
         <p class="meta">
           Runtime:
           Rust crate compiled to <code>wasm32-wasip1</code>, instantiated in-browser via


### PR DESCRIPTION

First Phase 8 V″ PoC: opt regex-779 into a two-column desktop
layout (1024px+ breakpoint, sticky verdict sidebar). The
matches_plus / matches_expanded arrays now display alongside a
persistent verdict pill instead of stacking vertically in a
single 880px column.

Implementation:
- _shared/style.css: new .vh-desktop-layout opt-in class with
  CSS Grid 2-column template (header / main+side / footer
  areas); 280px sticky sidebar offset from rspress's 60px top
  nav (top: calc(60px + 1rem)).
- regex-779/index.html: <main> opts in via class; existing
  sections wrap into __main (code + output) and __side
  (verdict + meta) slots. Header and footer carry their own
  slot classes.
- Mobile (<1024px) keeps the existing single-column stack
  unchanged. Recipes that have not been propagated stay on
  single-column — no class, no impact.

Sibling propagation order (informational): pandas → numpy →
cpython → ruby → php (php last to defer Path A interleaving).

Related ADR (private under _context/decisions/):
- ADR-0033 — Phase 8 V″ PoC: regex-779 desktop layout
  (class-based opt-in via _shared/style.css)

Refs ADR-0032 §V″.
