### PR TITLE
chore(infra): gitignore docs/ Playwright run artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,14 @@ src/layer1_wasm/playwright-report/
 src/layer1_wasm/test-results/
 src/layer1_wasm/blob-report/
 src/layer1_wasm/.last-run.json
+# Same artefacts for the docs-site E2E suite (`docs/playwright.config.ts`,
+# added in PR #189). Generated under docs/ on every `bun run test:e2e`
+# run; CI uploads playwright-report/ as a workflow artifact on failure
+# but neither directory is meant to live in version control.
+docs/playwright-report/
+docs/test-results/
+docs/blob-report/
+docs/.last-run.json
 
 # ─── rspress ─────────────────────────────────
 doc_build/


### PR DESCRIPTION

PR #189 added a Playwright E2E suite under docs/. Each local run
generates docs/test-results/ + docs/playwright-report/ (and a few
sidecar files: blob-report/, .last-run.json). These mirror the
Layer 1 Playwright artefacts already ignored under
src/layer1_wasm/, but the docs/ entries were never added.

Same gitignore policy as the Layer 1 ones — generated on demand,
uploaded to CI as a workflow artifact on failure, never committed.
