### PR TITLE
feat(docs): ajv-standalone migration for manifest + verdict validators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,12 @@ docs/.last-run.json
 doc_build/
 .rspress/
 
+# ajv-standalone validators emitted by `docs/scripts/generate-validators.ts`
+# from the schemas under `docs/public/spec/`. Reproducible from the schema
+# + the codegen script + pinned ajv/ajv-formats versions; the schemas are
+# the source of truth. See ADR-0034 for the migration rationale.
+docs/generated/
+
 # Per-project landing pages under `/repro/<project>/` are generated at
 # build time by `docs/scripts/generate-project-pages.ts` from the
 # `docs/public/api/projects.json` index — see the AUTO-GENERATED marker

--- a/docs/biome.json
+++ b/docs/biome.json
@@ -17,7 +17,8 @@
       "!**/public/api/projects.json",
       "!**/public/api/recipes.schema.json",
       "!**/public/spec",
-      "!**/bun.lock"
+      "!**/bun.lock",
+      "!**/generated"
     ]
   },
   "formatter": {

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -13,6 +13,8 @@
         "@rspress/core": "^2.0.9",
         "@types/bun": "^1.3.13",
         "@types/node": "^25.6.2",
+        "ajv": "8.20.0",
+        "ajv-formats": "3.0.1",
         "jszip": "^3.10.1",
       },
     },
@@ -136,6 +138,10 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
@@ -204,6 +210,10 @@
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
     "flexsearch": ["flexsearch@0.8.212", "", {}, "sha512-wSyJr1GUWoOOIISRu+X2IXiOcVfg9qqBRyCPRUdLMIGJqPzMo+jMRlvE83t14v1j0dRMEaBbER/adQjp6Du2pw=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
@@ -257,6 +267,8 @@
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
 
@@ -453,6 +465,8 @@
     "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 

--- a/docs/components/ManifestScaffolder.tsx
+++ b/docs/components/ManifestScaffolder.tsx
@@ -1,14 +1,20 @@
 import { useMemo, useState } from 'react';
+import validateManifestRaw from '../generated/manifest-validator.mjs';
 import './manifest-scaffolder.css';
 
 /* ============================================================================
  * Phase 6 M.1 — interactive .vivarium/manifest.toml scaffolder.
  *
  * Hand-rolled form per ADR-0026 §1 (JSON Schema → labels/help only,
- * fields are hand-coded). Hand-rolled validation + TOML emission per
- * §2/§3. No backend; all state is in-memory.
+ * fields are hand-coded). TOML emission per §3.
  *
- * Output mirrors docs/public/spec/manifest.schema.json's example block.
+ * Validation runs against the ajv-standalone-generated validator at
+ * `docs/generated/manifest-validator.mjs`, which is built from
+ * `docs/public/spec/manifest.schema.json` by `scripts/generate-validators.ts`.
+ * The schema is the single source of truth; this component only converts
+ * the form state into a candidate manifest object and translates ajv
+ * errors back into the per-field UI map. See ADR-0034 for the migration
+ * rationale.
  * ========================================================================== */
 
 type Lang = 'en' | 'ja';
@@ -41,32 +47,156 @@ interface FormState {
   };
 }
 
-const SLUG_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
-const URL_RE = /^https?:\/\/.+/;
-
 type FieldErrors = Partial<Record<string, string>>;
 
-function validate(state: FormState): FieldErrors {
-  const errors: FieldErrors = {};
-  if (!state.slug) errors.slug = 'required';
-  else if (!SLUG_RE.test(state.slug))
-    errors.slug = 'must match /^[a-z0-9]+(-[a-z0-9]+)*$/';
-  if (state.layer == null) errors.layer = 'required';
-  if (!state.bug.project) errors['bug.project'] = 'required';
-  if (state.bug.issue !== '' && !/^\d+$/.test(state.bug.issue))
-    errors['bug.issue'] = 'must be a non-negative integer';
-  if (!state.bug.upstream_url) errors['bug.upstream_url'] = 'required';
-  else if (!URL_RE.test(state.bug.upstream_url))
-    errors['bug.upstream_url'] = 'must be http(s)://…';
+interface AjvErrorObject {
+  instancePath: string;
+  schemaPath: string;
+  keyword: string;
+  params: Record<string, unknown>;
+  message?: string;
+}
+
+interface AjvValidateFn {
+  (data: unknown): boolean;
+  errors?: AjvErrorObject[] | null;
+}
+
+const validateManifest = validateManifestRaw as unknown as AjvValidateFn;
+
+function buildCandidate(state: FormState): Record<string, unknown> {
+  const candidate: Record<string, unknown> = { manifest: 'v1' };
+
+  if (state.slug) candidate.slug = state.slug;
+  if (state.layer != null) candidate.layer = state.layer;
+  if (state.title) candidate.title = state.title;
+  if (state.description) candidate.description = state.description;
+
+  const bug: Record<string, unknown> = {};
+  if (state.bug.project) bug.project = state.bug.project;
+  if (state.bug.issue === '') {
+    bug.issue = 0;
+  } else if (/^\d+$/.test(state.bug.issue)) {
+    bug.issue = Number(state.bug.issue);
+  } else {
+    // Non-numeric input — leave as-is so ajv can report a type error.
+    bug.issue = state.bug.issue;
+  }
+  if (state.bug.upstream_url) bug.upstream_url = state.bug.upstream_url;
+  candidate.bug = bug;
 
   if (state.layer === 1) {
-    if (!state.layer1.page_url) errors['layer1.page_url'] = 'required';
-    else if (!URL_RE.test(state.layer1.page_url))
-      errors['layer1.page_url'] = 'must be http(s)://…';
+    const layer1: Record<string, unknown> = {};
+    if (state.layer1.page_url) layer1.page_url = state.layer1.page_url;
+    if (state.layer1.expected_verdict)
+      layer1.expected_verdict = state.layer1.expected_verdict;
+    candidate.layer1 = layer1;
   } else if (state.layer === 2) {
-    if (!state.layer2.image) errors['layer2.image'] = 'required';
+    const layer2: Record<string, unknown> = {};
+    if (state.layer2.image) layer2.image = state.layer2.image;
+    if (state.layer2.dockerfile) layer2.dockerfile = state.layer2.dockerfile;
+    if (state.layer2.expected_verdict)
+      layer2.expected_verdict = state.layer2.expected_verdict;
+    candidate.layer2 = layer2;
   } else if (state.layer === 3) {
-    if (!state.layer3.image) errors['layer3.image'] = 'required';
+    const layer3: Record<string, unknown> = {};
+    if (state.layer3.image) layer3.image = state.layer3.image;
+    if (state.layer3.dockerfile) layer3.dockerfile = state.layer3.dockerfile;
+    if (state.layer3.expected_verdict)
+      layer3.expected_verdict = state.layer3.expected_verdict;
+    candidate.layer3 = layer3;
+  }
+
+  return candidate;
+}
+
+// Translate ajv `instancePath` (e.g. "/bug/upstream_url") + the optional
+// `params.missingProperty` for `required` errors into the dotted field
+// keys the UI map uses (e.g. "bug.upstream_url").
+function ajvErrorToFieldKey(err: AjvErrorObject): string {
+  const base = err.instancePath.replace(/^\//, '').replaceAll('/', '.');
+  if (
+    err.keyword === 'required' &&
+    typeof err.params.missingProperty === 'string'
+  ) {
+    return base
+      ? `${base}.${err.params.missingProperty}`
+      : err.params.missingProperty;
+  }
+  return base;
+}
+
+// Map ajv keywords to short UI-friendly messages. Falls back to ajv's
+// default `message` when the keyword is not specifically handled.
+function humanizeAjvError(err: AjvErrorObject): string {
+  switch (err.keyword) {
+    case 'required':
+      return 'required';
+    case 'pattern':
+      return `must match /${err.params.pattern}/`;
+    case 'format':
+      return err.params.format === 'uri'
+        ? 'must be a URI (e.g. https://…)'
+        : `must match format "${err.params.format}"`;
+    case 'type':
+      return `must be ${err.params.type}`;
+    case 'enum':
+      return 'must be one of the allowed values';
+    case 'minLength':
+      return `must be at least ${err.params.limit} character(s)`;
+    case 'minimum':
+      return `must be ≥ ${err.params.limit}`;
+    case 'const':
+      return `must equal ${JSON.stringify(err.params.allowedValue)}`;
+    default:
+      return err.message ?? `invalid (${err.keyword})`;
+  }
+}
+
+// Errors emitted only because the schema's per-layer `oneOf` branch
+// rejected a non-active layer. Hide these from the UI — the active
+// layer's own required/pattern errors are still surfaced.
+function isOneOfBranchNoise(err: AjvErrorObject): boolean {
+  if (err.keyword === 'oneOf') return true;
+  if (err.keyword === 'not') return true;
+  if (err.keyword === 'const' && err.instancePath === '/layer') return true;
+  return false;
+}
+
+function validate(state: FormState): FieldErrors {
+  // Pre-ajv guard: layer is the only field whose absence cannot be
+  // signalled via "candidate.layer omitted" (ajv would just say the
+  // root needs `layer`, with an empty instancePath). Surfacing it as a
+  // field error here keeps the UI consistent with the previous
+  // behaviour.
+  if (state.layer == null) {
+    const candidateNoLayer = buildCandidate(state);
+    const errors: FieldErrors = { layer: 'required' };
+    // Run ajv anyway so the user sees other field errors at the same
+    // time, but skip the root-level required error for `layer`.
+    if (!validateManifest(candidateNoLayer)) {
+      for (const err of validateManifest.errors ?? []) {
+        if (isOneOfBranchNoise(err)) continue;
+        if (
+          err.keyword === 'required' &&
+          err.params.missingProperty === 'layer'
+        )
+          continue;
+        const key = ajvErrorToFieldKey(err);
+        if (key && !errors[key]) errors[key] = humanizeAjvError(err);
+      }
+    }
+    return errors;
+  }
+
+  const candidate = buildCandidate(state);
+  if (validateManifest(candidate)) return {};
+
+  const errors: FieldErrors = {};
+  for (const err of validateManifest.errors ?? []) {
+    if (isOneOfBranchNoise(err)) continue;
+    const key = ajvErrorToFieldKey(err);
+    if (key && !errors[key]) errors[key] = humanizeAjvError(err);
   }
   return errors;
 }

--- a/docs/components/ReproCompare.tsx
+++ b/docs/components/ReproCompare.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import validateVerdictRaw from '../generated/verdict-validator.mjs';
 import './repro-compare.css';
 
 /* ============================================================================
@@ -13,9 +14,10 @@ import './repro-compare.css';
  *   1. Accepts file drop / file picker (zip artefact OR bare json).
  *   2. Accepts URL params (?slug=&branch_url=&original_url=).
  *   3. Falls back to JSON paste on CORS / parse failure.
- *   4. Validates each loaded verdict against Contract v1 v1 shape
- *      (hand-rolled — schema is static and tiny; ajv-standalone migration
- *      is deferred per ADR-0023 §1 Negative until the schema grows).
+ *   4. Validates each loaded verdict against Contract v1 v1 shape via
+ *      the ajv-standalone-generated validator built from
+ *      `docs/public/spec/verdict.schema.json` (see ADR-0034). The schema
+ *      is the single source of truth.
  *   5. Renders side-by-side comparison via the V.2 component family.
  *
  * The visitor's verdicts never leave the browser — all parsing,
@@ -46,106 +48,51 @@ type ValidationResult =
   | { ok: true; data: VerdictV1 }
   | { ok: false; error: ValidationError };
 
-const REQUIRED_FIELDS = [
-  'contract',
-  'verdict',
-  'exit_code',
-  'image_tag',
-  'image_digest',
-  'captured_at',
-  'stdout',
-  'stderr_tail',
-] as const;
+interface AjvErrorObject {
+  instancePath: string;
+  schemaPath: string;
+  keyword: string;
+  params: Record<string, unknown>;
+  message?: string;
+}
+
+interface AjvValidateFn {
+  (data: unknown): boolean;
+  errors?: AjvErrorObject[] | null;
+}
+
+const validateVerdictAjv = validateVerdictRaw as unknown as AjvValidateFn;
+
+function ajvErrorToValidationError(err: AjvErrorObject): ValidationError {
+  // For `required` errors, ajv reports the parent's instancePath and
+  // the missing key in `params.missingProperty` — surface the missing
+  // path explicitly so the UI's "at /field" hint is precise.
+  if (
+    err.keyword === 'required' &&
+    typeof err.params.missingProperty === 'string'
+  ) {
+    const parent = err.instancePath || '';
+    return {
+      path: `${parent}/${err.params.missingProperty}`,
+      message: 'required field missing',
+    };
+  }
+  return {
+    path: err.instancePath || '/',
+    message: err.message ?? `invalid (${err.keyword})`,
+  };
+}
 
 function validateVerdict(raw: unknown): ValidationResult {
-  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
-    return {
-      ok: false,
-      error: {
-        path: '/',
-        message: 'expected a JSON object at the top level',
-      },
-    };
+  if (validateVerdictAjv(raw)) {
+    return { ok: true, data: raw as VerdictV1 };
   }
-  const obj = raw as Record<string, unknown>;
-
-  for (const field of REQUIRED_FIELDS) {
-    if (!(field in obj)) {
-      return {
-        ok: false,
-        error: {
-          path: `/${field}`,
-          message: 'required field missing',
-        },
-      };
-    }
-  }
-
-  if (obj.contract !== 'v1') {
-    return {
-      ok: false,
-      error: {
-        path: '/contract',
-        message: `expected "v1", got ${JSON.stringify(obj.contract)}`,
-      },
-    };
-  }
-  if (obj.verdict !== 'reproduced' && obj.verdict !== 'unreproduced') {
-    return {
-      ok: false,
-      error: {
-        path: '/verdict',
-        message: `expected "reproduced" or "unreproduced", got ${JSON.stringify(obj.verdict)}`,
-      },
-    };
-  }
-  if (typeof obj.exit_code !== 'number' || !Number.isInteger(obj.exit_code)) {
-    return {
-      ok: false,
-      error: {
-        path: '/exit_code',
-        message: `expected integer, got ${typeof obj.exit_code}`,
-      },
-    };
-  }
-  if (typeof obj.image_tag !== 'string' || obj.image_tag.length === 0) {
-    return {
-      ok: false,
-      error: {
-        path: '/image_tag',
-        message: 'expected non-empty string',
-      },
-    };
-  }
-  for (const field of [
-    'image_digest',
-    'captured_at',
-    'stdout',
-    'stderr_tail',
-  ] as const) {
-    if (typeof obj[field] !== 'string') {
-      return {
-        ok: false,
-        error: {
-          path: `/${field}`,
-          message: `expected string, got ${typeof obj[field]}`,
-        },
-      };
-    }
-  }
-
+  const firstErr = validateVerdictAjv.errors?.[0];
   return {
-    ok: true,
-    data: {
-      contract: 'v1',
-      verdict: obj.verdict as VerdictLiteral,
-      exit_code: obj.exit_code,
-      image_tag: obj.image_tag as string,
-      image_digest: obj.image_digest as string,
-      captured_at: obj.captured_at as string,
-      stdout: obj.stdout as string,
-      stderr_tail: obj.stderr_tail as string,
-    },
+    ok: false,
+    error: firstErr
+      ? ajvErrorToValidationError(firstErr)
+      : { path: '/', message: 'invalid verdict shape' },
   };
 }
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,14 +5,15 @@
   "description": "Documentation site for Vivarium, built with rspress.",
   "type": "module",
   "scripts": {
+    "generate-validators": "bun run scripts/generate-validators.ts",
     "generate-index": "bun run scripts/generate-recipes-index.ts",
     "generate-project-pages": "bun run scripts/generate-project-pages.ts",
     "prebuild-repro": "bun run scripts/prebuild-repro.ts",
-    "dev": "bun run generate-index && bun run generate-project-pages && bun run prebuild-repro && rspress dev",
-    "build": "bun run generate-index && bun run generate-project-pages && rspress build",
+    "dev": "bun run generate-validators && bun run generate-index && bun run generate-project-pages && bun run prebuild-repro && rspress dev",
+    "build": "bun run generate-validators && bun run generate-index && bun run generate-project-pages && rspress build",
     "preview": "rspress preview",
     "test:e2e": "playwright test",
-    "test:unit": "bun test scripts/__tests__"
+    "test:unit": "bun run generate-validators && bun test scripts/__tests__"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",
@@ -20,6 +21,8 @@
     "@rspress/core": "^2.0.9",
     "@types/bun": "^1.3.13",
     "@types/node": "^25.6.2",
+    "ajv": "8.20.0",
+    "ajv-formats": "3.0.1",
     "jszip": "^3.10.1"
   },
   "dependencies": {

--- a/docs/scripts/__tests__/validators.test.ts
+++ b/docs/scripts/__tests__/validators.test.ts
@@ -1,0 +1,178 @@
+// Unit tests for the ajv-standalone-generated validators used by
+// `ManifestScaffolder.tsx` (Manifest v1) and `ReproCompare.tsx`
+// (Verdict / Contract v1). See ADR-0034 for the migration rationale.
+//
+// The tests are deliberately small and read directly from the schema
+// files: each schema's `examples` array MUST validate, and a hand-
+// curated set of invalid fixtures MUST fail with the expected
+// `instancePath`. If a future schema edit accidentally drops a
+// constraint or breaks the bundled example, this suite catches it
+// before the codegen output ships.
+//
+// The validators are imported from `docs/generated/`, which is
+// gitignored — running this suite without first running
+// `bun run generate-validators` (or `bun run dev` / `build`, both of
+// which trigger codegen) returns a clear "no module found" error.
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import validateManifestRaw from '../../generated/manifest-validator.mjs';
+import validateVerdictRaw from '../../generated/verdict-validator.mjs';
+
+interface AjvErrorObject {
+  instancePath: string;
+  keyword: string;
+  params: Record<string, unknown>;
+  message?: string;
+}
+
+interface AjvValidateFn {
+  (data: unknown): boolean;
+  errors?: AjvErrorObject[] | null;
+}
+
+const validateManifest = validateManifestRaw as unknown as AjvValidateFn;
+const validateVerdict = validateVerdictRaw as unknown as AjvValidateFn;
+
+const SCHEMA_DIR = path.join(import.meta.dirname, '..', '..', 'public', 'spec');
+
+function loadSchemaExamples(filename: string): unknown[] {
+  const schema = JSON.parse(
+    readFileSync(path.join(SCHEMA_DIR, filename), 'utf-8'),
+  );
+  return Array.isArray(schema.examples) ? schema.examples : [];
+}
+
+describe('Manifest v1 validator', () => {
+  test('schema example validates', () => {
+    const examples = loadSchemaExamples('manifest.schema.json');
+    expect(examples.length).toBeGreaterThan(0);
+    for (const example of examples) {
+      const ok = validateManifest(example);
+      if (!ok) {
+        console.error('Manifest example failed:', validateManifest.errors);
+      }
+      expect(ok).toBe(true);
+    }
+  });
+
+  test('rejects missing required field (slug)', () => {
+    const ok = validateManifest({
+      manifest: 'v1',
+      layer: 1,
+      bug: { project: 'x', issue: 0, upstream_url: 'https://example.org/' },
+      layer1: { page_url: 'https://example.org/' },
+    });
+    expect(ok).toBe(false);
+    expect(validateManifest.errors).toContainEqual(
+      expect.objectContaining({
+        keyword: 'required',
+        params: { missingProperty: 'slug' },
+      }),
+    );
+  });
+
+  test('rejects bad slug pattern', () => {
+    const ok = validateManifest({
+      manifest: 'v1',
+      slug: 'BadSlug_Name',
+      layer: 1,
+      bug: { project: 'x', issue: 0, upstream_url: 'https://example.org/' },
+      layer1: { page_url: 'https://example.org/' },
+    });
+    expect(ok).toBe(false);
+    expect(validateManifest.errors).toContainEqual(
+      expect.objectContaining({
+        keyword: 'pattern',
+        instancePath: '/slug',
+      }),
+    );
+  });
+
+  test('rejects layer 1 manifest carrying layer2 block (oneOf)', () => {
+    const ok = validateManifest({
+      manifest: 'v1',
+      slug: 'good-slug',
+      layer: 1,
+      bug: { project: 'x', issue: 0, upstream_url: 'https://example.org/' },
+      layer1: { page_url: 'https://example.org/' },
+      layer2: { image: 'ghcr.io/example/x' },
+    });
+    expect(ok).toBe(false);
+  });
+});
+
+describe('Verdict v1 (Contract v1) validator', () => {
+  test('schema example validates', () => {
+    const examples = loadSchemaExamples('verdict.schema.json');
+    expect(examples.length).toBeGreaterThan(0);
+    for (const example of examples) {
+      const ok = validateVerdict(example);
+      if (!ok) {
+        console.error('Verdict example failed:', validateVerdict.errors);
+      }
+      expect(ok).toBe(true);
+    }
+  });
+
+  test('rejects missing required field', () => {
+    const ok = validateVerdict({
+      contract: 'v1',
+      verdict: 'reproduced',
+      exit_code: 0,
+      // image_tag missing
+      image_digest: '',
+      captured_at: '2026-04-27T03:44:39Z',
+      stdout: '',
+      stderr_tail: '',
+    });
+    expect(ok).toBe(false);
+    expect(validateVerdict.errors).toContainEqual(
+      expect.objectContaining({
+        keyword: 'required',
+        params: { missingProperty: 'image_tag' },
+      }),
+    );
+  });
+
+  test('rejects unknown verdict enum value (e.g. legacy "pass")', () => {
+    const ok = validateVerdict({
+      contract: 'v1',
+      verdict: 'pass', // post-ADR-0029 rename, this should fail
+      exit_code: 0,
+      image_tag: 'x:1',
+      image_digest: '',
+      captured_at: '2026-04-27T03:44:39Z',
+      stdout: '',
+      stderr_tail: '',
+    });
+    expect(ok).toBe(false);
+    expect(validateVerdict.errors).toContainEqual(
+      expect.objectContaining({
+        keyword: 'enum',
+        instancePath: '/verdict',
+      }),
+    );
+  });
+
+  test('rejects malformed captured_at (not ISO-8601)', () => {
+    const ok = validateVerdict({
+      contract: 'v1',
+      verdict: 'reproduced',
+      exit_code: 0,
+      image_tag: 'x:1',
+      image_digest: '',
+      captured_at: 'not-a-date',
+      stdout: '',
+      stderr_tail: '',
+    });
+    expect(ok).toBe(false);
+    expect(validateVerdict.errors).toContainEqual(
+      expect.objectContaining({
+        keyword: 'format',
+        instancePath: '/captured_at',
+      }),
+    );
+  });
+});

--- a/docs/scripts/generate-validators.ts
+++ b/docs/scripts/generate-validators.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env bun
+//
+// Build-time codegen for ajv-standalone validators.
+//
+// Reads each schema under `docs/public/spec/` and emits a self-contained
+// validator module under `docs/generated/`. The generated modules are
+// gitignored — they are reproducible from the schema + this script + the
+// pinned ajv / ajv-formats versions in package.json.
+//
+// Wired into `bun run dev` and `bun run build` via docs/package.json,
+// ahead of `generate-index` so the rspress build never sees a stale
+// validator. See ADR-0034 for the trust-the-trigger override that
+// authorised this migration ahead of the original A3 trigger conditions.
+//
+// Adding a new schema → add an entry to `TARGETS` below; the rest of the
+// pipeline picks it up.
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import standaloneCode from 'ajv/dist/standalone/index.js';
+import addFormats from 'ajv-formats';
+
+interface Target {
+  /** Path relative to docs/public/spec/. */
+  schema: string;
+  /** Output filename under docs/generated/. */
+  output: string;
+  /** Human-friendly name used in log lines. */
+  label: string;
+}
+
+const TARGETS: Target[] = [
+  {
+    schema: 'manifest.schema.json',
+    output: 'manifest-validator.mjs',
+    label: 'Manifest v1',
+  },
+  {
+    schema: 'verdict.schema.json',
+    output: 'verdict-validator.mjs',
+    label: 'Verdict v1 (Contract v1)',
+  },
+];
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const DOCS_DIR = join(SCRIPT_DIR, '..');
+const SCHEMA_DIR = join(DOCS_DIR, 'public', 'spec');
+const OUTPUT_DIR = join(DOCS_DIR, 'generated');
+
+mkdirSync(OUTPUT_DIR, { recursive: true });
+
+for (const { schema, output, label } of TARGETS) {
+  const schemaPath = join(SCHEMA_DIR, schema);
+  const outputPath = join(OUTPUT_DIR, output);
+  const schemaJson = JSON.parse(readFileSync(schemaPath, 'utf-8'));
+
+  // Strict mode is on by default; the schemas use only documented
+  // keywords (oneOf, not, format, const, enum) so no exceptions needed.
+  // `code: { source: true, esm: true }` is required for standaloneCode.
+  // `allErrors: true` lets the consumer surface every field error in
+  // one pass instead of bailing on the first failure.
+  const ajv = new Ajv2020({
+    allErrors: true,
+    code: { source: true, esm: true },
+  });
+  addFormats(ajv);
+
+  const validate = ajv.compile(schemaJson);
+  const moduleCode = standaloneCode(ajv, validate);
+
+  writeFileSync(outputPath, moduleCode, 'utf-8');
+  console.log(
+    `[generate-validators] ${label}: ${schema} → generated/${output}`,
+  );
+}


### PR DESCRIPTION

Replaces the hand-rolled validators in `ManifestScaffolder.tsx` (manifest v1,
phase 6 m.1) and `ReproCompare.tsx` (verdict / contract v1, phase 6 r.3)
with ajv-standalone-generated modules built from
`docs/public/spec/{manifest,verdict}.schema.json` at build time. The
public JSON Schemas under `docs/public/spec/` become the single source
of truth — drift modes flagged in adr-0034 (rename sweep, schema
tightening, schema-grew-a-field) are now caught mechanically instead
of by hand-edits in two places.

Pipeline:
- new `docs/scripts/generate-validators.ts` runs ajv 8.20.0 +
  ajv-formats 3.0.1 in `code: { source: true, esm: true }` mode
  and emits self-contained ESM validators under `docs/generated/`.
- wired ahead of `generate-index` in `bun run dev` and `bun run build`
  so rspress never sees a stale validator.
- also wired into `test:unit` (validators are gitignored, so the
  unit suite needs codegen before bun-test starts).
- `docs/generated/` is gitignored — reproducible from schema +
  codegen + pinned versions; the schemas remain canonical.
- biome ignores `**/generated`.
- consumer code translates ajv errors back into the existing UI
  shape: `ManifestScaffolder` keeps its dotted field-key map
  (`bug.upstream_url`, `layer1.page_url`, …) and silences `oneOf`-
  branch noise; `ReproCompare` keeps its `{ path, message }`
  ValidationError shape.

Tests:
- `docs/scripts/__tests__/validators.test.ts` round-trips every
  schema-bundled `examples` array through the generated validator
  and asserts on representative invalid fixtures (missing required,
  bad pattern, bad enum, bad format, oneOf cross-layer).
- `bun run test:unit` → 24 pass / 0 fail (locally on Windows).
- `bun run build` succeeds with codegen in front.

Refs adr-0034 (trust-the-trigger override authorising a3 with
neither original trigger fired); supersedes the deferral noted in
adr-0023 §1 negative.
