### PR TITLE
feat(wasm): phase 8 V″ — split-pane recipe layout with overlay description drawer

### DIFF
--- a/docs/components/ProjectPage.tsx
+++ b/docs/components/ProjectPage.tsx
@@ -127,6 +127,22 @@ const STRINGS: Record<Lang, Strings> = {
   },
 };
 
+// Rewrite the production-host URL baked into recipes.json so that, when
+// served from a different origin (local rspress dev at localhost:3000,
+// a fork's Pages deploy, an rspress preview), the "Open" link points
+// at this page's own host instead of the upstream Pages site. The
+// pathname (`/<base>/repro/<project>/<issue>/`) is preserved verbatim;
+// only the origin is swapped. SSR is left untouched.
+function localizeRecipeUrl(url: string): string {
+  if (typeof window === 'undefined') return url;
+  try {
+    const u = new URL(url);
+    return window.location.origin + u.pathname + u.search + u.hash;
+  } catch {
+    return url;
+  }
+}
+
 function LayerPill({ lang, layer }: { lang: Lang; layer: 1 | 2 | 3 }) {
   const accent = layer === 1 ? 'teal' : layer === 2 ? 'violet' : 'coral';
   return (
@@ -256,7 +272,7 @@ export function ProjectPage({
                 <td className="v-pp__actions-cell">
                   <a
                     className="v-pp__btn v-pp__btn--primary"
-                    href={recipe.page_url}
+                    href={localizeRecipeUrl(recipe.page_url)}
                     target="_blank"
                     rel="noreferrer"
                   >

--- a/docs/components/RecipeGallery.tsx
+++ b/docs/components/RecipeGallery.tsx
@@ -101,6 +101,22 @@ const STRINGS: Record<Lang, Strings> = {
 
 /* ----------------------------- Helpers --------------------------------- */
 
+// Rewrite the production-host URL baked into recipes.json so that, when
+// served from a different origin (local rspress dev at localhost:3000,
+// a fork's Pages deploy, an rspress preview), the "Open" link points
+// at the gallery's own host instead of the upstream Pages site. The
+// pathname (`/<base>/repro/<project>/<issue>/`) is preserved verbatim;
+// only the origin is swapped. SSR is left untouched.
+function localizeRecipeUrl(url: string): string {
+  if (typeof window === 'undefined') return url;
+  try {
+    const u = new URL(url);
+    return window.location.origin + u.pathname + u.search + u.hash;
+  } catch {
+    return url;
+  }
+}
+
 function uniqueValues<T>(
   items: RecipeEntry[],
   pick: (r: RecipeEntry) => T | undefined,
@@ -235,7 +251,7 @@ function RecipeCard({ lang, recipe }: { lang: Lang; recipe: RecipeEntry }) {
       <div className="v-rg__actions">
         <a
           className="v-rg__btn v-rg__btn--primary"
-          href={recipe.page_url}
+          href={localizeRecipeUrl(recipe.page_url)}
           target="_blank"
           rel="noreferrer"
         >

--- a/src/layer1_wasm/_assets/chrome.js
+++ b/src/layer1_wasm/_assets/chrome.js
@@ -42,9 +42,12 @@ window.addEventListener('storage', (e) => {
 
 // ── Inline SVG icons ────────────────────────────────────────────────────
 
-const sun = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>';
-const moon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
-const github = '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12.02c0 5.09 3.29 9.4 7.86 10.93.58.11.79-.25.79-.55 0-.27-.01-.99-.02-1.94-3.2.69-3.87-1.54-3.87-1.54-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.69 1.24 3.34.95.1-.74.4-1.24.72-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.18.91-.25 1.89-.38 2.86-.38.97 0 1.95.13 2.86.38 2.18-1.49 3.14-1.18 3.14-1.18.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14 0 1.55-.01 2.79-.01 3.17 0 .31.21.67.79.55 4.57-1.53 7.86-5.84 7.86-10.93C23.5 5.65 18.35.5 12 .5z"/></svg>';
+const sun =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>';
+const moon =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+const github =
+  '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12.02c0 5.09 3.29 9.4 7.86 10.93.58.11.79-.25.79-.55 0-.27-.01-.99-.02-1.94-3.2.69-3.87-1.54-3.87-1.54-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.69 1.24 3.34.95.1-.74.4-1.24.72-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.18.91-.25 1.89-.38 2.86-.38.97 0 1.95.13 2.86.38 2.18-1.49 3.14-1.18 3.14-1.18.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14 0 1.55-.01 2.79-.01 3.17 0 .31.21.67.79.55 4.57-1.53 7.86-5.84 7.86-10.93C23.5 5.65 18.35.5 12 .5z"/></svg>';
 
 // rspress's nav links — keep in sync with docs/docs/_nav.json. Hardcoded
 // here so this script doesn't need to fetch a JSON file before the page
@@ -74,8 +77,7 @@ function injectChrome() {
   nav.className = 'vh-topnav';
 
   const navLinks = NAV_ITEMS.map(
-    (it) =>
-      `<a class="vh-topnav__link" href="${it.link}">${it.text}</a>`,
+    (it) => `<a class="vh-topnav__link" href="${it.link}">${it.text}</a>`,
   ).join('');
 
   nav.innerHTML = `
@@ -101,8 +103,21 @@ function injectChrome() {
   // accommodate either element comfortably).
   const outputEl = document.querySelector('#output');
   if (outputEl?.parentElement) {
-    outputEl.parentElement.classList.add('vh-output-section');
+    const outputCol = outputEl.parentElement;
+    outputCol.classList.add('vh-output-section');
     outputEl.classList.add('vh-output');
+
+    // Wrap the output column's <h2> in a `.vh-runner__head` row so its
+    // height matches the script column's head row (which carries Edit /
+    // Run / Reset). Without this wrap the output column's content area
+    // is taller than the script column's by the action-row height.
+    const colH2 = outputCol.querySelector(':scope > h2');
+    if (colH2 && colH2.parentElement === outputCol) {
+      const head = document.createElement('div');
+      head.className = 'vh-runner__head';
+      outputCol.insertBefore(head, colH2);
+      head.appendChild(colH2);
+    }
 
     const progress = document.createElement('div');
     progress.className = 'vh-progress';
@@ -169,7 +184,7 @@ function hideProgress() {
 }
 
 document.addEventListener('vh-progress', (e) => {
-  const d = (e && e.detail) || {};
+  const d = e?.detail || {};
   if (d.stage === 'done') {
     setProgress(100, 'Reproduction complete.', '');
     hideProgress();
@@ -197,14 +212,109 @@ function registerServiceWorker() {
     });
 }
 
+// ── Description drawer (Phase 8 V″, ADR-0035) ──────────────────────────
+//
+// Recipe pages opt in by inlining:
+//   1. A `<template id="bug-context">` whose content is the drawer body
+//      (the description prose + any "Reported on" / metadata blocks).
+//   2. A `<button data-vh-action="open-drawer">` somewhere in the page
+//      (typically in the header action row) that triggers the drawer.
+//
+// We construct the drawer + click-wash at body level once, then wire
+// every matching button to toggle it. Closing on:
+//   - X button click
+//   - wash click
+//   - Escape key
+
+const drawerCloseSvg =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>';
+
+function injectDescriptionDrawer() {
+  const tpl = document.getElementById('bug-context');
+  const triggers = document.querySelectorAll(
+    'button[data-vh-action="open-drawer"]',
+  );
+  if (!tpl || triggers.length === 0) return;
+
+  const wash = document.createElement('div');
+  wash.className = 'vh-drawer-wash';
+  wash.setAttribute('aria-hidden', 'true');
+
+  const drawer = document.createElement('aside');
+  drawer.className = 'vh-drawer';
+  drawer.setAttribute('role', 'dialog');
+  drawer.setAttribute('aria-modal', 'true');
+  drawer.setAttribute('aria-label', 'Bug context');
+  drawer.setAttribute('aria-hidden', 'true');
+  drawer.tabIndex = -1;
+
+  const close = document.createElement('button');
+  close.type = 'button';
+  close.className = 'vh-drawer__close';
+  close.setAttribute('aria-label', 'Close bug context');
+  close.innerHTML = drawerCloseSvg;
+  drawer.appendChild(close);
+
+  // Clone the template content into the drawer.
+  drawer.appendChild(tpl.content.cloneNode(true));
+
+  document.body.appendChild(wash);
+  document.body.appendChild(drawer);
+
+  let lastTrigger = null;
+
+  function open(triggerEl) {
+    lastTrigger = triggerEl ?? null;
+    drawer.classList.add('is-open');
+    wash.classList.add('is-visible');
+    drawer.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('vh-drawer-open');
+    for (const t of triggers) t.setAttribute('aria-expanded', 'true');
+    // Focus the close button so keyboard users can dismiss with Enter.
+    setTimeout(() => close.focus(), 50);
+  }
+
+  function closeDrawer() {
+    drawer.classList.remove('is-open');
+    wash.classList.remove('is-visible');
+    drawer.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('vh-drawer-open');
+    for (const t of triggers) t.setAttribute('aria-expanded', 'false');
+    if (lastTrigger && typeof lastTrigger.focus === 'function') {
+      lastTrigger.focus();
+    }
+    lastTrigger = null;
+  }
+
+  triggers.forEach((t) => {
+    t.setAttribute('aria-expanded', 'false');
+    t.setAttribute('aria-controls', 'vh-drawer-body');
+    t.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      open(t);
+    });
+  });
+
+  close.addEventListener('click', () => closeDrawer());
+  wash.addEventListener('click', () => closeDrawer());
+  document.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Escape' && drawer.classList.contains('is-open')) {
+      ev.preventDefault();
+      closeDrawer();
+    }
+  });
+}
+
 // ── Bootstrap ───────────────────────────────────────────────────────────
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', () => {
     injectChrome();
+    injectDescriptionDrawer();
     registerServiceWorker();
   });
 } else {
   injectChrome();
+  injectDescriptionDrawer();
   registerServiceWorker();
 }

--- a/src/layer1_wasm/_shared/runner.ts
+++ b/src/layer1_wasm/_shared/runner.ts
@@ -1,0 +1,306 @@
+// Phase 8 V″ — editable reproduction script + Run / Reset buttons.
+//
+// Recipes mount this helper after the baseline run finishes by calling
+// `enableRunner({...})`. It:
+//   1. Wraps the existing `<pre><code id="repro-code">` block (which
+//      `highlight-repros.ts` pre-renders with Shiki spans) inside a
+//      viewport that also contains a hidden `<textarea>`. The Shiki
+//      `<pre>` is the default surface — colourful, read-only.
+//   2. Inserts a `<div class="vh-runner__head">` flex row that hosts
+//      the script column's `<h2>` heading next to an Edit / Run /
+//      Reset action group. Putting the actions inline with the
+//      heading saves the column-height that an action bar below the
+//      editor would otherwise consume.
+//   3. On Edit, swaps the `<pre>` for the `<textarea>` (drops Shiki
+//      highlighting during edit — see ADR-0035 §"Negative"). Edits
+//      stay in the textarea until Reset.
+//   4. On Run, calls the recipe's `runFix(source)` callback with the
+//      currently-active source (textarea content if editing, the
+//      baseline source otherwise) and updates `#output` + the verdict
+//      pill in place.
+//   5. On Reset, restores the baseline source, switches back to view
+//      mode, and re-runs.
+//
+// Reuses the `PathACapturedRun` shape from `_shared/path_a.ts` so each
+// recipe needs only one `captureRun(source)` adapter to participate in
+// both the runner here and the existing Path A panel.
+//
+// Design decisions in ADR-0035.
+
+import type { PathACapturedRun } from './path_a.js';
+import { setVerdict } from './verdict.js';
+
+export interface RunnerOptions {
+  /** Recipe slug — informational, included in the runner mount-point id. */
+  slug: string;
+  /** The recipe's canonical reproduction source (plaintext). Used as the
+   *  initial textarea value and the Reset target. */
+  baselineSource: string;
+  /** Run the (possibly edited) source through the same already-loaded
+   *  WASM interpreter. Owns the actual re-run; the runner only
+   *  marshals the source string and surfaces the captured result. */
+  runFix: (source: string) => Promise<PathACapturedRun>;
+  /** DOM id of the existing `<pre><code>` block holding the
+   *  Shiki-highlighted baseline source. Defaults to `repro-code`. */
+  codeBlockId?: string;
+  /** DOM id of the `<pre>` block that holds the run output (the
+   *  same element existing chrome.js wires the progress overlay over).
+   *  Defaults to `output`. */
+  outputId?: string;
+}
+
+const SVG_PLAY =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="6 4 20 12 6 20 6 4"/></svg>';
+const SVG_PENCIL =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/></svg>';
+const SVG_EYE =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>';
+const SVG_RESET =
+  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>';
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  attrs: Record<string, string | undefined> = {},
+  ...children: (Node | string)[]
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs)) {
+    if (v == null) continue;
+    if (k === 'class') node.className = v;
+    else node.setAttribute(k, v);
+  }
+  for (const c of children) {
+    node.append(typeof c === 'string' ? document.createTextNode(c) : c);
+  }
+  return node;
+}
+
+export function enableRunner(opts: RunnerOptions): void {
+  const codeBlockId = opts.codeBlockId ?? 'repro-code';
+  const outputId = opts.outputId ?? 'output';
+
+  const codeEl = document.getElementById(codeBlockId);
+  if (!codeEl) {
+    console.warn(
+      `[vivarium runner] #${codeBlockId} not found — runner disabled.`,
+    );
+    return;
+  }
+
+  // The Shiki-rendered code lives inside `<pre><code id="repro-code">`.
+  // We wrap the `<pre>` in a viewport that also contains a hidden
+  // `<textarea>` for edit mode.
+  const preEl = codeEl.closest('pre');
+  if (!preEl) {
+    console.warn(
+      `[vivarium runner] #${codeBlockId} is not inside a <pre> — runner disabled.`,
+    );
+    return;
+  }
+
+  const preParent = preEl.parentElement;
+  if (!preParent) {
+    console.warn('[vivarium runner] <pre> has no parent — runner disabled.');
+    return;
+  }
+
+  // Capture the script column + its <h2> BEFORE moving <pre> into the
+  // viewport — once <pre> is detached and re-parented under viewport,
+  // `closest('.vh-main__col')` would return null because viewport has
+  // no parent yet.
+  const colEl = preEl.closest<HTMLElement>('.vh-main__col');
+  const h2El = colEl?.querySelector('h2') ?? null;
+
+  const outputEl = document.getElementById(outputId);
+
+  // ---- Build viewport (pre + textarea) -------------------------------------
+
+  const viewport = el('div', { class: 'vh-runner__viewport' });
+  const textarea = el('textarea', {
+    class: 'vh-runner__textarea',
+    spellcheck: 'false',
+    autocapitalize: 'off',
+    autocorrect: 'off',
+    'aria-label': 'Reproduction script editor',
+  }) as HTMLTextAreaElement;
+  textarea.value = opts.baselineSource;
+
+  // Lift the existing `<pre>` into the viewport, then append the textarea.
+  // CSS toggles which surface is visible based on `.vh-runner.is-editing`.
+  const placeholder = document.createComment('vh-runner-mount');
+  preParent.insertBefore(placeholder, preEl);
+  viewport.append(preEl, textarea);
+
+  // ---- Build action group (Edit / Run / Reset) -----------------------------
+
+  const editBtn = el(
+    'button',
+    {
+      type: 'button',
+      class: 'vh-runner__btn vh-runner__btn--ghost',
+      'aria-label': 'Edit reproduction script',
+    },
+    el('span', { 'aria-hidden': 'true' }),
+    'Edit',
+  ) as HTMLButtonElement;
+  editBtn.firstElementChild!.innerHTML = SVG_PENCIL;
+
+  const runBtn = el(
+    'button',
+    {
+      type: 'button',
+      class: 'vh-runner__btn vh-runner__btn--primary',
+      'aria-label': 'Run reproduction',
+    },
+    el('span', { 'aria-hidden': 'true' }),
+    'Run',
+  ) as HTMLButtonElement;
+  runBtn.firstElementChild!.innerHTML = SVG_PLAY;
+
+  const resetBtn = el(
+    'button',
+    {
+      type: 'button',
+      class: 'vh-runner__btn vh-runner__btn--ghost',
+      'aria-label': 'Reset to default',
+    },
+    el('span', { 'aria-hidden': 'true' }),
+    'Reset',
+  ) as HTMLButtonElement;
+  resetBtn.firstElementChild!.innerHTML = SVG_RESET;
+
+  const actions = el(
+    'div',
+    { class: 'vh-runner__actions' },
+    editBtn,
+    runBtn,
+    resetBtn,
+  );
+
+  // ---- Status line ---------------------------------------------------------
+
+  const statusEl = el('p', {
+    class: 'vh-runner__status',
+    role: 'status',
+    'aria-live': 'polite',
+  });
+
+  // ---- Mount: head row (h2 + actions) + viewport + status ------------------
+  // colEl + h2El were captured above, before we moved <pre>.
+
+  if (h2El?.parentElement) {
+    const headRow = el('div', { class: 'vh-runner__head' });
+    h2El.parentElement.insertBefore(headRow, h2El);
+    headRow.append(h2El, actions);
+  } else {
+    // Fallback — append actions before the viewport.
+    viewport.parentElement?.insertBefore(actions, viewport);
+  }
+
+  // Build the runner shell and place it where the original `<pre>` lived.
+  const shell = el(
+    'div',
+    { class: 'vh-runner', id: `vh-runner-${opts.slug}` },
+    viewport,
+    statusEl,
+  );
+
+  preParent.insertBefore(shell, placeholder);
+  placeholder.remove();
+
+  // ---- State + behaviour --------------------------------------------------
+
+  let isEditing = false;
+  let isBusy = false;
+
+  const updateEditButtonLabel = (): void => {
+    editBtn.textContent = '';
+    const span = el('span', { 'aria-hidden': 'true' });
+    span.innerHTML = isEditing ? SVG_EYE : SVG_PENCIL;
+    editBtn.append(span, isEditing ? 'View' : 'Edit');
+    editBtn.setAttribute(
+      'aria-label',
+      isEditing ? 'View highlighted source' : 'Edit reproduction script',
+    );
+  };
+
+  const setEditing = (next: boolean): void => {
+    isEditing = next;
+    shell.classList.toggle('is-editing', next);
+    updateEditButtonLabel();
+    if (next) {
+      // When entering edit mode, focus the textarea so the visitor
+      // can start typing without an extra click.
+      textarea.focus();
+      const len = textarea.value.length;
+      textarea.setSelectionRange(len, len);
+    }
+  };
+
+  const setBusy = (next: boolean): void => {
+    isBusy = next;
+    runBtn.disabled = next;
+    resetBtn.disabled = next;
+    editBtn.disabled = next;
+    runBtn.textContent = '';
+    const span = el('span', { 'aria-hidden': 'true' });
+    span.innerHTML = SVG_PLAY;
+    runBtn.append(span, next ? 'Running…' : 'Run');
+  };
+
+  const setStatus = (text: string, kind: 'info' | 'ok' | 'error'): void => {
+    statusEl.textContent = text;
+    statusEl.classList.remove(
+      'vh-runner__status--ok',
+      'vh-runner__status--error',
+    );
+    if (kind === 'ok') statusEl.classList.add('vh-runner__status--ok');
+    if (kind === 'error') statusEl.classList.add('vh-runner__status--error');
+  };
+
+  const currentSource = (): string =>
+    isEditing ? textarea.value : opts.baselineSource;
+
+  const runOnce = async (source: string): Promise<void> => {
+    if (isBusy) return;
+    setBusy(true);
+    setStatus('Running reproduction…', 'info');
+    setVerdict('pending', 'Re-running reproduction script…');
+    try {
+      const run = await opts.runFix(source);
+      if (outputEl) outputEl.textContent = run.stdout || '(no output)';
+      setVerdict(run.verdict, run.message);
+      setStatus(`${run.verdict} — ${run.message}`, 'ok');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      setStatus(`Run failed: ${message}`, 'error');
+      setVerdict('unreproduced', `runtime error: ${message}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // ---- Wire ---------------------------------------------------------------
+
+  editBtn.addEventListener('click', () => {
+    if (isBusy) return;
+    setEditing(!isEditing);
+  });
+
+  runBtn.addEventListener('click', () => {
+    void runOnce(currentSource());
+  });
+
+  resetBtn.addEventListener('click', () => {
+    if (isBusy) return;
+    textarea.value = opts.baselineSource;
+    setEditing(false);
+    setStatus('Reset to default — re-running baseline…', 'info');
+    void runOnce(opts.baselineSource);
+  });
+
+  // Initial paint of buttons (the textContent shuffle inside set*())
+  setEditing(false);
+  setBusy(false);
+  setStatus('', 'info');
+}

--- a/src/layer1_wasm/_shared/style.css
+++ b/src/layer1_wasm/_shared/style.css
@@ -9,7 +9,7 @@
  * from a verdict link, so we cannot rely on a cross-page theme toggle.
  */
 
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap");
 
 /* Theme tokens — matches rspress's pattern: html gets a `dark` class when
  * the user (or the inline early-theme script) decides dark mode is on,
@@ -79,7 +79,8 @@ body {
   margin: 0;
   background: var(--vh-bg);
   color: var(--vh-text);
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   line-height: 1.6;
   position: relative;
   overflow-x: hidden;
@@ -88,7 +89,7 @@ body {
 /* Subtle radial atmosphere — matches the home hero's "lit from within"
  * teal/violet glow. Only painted on dark mode where it has impact. */
 html.dark body::before {
-  content: '';
+  content: "";
   position: fixed;
   top: -10%;
   left: -10%;
@@ -101,13 +102,17 @@ html.dark body::before {
 }
 
 html.dark body::after {
-  content: '';
+  content: "";
   position: fixed;
   bottom: -10%;
   right: -10%;
   width: 50%;
   height: 50%;
-  background: radial-gradient(circle, rgba(124, 92, 255, 0.06), transparent 60%);
+  background: radial-gradient(
+    circle,
+    rgba(124, 92, 255, 0.06),
+    transparent 60%
+  );
   filter: blur(60px);
   pointer-events: none;
   z-index: -1;
@@ -126,7 +131,7 @@ html.dark body::after {
   padding: 0 1.25rem;
   border-bottom: 1px solid var(--vh-hairline);
   background: var(--vh-bg);
-  font-family: 'Inter', sans-serif;
+  font-family: "Inter", sans-serif;
 }
 
 @media (min-width: 1280px) {
@@ -145,7 +150,7 @@ html.dark body::after {
 .vh-topnav__brand-link {
   display: inline-flex;
   align-items: center;
-  font-family: 'Inter', sans-serif;
+  font-family: "Inter", sans-serif;
   font-weight: 700;
   font-size: 1.05rem;
   letter-spacing: -0.01em;
@@ -303,7 +308,11 @@ main {
 .vh-progress__fill {
   height: 100%;
   width: 5%;
-  background: linear-gradient(90deg, var(--vh-accent-teal-bright), var(--vh-accent-violet-bright));
+  background: linear-gradient(
+    90deg,
+    var(--vh-accent-teal-bright),
+    var(--vh-accent-violet-bright)
+  );
   transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);
   box-shadow: 0 0 12px rgba(0, 212, 170, 0.45);
 }
@@ -313,7 +322,7 @@ main {
   justify-content: space-between;
   align-items: center;
   margin-top: 0.6rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.7rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -327,9 +336,16 @@ main {
   color: var(--vh-text-dim);
 }
 
-/* ---------- Header ---------- */
+/* ---------- Header ----------
+ *
+ * Originally this targeted the bare `<header>` inside `<main>`, but
+ * `chrome.js` now also injects a `.vh-topnav` `<header>` at the top
+ * of `<body>`. Scoping to `.vh-main__header` keeps the original
+ * spacing for the recipe content header without bleeding into the
+ * topnav (which had a `margin-bottom: 1.75rem` ghost gap below it
+ * before this fix). */
 
-header {
+.vh-main__header {
   margin-bottom: 1.75rem;
   padding-bottom: 1.25rem;
   border-bottom: 1px solid var(--vh-hairline);
@@ -342,7 +358,8 @@ header {
   border: 1px solid var(--vh-hairline);
   border-radius: 9999px;
   background: rgba(0, 212, 170, 0.05);
-  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-family:
+    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.65rem;
   color: var(--vh-accent-teal);
   letter-spacing: 0.12em;
@@ -351,7 +368,7 @@ header {
 
 h1 {
   margin: 0 0 1rem;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-weight: 700;
   font-size: clamp(1.75rem, 4vw, 2.75rem);
   line-height: 1.1;
@@ -372,7 +389,7 @@ h1 a:hover {
 
 h2 {
   margin: 0 0 1rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.7rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -406,7 +423,7 @@ a:hover {
 }
 
 code {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.92em;
   padding: 0.1em 0.35em;
   background: var(--vh-card-bg);
@@ -424,7 +441,7 @@ pre {
   border: 1px solid var(--vh-hairline);
   border-radius: 8px;
   overflow-x: auto;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.85rem;
   line-height: 1.65;
   color: #e0e6e3;
@@ -448,7 +465,7 @@ pre code {
   padding: 0.85rem 1.25rem;
   border-radius: 8px;
   border: 1px solid;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-weight: 700;
   font-size: 0.95rem;
   letter-spacing: 0.02em;
@@ -460,7 +477,7 @@ pre code {
   height: 10px;
   border-radius: 9999px;
   background: currentColor;
-  content: '';
+  content: "";
   flex-shrink: 0;
 }
 
@@ -489,8 +506,13 @@ pre code {
 }
 
 @keyframes vh-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
 }
 
 /* ---------- Output / terminal block ---------- */
@@ -506,7 +528,7 @@ pre code {
   margin: 0.85rem 0 0;
   font-size: 0.85rem;
   color: var(--vh-text-dim);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   letter-spacing: 0.02em;
 }
 
@@ -519,7 +541,7 @@ main > footer {
 }
 
 main > footer .meta {
-  font-family: 'Inter', sans-serif;
+  font-family: "Inter", sans-serif;
   font-size: 0.85rem;
   line-height: 1.65;
   color: var(--vh-text-muted);
@@ -537,7 +559,7 @@ main > footer code {
   padding: 2rem 1.5rem;
   border-top: 1px solid var(--vh-hairline);
   background: var(--vh-bg);
-  font-family: 'Inter', sans-serif;
+  font-family: "Inter", sans-serif;
 }
 
 .vh-footer__msg {
@@ -575,7 +597,7 @@ main > footer code {
 
 .vh-path-a__eyebrow {
   margin: 0 0 0.5rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   letter-spacing: 0.05em;
   color: var(--vh-accent-teal);
@@ -583,7 +605,7 @@ main > footer code {
 
 .vh-path-a__heading {
   margin: 0 0 0.5rem;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-size: 1.4rem;
   letter-spacing: -0.01em;
 }
@@ -615,7 +637,7 @@ main > footer code {
   border-radius: 6px;
   background: var(--vh-bg-deep);
   color: var(--vh-text);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.85rem;
   line-height: 1.5;
 }
@@ -632,7 +654,7 @@ main > footer code {
 }
 
 .vh-path-a__file {
-  font-family: 'Inter', sans-serif;
+  font-family: "Inter", sans-serif;
   font-size: 0.85rem;
   color: var(--vh-text-muted);
 }
@@ -646,7 +668,7 @@ main > footer code {
 .vh-path-a__btn {
   padding: 0.5rem 1rem;
   border-radius: 6px;
-  font-family: 'Inter', sans-serif;
+  font-family: "Inter", sans-serif;
   font-size: 0.9rem;
   font-weight: 500;
   cursor: pointer;
@@ -699,7 +721,7 @@ main > footer code {
 
 .vh-path-a__result-heading {
   margin: 1.5rem 0 0.5rem;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-size: 1rem;
   letter-spacing: -0.01em;
   color: var(--vh-text-muted);
@@ -730,7 +752,7 @@ main > footer code {
 }
 
 .vh-path-a__verdict {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.75rem;
   font-weight: 500;
   padding: 0.15rem 0.5rem;
@@ -787,7 +809,7 @@ main > footer code {
 
 .vh-path-a__semantics-heading {
   margin: 0 0 0.35rem;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: "Space Grotesk", sans-serif;
   font-size: 0.95rem;
   color: var(--vh-text-muted);
 }
@@ -796,4 +818,787 @@ main > footer code {
   margin: 0;
   font-size: 0.85rem;
   color: var(--vh-text-muted);
+}
+
+/* ============================================================================
+ * Phase 8 V″ — desktop two-pane split + right-overlay description drawer.
+ * ADR-0035. Activates at >=1024px; below that breakpoint the recipe page
+ * keeps its existing single-column stack (no class needed for the
+ * fallback — the existing rules above already paint that path).
+ *
+ * Recipes opt in by structuring their `<main>` as:
+ *
+ *   <main class="vh-main">
+ *     <header class="vh-main__header"> ... </header>
+ *     <div    class="vh-main__cols">
+ *       <section class="vh-main__col vh-main__col--script"> ... </section>
+ *       <section class="vh-main__col vh-main__col--output"> ... </section>
+ *     </div>
+ *     <footer> ... </footer>
+ *   </main>
+ *
+ * The drawer (`<aside class="vh-drawer">`) and its wash
+ * (`<div class="vh-drawer-wash">`) are injected from `_assets/chrome.js`
+ * at runtime, populated from a per-recipe `<template id="bug-context">`
+ * the recipe HTML inlines in `<head>`.
+ * ========================================================================== */
+
+@media (min-width: 1024px) {
+  main.vh-main {
+    max-width: 1280px;
+  }
+}
+
+/* ---------- Header strip with right-aligned verdict aside ---------- */
+
+.vh-main__header {
+  margin-bottom: 1.25rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--vh-hairline);
+}
+
+.vh-main__header .lede {
+  margin-top: 0.85rem;
+  max-width: 720px;
+}
+
+.vh-main__header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+@media (min-width: 1024px) {
+  .vh-main__header {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    column-gap: 2rem;
+    align-items: start;
+  }
+  .vh-main__header-text {
+    grid-column: 1 / 2;
+    min-width: 0;
+  }
+  .vh-main__header-aside {
+    grid-column: 2 / 3;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.75rem;
+  }
+}
+
+/* ---------- Inline-icon ghost / primary chips for the action row ---------- */
+
+.vh-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 9999px;
+  border: 1px solid var(--vh-hairline);
+  background: transparent;
+  color: var(--vh-text-muted);
+  font-family: "Inter", sans-serif;
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  text-decoration: none;
+  transition:
+    background 0.18s ease,
+    color 0.18s ease,
+    border-color 0.18s ease;
+}
+
+.vh-chip:hover {
+  background: color-mix(in srgb, var(--vh-text) 6%, transparent);
+  color: var(--vh-text);
+  border-color: color-mix(
+    in srgb,
+    var(--vh-accent-teal) 35%,
+    var(--vh-hairline)
+  );
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--vh-accent-teal) 35%, var(--vh-hairline));
+}
+
+.vh-chip svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+/* ---------- Two-column work surface ---------- */
+
+.vh-main__cols {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  .vh-main__cols {
+    grid-template-columns: minmax(0, 6fr) minmax(0, 4fr);
+    column-gap: 1.75rem;
+    align-items: stretch;
+  }
+}
+
+.vh-main__col {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  min-width: 0;
+}
+
+.vh-main__col h2 {
+  margin-bottom: 0.85rem;
+}
+
+/* ---------- Editable script + Run button (the runner) ---------- */
+
+.vh-runner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.vh-runner__viewport {
+  position: relative;
+  border: 1px solid var(--vh-hairline);
+  border-radius: 8px;
+  background: var(--vh-code-bg);
+  overflow: hidden;
+}
+
+.vh-runner__viewport pre {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  max-height: 32rem;
+  overflow: auto;
+}
+
+.vh-runner__textarea {
+  display: none;
+  width: 100%;
+  margin: 0;
+  padding: 1.25rem 1.5rem;
+  border: 0;
+  background: transparent;
+  color: #e0e6e3;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.85rem;
+  line-height: 1.65;
+  resize: vertical;
+  min-height: 14rem;
+  max-height: 32rem;
+}
+
+.vh-runner.is-editing .vh-runner__viewport pre {
+  display: none;
+}
+
+.vh-runner.is-editing .vh-runner__textarea {
+  display: block;
+}
+
+.vh-runner__textarea:focus {
+  outline: 0;
+}
+
+.vh-runner__viewport:focus-within {
+  border-color: color-mix(
+    in srgb,
+    var(--vh-accent-teal) 40%,
+    var(--vh-hairline)
+  );
+  box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.12);
+}
+
+.vh-runner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.vh-runner__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.55rem 1rem;
+  border-radius: 6px;
+  font-family: "Inter", sans-serif;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 0.18s ease,
+    color 0.18s ease,
+    border-color 0.18s ease;
+}
+
+.vh-runner__btn svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.vh-runner__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.vh-runner__btn--primary {
+  border: 0;
+  background: var(--vh-accent-teal);
+  color: #00110e;
+}
+
+.vh-runner__btn--primary:not(:disabled):hover {
+  background: var(--vh-accent-teal-bright);
+}
+
+.vh-runner__btn--ghost {
+  border: 1px solid var(--vh-hairline);
+  background: transparent;
+  color: var(--vh-text);
+}
+
+.vh-runner__btn--ghost:not(:disabled):hover {
+  background: color-mix(in srgb, var(--vh-text) 8%, transparent);
+}
+
+.vh-runner__hint {
+  margin-left: auto;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  color: var(--vh-text-dim);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.vh-runner__status {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--vh-text-muted);
+  min-height: 1.2em;
+}
+
+.vh-runner__status--ok {
+  color: var(--vh-reproduced-fg);
+}
+
+.vh-runner__status--error {
+  color: var(--vh-unreproduced-fg);
+}
+
+/* ---------- Description drawer (right slide-in overlay) ---------- */
+
+.vh-drawer-wash {
+  position: fixed;
+  inset: 60px 0 0 0;
+  background: rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.22s ease;
+  z-index: 55;
+}
+
+.vh-drawer-wash.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.vh-drawer {
+  position: fixed;
+  top: 60px;
+  right: 0;
+  bottom: 0;
+  width: min(480px, 100vw);
+  /* Theme-aware surface — white in light mode, near-black in dark.
+   * Earlier draft used --vh-window-bg (always deep-dark, matches the
+   * code editor) but that broke the page's light-mode contract. */
+  background: var(--vh-bg-deep);
+  border-left: 1px solid var(--vh-hairline);
+  transform: translateX(100%);
+  transition: transform 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 60;
+  overflow-y: auto;
+  padding: 1.5rem 1.75rem 2rem;
+  color: var(--vh-text);
+}
+
+.vh-drawer.is-open {
+  transform: translateX(0);
+  box-shadow: -24px 0 60px rgba(0, 0, 0, 0.45);
+}
+
+.vh-drawer__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 32px;
+  height: 32px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--vh-text-muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background 0.18s ease,
+    color 0.18s ease;
+}
+
+.vh-drawer__close:hover {
+  background: color-mix(in srgb, var(--vh-text) 8%, transparent);
+  color: var(--vh-text);
+}
+
+.vh-drawer__close svg {
+  width: 16px;
+  height: 16px;
+}
+
+.vh-drawer__eyebrow {
+  margin: 0 0 0.5rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vh-accent-teal);
+}
+
+.vh-drawer__heading {
+  margin: 0 0 1.25rem;
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 1.4rem;
+  letter-spacing: -0.01em;
+  color: var(--vh-text);
+}
+
+.vh-drawer__body {
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: var(--vh-text-muted);
+}
+
+.vh-drawer__body p {
+  margin: 0 0 0.85rem;
+}
+
+.vh-drawer__body p:last-child {
+  margin-bottom: 0;
+}
+
+.vh-drawer__body code {
+  font-size: 0.92em;
+  background: var(--vh-card-bg);
+  border: 1px solid var(--vh-hairline);
+  border-radius: 4px;
+  padding: 0.05em 0.3em;
+}
+
+.vh-drawer__divider {
+  margin: 1.25rem 0;
+  border: 0;
+  border-top: 1px solid var(--vh-hairline);
+}
+
+.vh-drawer__meta-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem 1rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.75rem;
+}
+
+.vh-drawer__meta-key {
+  color: var(--vh-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.vh-drawer__meta-val {
+  color: var(--vh-text);
+  word-break: break-word;
+}
+
+.vh-drawer__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.65rem 1rem;
+  border-radius: 6px;
+  background: var(--vh-accent-teal);
+  color: #00110e;
+  font-family: "Inter", sans-serif;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+  border-bottom: 0;
+  transition: background 0.18s ease;
+}
+
+.vh-drawer__cta:hover {
+  background: var(--vh-accent-teal-bright);
+  border-bottom: 0;
+}
+
+.vh-drawer__cta svg {
+  width: 14px;
+  height: 14px;
+}
+
+.vh-drawer__secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--vh-text-muted);
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.18s ease;
+}
+
+.vh-drawer__secondary:hover {
+  border-bottom-color: var(--vh-accent-teal);
+}
+
+.vh-drawer__secondary svg {
+  width: 12px;
+  height: 12px;
+}
+
+/* Body scroll lock when drawer is open. */
+body.vh-drawer-open {
+  overflow: hidden;
+}
+
+/* ============================================================================
+ * Phase 8 V″ — second-pass header & viewport-fit refinements (2026-05-09).
+ *
+ * The earlier draft (above this block) gave the right structural shape
+ * but two complaints surfaced after the maintainer stepped through it:
+ *   1. The header took 3 rows (kicker + title + action chips) plus a
+ *      verdict-aside column; on a laptop screen this pushed the script
+ *      and output below the fold.
+ *   2. The reproduction script's `<pre>` inflated to fit its content,
+ *      so a long script made the page itself scroll — which the
+ *      maintainer wants to avoid (page-scroll degrades the
+ *      script-vs-output side-by-side framing).
+ *
+ * This block:
+ *   - Folds the header into a single row at desktop width: kicker (now
+ *     inline as a small pill prefix to the h1), title, action chips,
+ *     verdict pill — all inline-aligned.
+ *   - Hides the meta line on desktop (the runtime version info is in
+ *     the drawer's metadata grid; replaying it under the verdict on
+ *     the page itself wastes vertical space).
+ *   - Constrains both columns to a viewport-relative max-height so the
+ *     reproduction script and the output panel each become independent
+ *     scroll containers.
+ * ========================================================================== */
+
+@media (min-width: 1024px) {
+  /* Header: collapse the previous grid (text-column / aside-column)
+   * into a single inline row. Override the rule defined above. */
+  .vh-main__header {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    column-gap: 1rem;
+    row-gap: 0.6rem;
+    margin-bottom: 1rem;
+    padding-bottom: 0.85rem;
+  }
+
+  .vh-main__header-text {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    column-gap: 0.85rem;
+    row-gap: 0.5rem;
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .vh-main__header-text .kicker {
+    margin: 0;
+    flex-shrink: 0;
+    font-size: 0.6rem;
+    padding: 0.22rem 0.6rem;
+  }
+
+  .vh-main__header-text h1 {
+    margin: 0;
+    font-size: clamp(1rem, 1.7vw, 1.3rem);
+    line-height: 1.15;
+    flex: 0 1 auto;
+    min-width: 0;
+  }
+
+  .vh-main__header-actions {
+    margin-top: 0;
+    gap: 0.4rem;
+    flex-shrink: 0;
+  }
+
+  .vh-main__header-aside {
+    align-items: center;
+    flex-direction: row;
+    flex-shrink: 0;
+    gap: 0.5rem;
+  }
+
+  /* Compact verdict pill — fixed-width so LOADING… / RUNNING… /
+   * REPRODUCED / UNREPRODUCED all paint at the same horizontal extent
+   * (no layout shift on state change, no row-wrap on long labels). */
+  .vh-main__header-aside .verdict {
+    padding: 0.25rem 0.65rem;
+    font-size: 0.72rem;
+    min-width: 9rem;
+    justify-content: center;
+  }
+
+  /* Meta line ("Python 3.13 · SQLite 3.46 · …") moved into the drawer's
+   * metadata grid; hide on desktop so it doesn't compete for vertical
+   * room next to the verdict pill. */
+  .vh-main__header-aside .meta {
+    display: none;
+  }
+
+  /* ----- Viewport-fit columns (independent scroll containers) -----
+   *
+   * Approach: turn the body into a flex column so the topnav + main +
+   * site-footer chain occupies *exactly* one viewport. Inside `main`,
+   * the slim header and the recipe footer are flex-shrink:0; the
+   * `.vh-main__cols` row consumes the remaining vertical space. Inside
+   * each column, the runner's `<pre>` / `<textarea>` and the output
+   * panel scroll internally. Body itself never scrolls. */
+  body:has(main.vh-main) {
+    height: 100vh;
+    margin: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  body:has(main.vh-main) > .vh-topnav,
+  body:has(main.vh-main) > .vh-footer {
+    flex-shrink: 0;
+  }
+
+  body:has(main.vh-main) > main.vh-main {
+    flex: 1 1 0;
+    min-height: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  body:has(main.vh-main) > main.vh-main > .vh-main__header,
+  body:has(main.vh-main) > main.vh-main > footer {
+    flex-shrink: 0;
+  }
+
+  body:has(main.vh-main) > main.vh-main > .vh-main__cols {
+    flex: 1 1 0;
+    min-height: 0;
+  }
+
+  /* Phase 8 V″ doesn't run inside path-a, but if the recipe HTML places
+   * `<section id="path-a-mount">` between cols and footer (php-12167),
+   * keep it shrink-zero so it doesn't squash cols. */
+  body:has(main.vh-main) > main.vh-main > section[id="path-a-mount"] {
+    flex-shrink: 0;
+  }
+
+  .vh-main__col {
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .vh-main__col--script {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .vh-main__col--script > h2 {
+    flex-shrink: 0;
+  }
+
+  /* Runner & viewport stretch to fill the script column. */
+  .vh-runner {
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  .vh-runner__viewport {
+    flex: 1 1 auto;
+    min-height: 0;
+    max-height: none;
+  }
+
+  .vh-runner__viewport pre {
+    height: 100%;
+    max-height: none;
+    min-height: 0;
+  }
+
+  .vh-runner__textarea {
+    height: 100%;
+    max-height: none;
+    min-height: 0;
+    resize: none;
+  }
+
+  .vh-runner__actions,
+  .vh-runner__status {
+    flex-shrink: 0;
+  }
+
+  /* Output column — chrome.js adds the `vh-output-section` class to the
+   * same `<section>`. The base `.vh-main__col` rule sets
+   * `display: flex` (for the script column's runner stack); restore
+   * grid here, with an explicit two-row template so the head row
+   * stays at content height and the output/progress row fills the
+   * rest via `1fr`. */
+  .vh-output-section.vh-main__col--output {
+    display: grid;
+    grid-template-rows: auto 1fr;
+  }
+
+  /* Output `<pre id="output">` — full-fill the grid cell, scroll
+   * internally if JSON is long. */
+  .vh-output-section.vh-main__col--output .vh-output {
+    min-height: 0;
+    height: 100%;
+    overflow: auto;
+  }
+
+  /* Progress overlay — same grid cell as output. Force `height: 100%`
+   * so the box fills the column during loading instead of collapsing
+   * to its content size. Centred flex layout (existing) keeps the
+   * bar + label visually centered inside the tall box. */
+  .vh-output-section.vh-main__col--output .vh-progress {
+    min-height: 0;
+    height: 100%;
+  }
+
+  .vh-main__col--output #output {
+    margin: 0;
+    height: 100%;
+    max-height: none;
+  }
+
+  /* Tighter `main` chrome — title close to the top, footer line just
+   * a hair below the cols. */
+  main.vh-main {
+    padding-top: 0;
+    padding-bottom: 0.3rem;
+  }
+
+  .vh-main__header {
+    margin-bottom: 0.4rem;
+    padding-bottom: 0.25rem;
+  }
+
+  /* Output column `.vh-runner__head` (chrome.js wraps its <h2> for
+   * height parity with the script column). On desktop, give it a
+   * fixed min-height matching the actions row so the script and
+   * output content areas line up exactly. */
+  .vh-main__col--output > .vh-runner__head {
+    min-height: 30px;
+  }
+  .vh-main__col--script > .vh-runner__head {
+    min-height: 30px;
+  }
+
+  /* Apache License footer — keep visible but compact (2026-05-09
+   * maintainer ask). Drops from ~128px to ~28px. */
+  body:has(main.vh-main) > .vh-footer {
+    margin-top: 0;
+    padding: 0.35rem 1rem;
+    font-size: 0.72rem;
+    flex-shrink: 0;
+  }
+
+  body:has(main.vh-main) > .vh-footer .vh-footer__msg {
+    line-height: 1.2;
+  }
+
+  /* Action buttons (Run / Reset) move next to the script column's h2
+   * so the action row stops eating column height. The runner injects
+   * a `.vh-runner__head` flex row that wraps both. */
+  .vh-runner__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    margin: 0 0 0.5rem;
+    flex-shrink: 0;
+  }
+
+  .vh-runner__head h2 {
+    margin: 0;
+    flex-shrink: 0;
+  }
+
+  .vh-runner__head .vh-runner__actions {
+    margin: 0;
+    gap: 0.4rem;
+    flex-wrap: nowrap;
+  }
+
+  .vh-runner__head .vh-runner__btn {
+    padding: 0.35rem 0.65rem;
+    font-size: 0.78rem;
+  }
+
+  .vh-runner__head .vh-runner__btn svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  /* Hide hint chip on desktop — the always-editable textarea is
+   * obvious enough; the hint just costs a button slot. */
+  .vh-runner__head .vh-runner__hint {
+    display: none;
+  }
+
+  /* Hide the runner status line on desktop V″ so the script column's
+   * black viewport fills the same vertical area as the output column's
+   * `<pre id="output">`. The verdict pill carries the state literal and
+   * `__VIVARIUM_VERDICT_MESSAGE__` carries the full message for any
+   * tooling / future overlay that wants it. */
+  .vh-runner__status {
+    display: none;
+  }
+
+  /* Slimmer top nav — Vivarium / Vision / Roadmap / etc. The 60px
+   * default is a desktop-shell convention; for the V″ recipe page
+   * it eats too much real-estate above the title. */
+  body:has(main.vh-main) > .vh-topnav {
+    height: 44px;
+  }
+
+  /* Drawer top offset must follow the top-nav height. */
+  body:has(main.vh-main) ~ .vh-drawer,
+  body:has(main.vh-main) > .vh-drawer {
+    top: 44px;
+  }
+
+  body:has(main.vh-main) ~ .vh-drawer-wash,
+  body:has(main.vh-main) > .vh-drawer-wash {
+    inset: 44px 0 0 0;
+  }
 }

--- a/src/layer1_wasm/_shared/verdict.ts
+++ b/src/layer1_wasm/_shared/verdict.ts
@@ -5,7 +5,7 @@
 // look without each loader having to opt in. The asset lives in `_assets/`
 // (hand-written, no tsc step) — kept apart from `_shared/` (TS sources +
 // their compiled `.js` siblings, which `.gitignore` blanket-excludes).
-import "../_assets/chrome.js";
+import '../_assets/chrome.js';
 
 // Vivarium contract v1 — verdict and result envelope helpers.
 //
@@ -24,7 +24,7 @@ import "../_assets/chrome.js";
 // errored before producing a result. `pending` means the run has not yet
 // produced a verdict.
 
-export type VerdictState = "pending" | "reproduced" | "unreproduced";
+export type VerdictState = 'pending' | 'reproduced' | 'unreproduced';
 
 export interface VivariumResultV1Bug {
   /** Upstream project short name (e.g. "pandas"). */
@@ -54,7 +54,7 @@ export interface VivariumResultV1Timing {
 }
 
 export interface VivariumResultV1 {
-  contract: "v1";
+  contract: 'v1';
   bug: VivariumResultV1Bug;
   runtime: VivariumResultV1Runtime;
   /** Page-specific structured output. */
@@ -66,6 +66,8 @@ declare global {
   // eslint-disable-next-line no-var
   var __VIVARIUM_VERDICT__: VerdictState | undefined;
   // eslint-disable-next-line no-var
+  var __VIVARIUM_VERDICT_MESSAGE__: string | undefined;
+  // eslint-disable-next-line no-var
   var __VIVARIUM_RESULT__: VivariumResultV1 | undefined;
 }
 
@@ -73,30 +75,47 @@ declare global {
  * Update the verdict element + the `__VIVARIUM_VERDICT__` global atomically.
  *
  * @param state Verdict state.
- * @param text  Human-readable verdict. Should start with
- *   "bug reproduced", "bug not reproduced", or a page-specific
- *   pending message — see ADR-0008 / ADR-0029.
+ * @param text  Human-readable verdict. For `pending` it is shown verbatim
+ *   on the pill (loading / running messages). For `reproduced` /
+ *   `unreproduced` only the state literal renders on the pill; the full
+ *   message is stashed on `__VIVARIUM_VERDICT_MESSAGE__` for tooling
+ *   (Path A, runner status line, etc.). Phase 8 V″ reduces the verdict
+ *   pill to its minimum on-screen footprint — the output panel speaks
+ *   for itself.
  */
 export function setVerdict(state: VerdictState, text: string): void {
-  const el = document.getElementById("verdict");
+  const el = document.getElementById('verdict');
   if (!el) {
-    throw new Error(
-      'vivarium contract v1: missing element with id="verdict".',
-    );
+    throw new Error('vivarium contract v1: missing element with id="verdict".');
   }
-  el.classList.remove("reproduced", "unreproduced", "pending");
+  el.classList.remove('reproduced', 'unreproduced', 'pending');
   el.classList.add(state);
-  el.dataset["verdict"] = state;
-  el.textContent = text;
+  el.dataset['verdict'] = state;
+  // Phase 8 V″ — render short uppercase literals on the pill so the
+  // header row never wraps to two lines. Long pending messages
+  // ("Loading Pyodide runtime and sqlite3…") still go to
+  // `__VIVARIUM_VERDICT_MESSAGE__` for tooling that wants the full
+  // string. We disambiguate "loading" vs "running" by inspecting the
+  // caller-supplied text.
+  let label: string;
+  if (state === 'pending') {
+    label = /running/i.test(text) ? 'RUNNING…' : 'LOADING…';
+  } else if (state === 'reproduced') {
+    label = 'REPRODUCED';
+  } else {
+    label = 'UNREPRODUCED';
+  }
+  el.textContent = label;
   globalThis.__VIVARIUM_VERDICT__ = state;
+  globalThis.__VIVARIUM_VERDICT_MESSAGE__ = text;
 
   // Tell the chrome.js progress bar the run is finished. Pending updates
   // (which arrive multiple times during loading) are ignored by chrome.js
   // because it only cares about pct + label fields.
-  if (state !== "pending") {
+  if (state !== 'pending') {
     document.dispatchEvent(
-      new CustomEvent("vh-progress", {
-        detail: { stage: "done", pct: 100, label: "Reproduction complete." },
+      new CustomEvent('vh-progress', {
+        detail: { stage: 'done', pct: 100, label: 'Reproduction complete.' },
       }),
     );
   }
@@ -106,10 +125,10 @@ export function setVerdict(state: VerdictState, text: string): void {
  * Publish the structured result envelope on `__VIVARIUM_RESULT__`.
  */
 export function setResult(envelope: VivariumResultV1): void {
-  if (!envelope || envelope.contract !== "v1") {
+  if (!envelope || envelope.contract !== 'v1') {
     throw new Error(
       `vivarium contract v1: setResult expected contract="v1", got ${
-        envelope ? JSON.stringify(envelope.contract) : "null"
+        envelope ? JSON.stringify(envelope.contract) : 'null'
       }.`,
     );
   }

--- a/src/layer1_wasm/cpython-137205/index.html
+++ b/src/layer1_wasm/cpython-137205/index.html
@@ -19,34 +19,74 @@
       crossorigin
     />
     <link rel="stylesheet" href="../_shared/style.css" />
-  </head>
-  <body>
-    <main>
-      <header>
-        <p class="kicker">Vivarium · Layer 1 · Pyodide · sqlite3</p>
-        <h1>Reproducing <a href="https://github.com/python/cpython/issues/137205">python/cpython#137205</a></h1>
-        <p class="lede">
+    <template id="bug-context">
+      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <div class="vh-drawer__body" id="vh-drawer-body">
+        <p>
           Python's <code>sqlite3</code> stdlib silently drops
           <code>PRAGMA foreign_keys = ON</code> when the connection
           was opened with <code>autocommit=False</code>. The same
           PRAGMA on a second connection opened with
-          <code>autocommit=True</code> takes effect — so two
+          <code>autocommit=True</code> takes effect, so two
           connections that should have identical FK enforcement
-          disagree. The disagreement is the bug surface.
+          disagree.
         </p>
+        <p>
+          The script on this page opens both kinds of connection,
+          issues the same PRAGMA on each, and reads the resulting
+          <code>foreign_keys</code> value back. If the two values
+          disagree, the bug reproduces in the runtime currently
+          loaded in your browser tab.
+        </p>
+        <p>
+          For the full discussion (motivation, repro variations,
+          patch progress, etc.), follow the GitHub issue link
+          below — that thread is the canonical home for this bug.
+        </p>
+      </div>
+      <hr class="vh-drawer__divider" />
+      <div class="vh-drawer__meta-grid">
+        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-val">python/cpython</span>
+        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-val">#137205</span>
+        <span class="vh-drawer__meta-key">Layer</span>
+        <span class="vh-drawer__meta-val">L1 · WASM</span>
+        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-val">Pyodide v0.29.3</span>
+      </div>
+    </template>
+  </head>
+  <body>
+    <main class="vh-main">
+      <header class="vh-main__header">
+        <div class="vh-main__header-text">
+          <p class="kicker">L1 · Pyodide · sqlite3</p>
+          <h1>Reproducing <a href="https://github.com/python/cpython/issues/137205">python/cpython#137205</a></h1>
+          <div class="vh-main__header-actions">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+              Bug context
+            </button>
+            <a class="vh-chip" href="https://github.com/python/cpython/issues/137205" target="_blank" rel="noreferrer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              Upstream issue
+            </a>
+          </div>
+        </div>
+        <div class="vh-main__header-aside">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+            Loading Pyodide runtime…
+          </div>
+          <p class="meta" id="meta"></p>
+        </div>
       </header>
 
-      <section>
-        <h2>Verdict</h2>
-        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
-          Loading Pyodide runtime…
-        </div>
-        <p class="meta" id="meta"></p>
-      </section>
-
-      <section>
-        <h2>Reproduction script</h2>
-        <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
+      <div class="vh-main__cols">
+        <section class="vh-main__col vh-main__col--script">
+          <h2>Reproduction script</h2>
+          <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
 <span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sqlite3</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#E1E4E8">off </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> sqlite3.connect(</span><span style="color:#9ECBFF">":memory:"</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">autocommit</span><span style="color:#F97583">=</span><span style="color:#79B8FF">False</span><span style="color:#E1E4E8">)</span></span>
@@ -66,26 +106,14 @@
 <span class="line"><span style="color:#9ECBFF">    "on_autocommit_fk"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">int</span><span style="color:#E1E4E8">(on_value),</span></span>
 <span class="line"><span style="color:#9ECBFF">    "fk_disagreement"</span><span style="color:#E1E4E8">: off_value </span><span style="color:#F97583">!=</span><span style="color:#E1E4E8"> on_value,</span></span>
 <span class="line"><span style="color:#E1E4E8">}</span></span></code></pre>
-      </section>
+        </section>
 
-      <section>
-        <h2>Output</h2>
-        <pre id="output">(running)</pre>
-      </section>
+        <section class="vh-main__col vh-main__col--output">
+          <h2>Output</h2>
+          <pre id="output">(running)</pre>
+        </section>
+      </div>
 
-      <footer>
-        <p class="meta">
-          Runtime:
-          <a href="https://pyodide.org/">Pyodide</a>
-          loaded from
-          <a href="https://www.jsdelivr.com/package/npm/pyodide">cdn.jsdelivr.net</a>.
-          SQLite is the version bundled into the Pyodide
-          <code>sqlite3</code> package — no separate
-          <code>sqlite-wasm</code> build is loaded for this page.
-          Source:
-          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/cpython-137205">vivarium/src/layer1_wasm/cpython-137205</a>.
-        </p>
-      </footer>
     </main>
 
     <script type="module" src="./repro.js"></script>

--- a/src/layer1_wasm/cpython-137205/repro.ts
+++ b/src/layer1_wasm/cpython-137205/repro.ts
@@ -14,13 +14,21 @@
 //   - "reproduced" — the bug REPRODUCES (the two connections disagree).
 //   - "unreproduced" — the bug does NOT reproduce (the runtime ships a fix,
 //     or the runtime errored before producing a result).
+//
+// Phase 8 V″ (ADR-0035) — after the baseline run, the recipe enables
+// `enableRunner({...})` so visitors can edit the script and re-run via
+// the Run button. The captured-run shape uses the same
+// `PathACapturedRun` interface Path A uses, so a single `captureRun`
+// adapter feeds both the runner and (when applicable) the Path A panel.
 
-import { loadVivariumPyodide } from "../_shared/loader.js";
+import { loadVivariumPyodide } from '../_shared/loader.js';
+import type { PathACapturedRun } from '../_shared/path_a.js';
+import { enableRunner } from '../_shared/runner.js';
 import {
   setResult,
   setVerdict,
   type VivariumResultV1,
-} from "../_shared/verdict.js";
+} from '../_shared/verdict.js';
 
 const REPRO_CODE = `
 import sys
@@ -60,13 +68,13 @@ interface PyodideRuntime {
   }>;
 }
 
-const outputEl = document.getElementById("output");
-const metaEl = document.getElementById("meta");
-const reproCodeEl = document.getElementById("repro-code");
+const outputEl = document.getElementById('output');
+const metaEl = document.getElementById('meta');
+const reproCodeEl = document.getElementById('repro-code');
 
 if (!outputEl || !metaEl || !reproCodeEl) {
   throw new Error(
-    "cpython-137205: missing required DOM elements (#output, #meta, #repro-code).",
+    'cpython-137205: missing required DOM elements (#output, #meta, #repro-code).',
   );
 }
 
@@ -76,12 +84,56 @@ if (!outputEl || !metaEl || !reproCodeEl) {
 // fallback below kicks in only when the placeholder is still empty.
 if (!reproCodeEl.firstChild) {
   reproCodeEl.textContent = REPRO_CODE;
-  fetch("./repro.highlighted.html")
+  fetch('./repro.highlighted.html')
     .then((r) => (r.ok ? r.text() : null))
     .then((html) => {
       if (html) reproCodeEl.innerHTML = html;
     })
     .catch(() => {});
+}
+
+function evaluate(result: ReproOutput): {
+  verdict: 'reproduced' | 'unreproduced';
+  message: string;
+} {
+  if (result.fk_disagreement) {
+    return {
+      verdict: 'reproduced',
+      message:
+        'bug reproduced — autocommit=False silently drops PRAGMA foreign_keys; the two connections disagree.',
+    };
+  }
+  return {
+    verdict: 'unreproduced',
+    message:
+      'bug not reproduced — both connections agree on PRAGMA foreign_keys (likely fixed upstream).',
+  };
+}
+
+async function captureRun(
+  runtime: PyodideRuntime,
+  source: string,
+): Promise<PathACapturedRun> {
+  try {
+    const proxy = await runtime.runPythonAsync(source);
+    const result = proxy.toJs({ dict_converter: Object.fromEntries });
+    proxy.destroy?.();
+    const ev = evaluate(result);
+    return {
+      exitCode: 0,
+      verdict: ev.verdict,
+      message: ev.message,
+      stdout: JSON.stringify(result, null, 2),
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      exitCode: 1,
+      verdict: 'unreproduced',
+      message: `runtime error: ${message}`,
+      stdout: message,
+    };
+  }
 }
 
 const startedAt = new Date();
@@ -91,53 +143,52 @@ try {
   // distribution and ships as a separately-loadable package; preload
   // it alongside the runtime bootstrap.
   const { pyodide, version } = await loadVivariumPyodide({
-    packages: ["sqlite3"],
-    pendingText: "Loading Pyodide runtime and sqlite3…",
+    packages: ['sqlite3'],
+    pendingText: 'Loading Pyodide runtime and sqlite3…',
   });
 
-  setVerdict("pending", "Running reproduction script…");
+  setVerdict('pending', 'Running reproduction script…');
   const runtime = pyodide as PyodideRuntime;
-  const proxy = await runtime.runPythonAsync(REPRO_CODE);
-  const result = proxy.toJs({ dict_converter: Object.fromEntries });
-  proxy.destroy?.();
+  const baseline = await captureRun(runtime, REPRO_CODE);
+
+  let baselineResult: ReproOutput | null = null;
+  try {
+    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
+  } catch {
+    // baseline failed before producing parseable JSON — surface the raw
+    // message in the output panel and stop short of trying to populate
+    // the meta line / verdict envelope.
+    outputEl.textContent = baseline.stdout;
+    setVerdict(baseline.verdict, baseline.message);
+    throw new Error(baseline.message);
+  }
 
   metaEl.textContent =
-    `Python ${result.python_version} with stdlib sqlite3 ` +
-    `(SQLite ${result.sqlite_version}) via Pyodide v${version}.`;
-  outputEl.textContent = JSON.stringify(result, null, 2);
-
-  if (result.fk_disagreement) {
-    setVerdict(
-      "reproduced",
-      "bug reproduced — autocommit=False silently drops PRAGMA foreign_keys; the two connections disagree.",
-    );
-  } else {
-    setVerdict(
-      "unreproduced",
-      "bug not reproduced — both connections agree on PRAGMA foreign_keys (likely fixed upstream).",
-    );
-  }
+    `Python ${baselineResult.python_version} with stdlib sqlite3 ` +
+    `(SQLite ${baselineResult.sqlite_version}) via Pyodide v${version}.`;
+  outputEl.textContent = baseline.stdout;
+  setVerdict(baseline.verdict, baseline.message);
 
   const finishedAt = new Date();
   const envelope: VivariumResultV1 = {
-    contract: "v1",
+    contract: 'v1',
     bug: {
-      project: "cpython",
+      project: 'cpython',
       issue: 137205,
-      upstream_url: "https://github.com/python/cpython/issues/137205",
+      upstream_url: 'https://github.com/python/cpython/issues/137205',
     },
     runtime: {
-      name: "pyodide",
+      name: 'pyodide',
       version,
       extras: {
-        python: result.python_version,
-        sqlite: result.sqlite_version,
+        python: baselineResult.python_version,
+        sqlite: baselineResult.sqlite_version,
       },
     },
     result: {
-      off_autocommit_fk: result.off_autocommit_fk,
-      on_autocommit_fk: result.on_autocommit_fk,
-      fk_disagreement: result.fk_disagreement,
+      off_autocommit_fk: baselineResult.off_autocommit_fk,
+      on_autocommit_fk: baselineResult.on_autocommit_fk,
+      fk_disagreement: baselineResult.fk_disagreement,
     },
     timing: {
       started_at: startedAt.toISOString(),
@@ -146,14 +197,23 @@ try {
     },
   };
   setResult(envelope);
+
+  // Phase 8 V″ — wire the editable script + Run button. The runner
+  // mounts itself around the existing #repro-code <pre>, so no
+  // additional mount-point is required in the recipe HTML.
+  enableRunner({
+    slug: 'cpython-137205',
+    baselineSource: REPRO_CODE,
+    runFix: (source) => captureRun(runtime, source),
+  });
 } catch (err: unknown) {
   console.error(err);
   const errAny = err as { stack?: string; message?: string } | null;
   outputEl.textContent =
     (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
-  if (globalThis.__VIVARIUM_VERDICT__ !== "unreproduced") {
+  if (globalThis.__VIVARIUM_VERDICT__ !== 'unreproduced') {
     setVerdict(
-      "unreproduced",
+      'unreproduced',
       `bug not reproduced — runtime error: ${errAny?.message ?? String(err)}`,
     );
   }

--- a/src/layer1_wasm/numpy-28287/index.html
+++ b/src/layer1_wasm/numpy-28287/index.html
@@ -20,34 +20,73 @@
       crossorigin
     />
     <link rel="stylesheet" href="../_shared/style.css" />
-  </head>
-  <body>
-    <main>
-      <header>
-        <p class="kicker">Vivarium · Layer 1 · Pyodide</p>
-        <h1>Reproducing <a href="https://github.com/numpy/numpy/issues/28287">numpy/numpy#28287</a></h1>
-        <p class="lede">
-          NumPy's <code>timedelta64</code> ordering is non-transitive when
-          one of the values uses the <em>generic</em> unit. With
+    <template id="bug-context">
+      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <div class="vh-drawer__body" id="vh-drawer-body">
+        <p>
+          NumPy's <code>timedelta64</code> ordering is non-transitive
+          when one of the values uses the <em>generic</em> unit. With
           <code>x = 1&nbsp;ms</code>, <code>y = 2 (generic)</code>, and
           <code>z = 5&nbsp;ns</code>, NumPy reports
           <code>x &lt; y</code> and <code>y &lt; z</code> but
-          <code>x &gt; z</code> — a transitivity violation in a built-in
-          comparison operator.
+          <code>x &gt; z</code> — a transitivity violation in a
+          built-in comparison operator.
         </p>
+        <p>
+          The script on this page constructs those three values, runs
+          all three pairwise comparisons, and reports whether the
+          composite (<code>x &lt; y</code> AND <code>y &lt; z</code>
+          AND <code>x &gt; z</code>) holds. If it does, the bug
+          reproduces in the NumPy build Pyodide currently ships.
+        </p>
+        <p>
+          The full discussion (motivation, repro variations, fix
+          progress) lives in the GitHub issue thread linked below.
+        </p>
+      </div>
+      <hr class="vh-drawer__divider" />
+      <div class="vh-drawer__meta-grid">
+        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-val">numpy/numpy</span>
+        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-val">#28287</span>
+        <span class="vh-drawer__meta-key">Layer</span>
+        <span class="vh-drawer__meta-val">L1 · WASM</span>
+        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-val">Pyodide v0.29.3</span>
+      </div>
+    </template>
+  </head>
+  <body>
+    <main class="vh-main">
+      <header class="vh-main__header">
+        <div class="vh-main__header-text">
+          <p class="kicker">L1 · Pyodide</p>
+          <h1>Reproducing <a href="https://github.com/numpy/numpy/issues/28287">numpy/numpy#28287</a></h1>
+          <div class="vh-main__header-actions">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+              Bug context
+            </button>
+            <a class="vh-chip" href="https://github.com/numpy/numpy/issues/28287" target="_blank" rel="noreferrer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              Upstream issue
+            </a>
+          </div>
+        </div>
+        <div class="vh-main__header-aside">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+            Loading Pyodide runtime…
+          </div>
+          <p class="meta" id="meta"></p>
+        </div>
       </header>
 
-      <section>
-        <h2>Verdict</h2>
-        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
-          Loading Pyodide runtime…
-        </div>
-        <p class="meta" id="meta"></p>
-      </section>
-
-      <section>
-        <h2>Reproduction script</h2>
-        <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
+      <div class="vh-main__cols">
+        <section class="vh-main__col vh-main__col--script">
+          <h2>Reproduction script</h2>
+          <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
 <span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> numpy </span><span style="color:#F97583">as</span><span style="color:#E1E4E8"> np</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#E1E4E8">x </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> np.timedelta64(</span><span style="color:#79B8FF">1</span><span style="color:#E1E4E8">, </span><span style="color:#9ECBFF">"ms"</span><span style="color:#E1E4E8">)</span></span>
@@ -66,23 +105,14 @@
 <span class="line"><span style="color:#9ECBFF">    "x_lt_z"</span><span style="color:#E1E4E8">: x_lt_z,</span></span>
 <span class="line"><span style="color:#9ECBFF">    "transitivity_violated"</span><span style="color:#E1E4E8">: x_lt_y </span><span style="color:#F97583">and</span><span style="color:#E1E4E8"> y_lt_z </span><span style="color:#F97583">and</span><span style="color:#F97583"> not</span><span style="color:#E1E4E8"> x_lt_z,</span></span>
 <span class="line"><span style="color:#E1E4E8">}</span></span></code></pre>
-      </section>
+        </section>
 
-      <section>
-        <h2>Output</h2>
-        <pre id="output">(running)</pre>
-      </section>
+        <section class="vh-main__col vh-main__col--output">
+          <h2>Output</h2>
+          <pre id="output">(running)</pre>
+        </section>
+      </div>
 
-      <footer>
-        <p class="meta">
-          Runtime:
-          <a href="https://pyodide.org/">Pyodide</a>
-          loaded from
-          <a href="https://www.jsdelivr.com/package/npm/pyodide">cdn.jsdelivr.net</a>.
-          Source:
-          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/numpy-28287">vivarium/src/layer1_wasm/numpy-28287</a>.
-        </p>
-      </footer>
     </main>
 
     <script type="module" src="./repro.js"></script>

--- a/src/layer1_wasm/numpy-28287/repro.ts
+++ b/src/layer1_wasm/numpy-28287/repro.ts
@@ -12,12 +12,14 @@
 //     ordering on the build Pyodide ships).
 //   - "unreproduced" — the bug does NOT reproduce (or the runtime errored).
 
-import { loadVivariumPyodide } from "../_shared/loader.js";
+import { loadVivariumPyodide } from '../_shared/loader.js';
+import type { PathACapturedRun } from '../_shared/path_a.js';
+import { enableRunner } from '../_shared/runner.js';
 import {
   setResult,
   setVerdict,
   type VivariumResultV1,
-} from "../_shared/verdict.js";
+} from '../_shared/verdict.js';
 
 const REPRO_CODE = `
 import sys
@@ -57,13 +59,13 @@ interface PyodideRuntime {
   }>;
 }
 
-const outputEl = document.getElementById("output");
-const metaEl = document.getElementById("meta");
-const reproCodeEl = document.getElementById("repro-code");
+const outputEl = document.getElementById('output');
+const metaEl = document.getElementById('meta');
+const reproCodeEl = document.getElementById('repro-code');
 
 if (!outputEl || !metaEl || !reproCodeEl) {
   throw new Error(
-    "numpy-28287: missing required DOM elements (#output, #meta, #repro-code).",
+    'numpy-28287: missing required DOM elements (#output, #meta, #repro-code).',
   );
 }
 
@@ -73,12 +75,56 @@ if (!outputEl || !metaEl || !reproCodeEl) {
 // fallback below kicks in only when the placeholder is still empty.
 if (!reproCodeEl.firstChild) {
   reproCodeEl.textContent = REPRO_CODE;
-  fetch("./repro.highlighted.html")
+  fetch('./repro.highlighted.html')
     .then((r) => (r.ok ? r.text() : null))
     .then((html) => {
       if (html) reproCodeEl.innerHTML = html;
     })
     .catch(() => {});
+}
+
+function evaluate(result: ReproOutput): {
+  verdict: 'reproduced' | 'unreproduced';
+  message: string;
+} {
+  if (result.transitivity_violated) {
+    return {
+      verdict: 'reproduced',
+      message:
+        'bug reproduced — timedelta64 ordering is non-transitive (x < y < z but x ≥ z).',
+    };
+  }
+  return {
+    verdict: 'unreproduced',
+    message:
+      'bug not reproduced — timedelta64 ordering is transitive in this numpy build.',
+  };
+}
+
+async function captureRun(
+  runtime: PyodideRuntime,
+  source: string,
+): Promise<PathACapturedRun> {
+  try {
+    const proxy = await runtime.runPythonAsync(source);
+    const result = proxy.toJs({ dict_converter: Object.fromEntries });
+    proxy.destroy?.();
+    const ev = evaluate(result);
+    return {
+      exitCode: 0,
+      verdict: ev.verdict,
+      message: ev.message,
+      stdout: JSON.stringify(result, null, 2),
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      exitCode: 1,
+      verdict: 'unreproduced',
+      message: `runtime error: ${message}`,
+      stdout: message,
+    };
+  }
 }
 
 const startedAt = new Date();
@@ -88,54 +134,50 @@ try {
   // explicitly via `loadPackage` / the `packages` option — it is not
   // imported at runtime startup.
   const { pyodide, version } = await loadVivariumPyodide({
-    packages: ["numpy"],
-    pendingText: "Loading Pyodide runtime and numpy…",
+    packages: ['numpy'],
+    pendingText: 'Loading Pyodide runtime and numpy…',
   });
 
-  setVerdict("pending", "Running reproduction script…");
+  setVerdict('pending', 'Running reproduction script…');
   const runtime = pyodide as PyodideRuntime;
-  const proxy = await runtime.runPythonAsync(REPRO_CODE);
-  const result = proxy.toJs({ dict_converter: Object.fromEntries });
-  proxy.destroy?.();
+  const baseline = await captureRun(runtime, REPRO_CODE);
+
+  let baselineResult: ReproOutput | null = null;
+  try {
+    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
+  } catch {
+    outputEl.textContent = baseline.stdout;
+    setVerdict(baseline.verdict, baseline.message);
+    throw new Error(baseline.message);
+  }
 
   metaEl.textContent =
-    `numpy ${result.numpy_version} on Python ${result.python_version} ` +
+    `numpy ${baselineResult.numpy_version} on Python ${baselineResult.python_version} ` +
     `via Pyodide v${version}.`;
-  outputEl.textContent = JSON.stringify(result, null, 2);
-
-  if (result.transitivity_violated) {
-    setVerdict(
-      "reproduced",
-      "bug reproduced — timedelta64 ordering is non-transitive (x < y < z but x ≥ z).",
-    );
-  } else {
-    setVerdict(
-      "unreproduced",
-      "bug not reproduced — timedelta64 ordering is transitive in this numpy build.",
-    );
-  }
+  outputEl.textContent = baseline.stdout;
+  setVerdict(baseline.verdict, baseline.message);
 
   const finishedAt = new Date();
   const envelope: VivariumResultV1 = {
-    contract: "v1",
+    contract: 'v1',
     bug: {
-      project: "numpy",
+      project: 'numpy',
       issue: 28287,
-      upstream_url: "https://github.com/numpy/numpy/issues/28287",
+      upstream_url: 'https://github.com/numpy/numpy/issues/28287',
     },
     runtime: {
-      name: "pyodide",
+      name: 'pyodide',
       version,
       extras: {
-        python: result.python_version,
-        numpy: result.numpy_version,
+        python: baselineResult.python_version,
+        numpy: baselineResult.numpy_version,
       },
     },
     result: {
-      x_lt_y: result.x_lt_y,
-      y_lt_z: result.y_lt_z,
-      x_lt_z: result.x_lt_z,
-      transitivity_violated: result.transitivity_violated,
+      x_lt_y: baselineResult.x_lt_y,
+      y_lt_z: baselineResult.y_lt_z,
+      x_lt_z: baselineResult.x_lt_z,
+      transitivity_violated: baselineResult.transitivity_violated,
     },
     timing: {
       started_at: startedAt.toISOString(),
@@ -144,6 +186,13 @@ try {
     },
   };
   setResult(envelope);
+
+  // Phase 8 V″ — wire the editable script + Run button.
+  enableRunner({
+    slug: 'numpy-28287',
+    baselineSource: REPRO_CODE,
+    runFix: (source) => captureRun(runtime, source),
+  });
 } catch (err: unknown) {
   console.error(err);
   const errAny = err as { stack?: string; message?: string } | null;
@@ -151,9 +200,9 @@ try {
     (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
   // `loadVivariumPyodide` already sets "unreproduced" on load-time errors. Cover
   // the case where the runtime loaded but the reproduction itself errored.
-  if (globalThis.__VIVARIUM_VERDICT__ !== "unreproduced") {
+  if (globalThis.__VIVARIUM_VERDICT__ !== 'unreproduced') {
     setVerdict(
-      "unreproduced",
+      'unreproduced',
       `bug not reproduced — runtime error: ${errAny?.message ?? String(err)}`,
     );
   }

--- a/src/layer1_wasm/pandas-56679/index.html
+++ b/src/layer1_wasm/pandas-56679/index.html
@@ -20,31 +20,68 @@
       crossorigin
     />
     <link rel="stylesheet" href="../_shared/style.css" />
-  </head>
-  <body>
-    <main>
-      <header>
-        <p class="kicker">Vivarium · Layer 1 · Pyodide</p>
-        <h1>Reproducing <a href="https://github.com/pandas-dev/pandas/issues/56679">pandas-dev/pandas#56679</a></h1>
-        <p class="lede">
+    <template id="bug-context">
+      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <div class="vh-drawer__body" id="vh-drawer-body">
+        <p>
           <code>pd.Series([])</code> returns dtype <code>object</code>,
           but <code>pd.DataFrame({'a': []})['a']</code> returns dtype
           <code>float64</code>. The two constructors should produce a
           consistent dtype for an empty input.
         </p>
+        <p>
+          The script on this page constructs both shapes and compares
+          their dtypes. If the dtypes differ, the bug reproduces in
+          the pandas build Pyodide currently ships.
+        </p>
+        <p>
+          The full discussion (motivation, history, fix progress)
+          lives in the GitHub issue thread linked below.
+        </p>
+      </div>
+      <hr class="vh-drawer__divider" />
+      <div class="vh-drawer__meta-grid">
+        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-val">pandas-dev/pandas</span>
+        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-val">#56679</span>
+        <span class="vh-drawer__meta-key">Layer</span>
+        <span class="vh-drawer__meta-val">L1 · WASM</span>
+        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-val">Pyodide v0.29.3</span>
+      </div>
+    </template>
+  </head>
+  <body>
+    <main class="vh-main">
+      <header class="vh-main__header">
+        <div class="vh-main__header-text">
+          <p class="kicker">L1 · Pyodide</p>
+          <h1>Reproducing <a href="https://github.com/pandas-dev/pandas/issues/56679">pandas-dev/pandas#56679</a></h1>
+          <div class="vh-main__header-actions">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+              Bug context
+            </button>
+            <a class="vh-chip" href="https://github.com/pandas-dev/pandas/issues/56679" target="_blank" rel="noreferrer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              Upstream issue
+            </a>
+          </div>
+        </div>
+        <div class="vh-main__header-aside">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+            Loading Pyodide runtime…
+          </div>
+          <p class="meta" id="meta"></p>
+        </div>
       </header>
 
-      <section>
-        <h2>Verdict</h2>
-        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
-          Loading Pyodide runtime…
-        </div>
-        <p class="meta" id="meta"></p>
-      </section>
-
-      <section>
-        <h2>Reproduction script</h2>
-        <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
+      <div class="vh-main__cols">
+        <section class="vh-main__col vh-main__col--script">
+          <h2>Reproduction script</h2>
+          <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
 <span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> pandas </span><span style="color:#F97583">as</span><span style="color:#E1E4E8"> pd</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#E1E4E8">series_dtype </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> str</span><span style="color:#E1E4E8">(pd.Series([]).dtype)</span></span>
@@ -57,23 +94,14 @@
 <span class="line"><span style="color:#9ECBFF">    "df_dtype"</span><span style="color:#E1E4E8">: df_dtype,</span></span>
 <span class="line"><span style="color:#9ECBFF">    "mismatch"</span><span style="color:#E1E4E8">: series_dtype </span><span style="color:#F97583">!=</span><span style="color:#E1E4E8"> df_dtype,</span></span>
 <span class="line"><span style="color:#E1E4E8">}</span></span></code></pre>
-      </section>
+        </section>
 
-      <section>
-        <h2>Output</h2>
-        <pre id="output">(running)</pre>
-      </section>
+        <section class="vh-main__col vh-main__col--output">
+          <h2>Output</h2>
+          <pre id="output">(running)</pre>
+        </section>
+      </div>
 
-      <footer>
-        <p class="meta">
-          Runtime:
-          <a href="https://pyodide.org/">Pyodide</a>
-          loaded from
-          <a href="https://www.jsdelivr.com/package/npm/pyodide">cdn.jsdelivr.net</a>.
-          Source:
-          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/pandas-56679">vivarium/src/layer1_wasm/pandas-56679</a>.
-        </p>
-      </footer>
     </main>
 
     <script type="module" src="./repro.js"></script>

--- a/src/layer1_wasm/pandas-56679/repro.ts
+++ b/src/layer1_wasm/pandas-56679/repro.ts
@@ -10,14 +10,16 @@
 //   - "unreproduced" — the bug does NOT reproduce (or the runtime errored).
 
 import {
-  loadVivariumPyodide,
   DEFAULT_PYODIDE_VERSION,
-} from "../_shared/loader.js";
+  loadVivariumPyodide,
+} from '../_shared/loader.js';
+import type { PathACapturedRun } from '../_shared/path_a.js';
+import { enableRunner } from '../_shared/runner.js';
 import {
   setResult,
   setVerdict,
   type VivariumResultV1,
-} from "../_shared/verdict.js";
+} from '../_shared/verdict.js';
 
 const REPRO_CODE = `
 import sys
@@ -50,13 +52,13 @@ interface PyodideRuntime {
   }>;
 }
 
-const outputEl = document.getElementById("output");
-const metaEl = document.getElementById("meta");
-const reproCodeEl = document.getElementById("repro-code");
+const outputEl = document.getElementById('output');
+const metaEl = document.getElementById('meta');
+const reproCodeEl = document.getElementById('repro-code');
 
 if (!outputEl || !metaEl || !reproCodeEl) {
   throw new Error(
-    "pandas-56679: missing required DOM elements (#output, #meta, #repro-code).",
+    'pandas-56679: missing required DOM elements (#output, #meta, #repro-code).',
   );
 }
 
@@ -66,7 +68,7 @@ if (!outputEl || !metaEl || !reproCodeEl) {
 // fallback below kicks in only when the placeholder is still empty.
 if (!reproCodeEl.firstChild) {
   reproCodeEl.textContent = REPRO_CODE;
-  fetch("./repro.highlighted.html")
+  fetch('./repro.highlighted.html')
     .then((r) => (r.ok ? r.text() : null))
     .then((html) => {
       if (html) reproCodeEl.innerHTML = html;
@@ -74,57 +76,95 @@ if (!reproCodeEl.firstChild) {
     .catch(() => {});
 }
 
+function evaluate(result: ReproOutput): {
+  verdict: 'reproduced' | 'unreproduced';
+  message: string;
+} {
+  if (result.mismatch) {
+    return {
+      verdict: 'reproduced',
+      message: 'bug reproduced — Series dtype ≠ DataFrame dtype.',
+    };
+  }
+  return {
+    verdict: 'unreproduced',
+    message: 'bug not reproduced — dtypes are consistent in this pandas build.',
+  };
+}
+
+async function captureRun(
+  runtime: PyodideRuntime,
+  source: string,
+): Promise<PathACapturedRun> {
+  try {
+    const proxy = await runtime.runPythonAsync(source);
+    const result = proxy.toJs({ dict_converter: Object.fromEntries });
+    proxy.destroy?.();
+    const ev = evaluate(result);
+    return {
+      exitCode: 0,
+      verdict: ev.verdict,
+      message: ev.message,
+      stdout: JSON.stringify(result, null, 2),
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      exitCode: 1,
+      verdict: 'unreproduced',
+      message: `runtime error: ${message}`,
+      stdout: message,
+    };
+  }
+}
+
 const startedAt = new Date();
 
 try {
   const { pyodide, version } = await loadVivariumPyodide({
-    packages: ["pandas"],
-    pendingText: "Loading Pyodide runtime and pandas…",
+    packages: ['pandas'],
+    pendingText: 'Loading Pyodide runtime and pandas…',
   });
 
-  setVerdict("pending", "Running reproduction script…");
+  setVerdict('pending', 'Running reproduction script…');
   const runtime = pyodide as PyodideRuntime;
-  const proxy = await runtime.runPythonAsync(REPRO_CODE);
-  const result = proxy.toJs({ dict_converter: Object.fromEntries });
-  proxy.destroy?.();
+  const baseline = await captureRun(runtime, REPRO_CODE);
+
+  let baselineResult: ReproOutput | null = null;
+  try {
+    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
+  } catch {
+    outputEl.textContent = baseline.stdout;
+    setVerdict(baseline.verdict, baseline.message);
+    throw new Error(baseline.message);
+  }
 
   metaEl.textContent =
-    `pandas ${result.pandas_version} on Python ${result.python_version} ` +
+    `pandas ${baselineResult.pandas_version} on Python ${baselineResult.python_version} ` +
     `via Pyodide v${version}.`;
-  outputEl.textContent = JSON.stringify(result, null, 2);
-
-  if (result.mismatch) {
-    setVerdict(
-      "reproduced",
-      "bug reproduced — Series dtype ≠ DataFrame dtype.",
-    );
-  } else {
-    setVerdict(
-      "unreproduced",
-      "bug not reproduced — dtypes are consistent in this pandas build.",
-    );
-  }
+  outputEl.textContent = baseline.stdout;
+  setVerdict(baseline.verdict, baseline.message);
 
   const finishedAt = new Date();
   const envelope: VivariumResultV1 = {
-    contract: "v1",
+    contract: 'v1',
     bug: {
-      project: "pandas",
+      project: 'pandas',
       issue: 56679,
-      upstream_url: "https://github.com/pandas-dev/pandas/issues/56679",
+      upstream_url: 'https://github.com/pandas-dev/pandas/issues/56679',
     },
     runtime: {
-      name: "pyodide",
+      name: 'pyodide',
       version,
       extras: {
-        python: result.python_version,
-        pandas: result.pandas_version,
+        python: baselineResult.python_version,
+        pandas: baselineResult.pandas_version,
       },
     },
     result: {
-      series_dtype: result.series_dtype,
-      df_dtype: result.df_dtype,
-      mismatch: result.mismatch,
+      series_dtype: baselineResult.series_dtype,
+      df_dtype: baselineResult.df_dtype,
+      mismatch: baselineResult.mismatch,
     },
     timing: {
       started_at: startedAt.toISOString(),
@@ -133,6 +173,13 @@ try {
     },
   };
   setResult(envelope);
+
+  // Phase 8 V″ — wire the editable script + Run button.
+  enableRunner({
+    slug: 'pandas-56679',
+    baselineSource: REPRO_CODE,
+    runFix: (source) => captureRun(runtime, source),
+  });
 } catch (err: unknown) {
   console.error(err);
   const errAny = err as { stack?: string; message?: string } | null;
@@ -141,9 +188,9 @@ try {
   // `loadVivariumPyodide` already sets the verdict to "unreproduced" on load-time
   // errors. Cover the case where the runtime loaded but the reproduction
   // itself errored — e.g. an unexpected pandas API change.
-  if (globalThis.__VIVARIUM_VERDICT__ !== "unreproduced") {
+  if (globalThis.__VIVARIUM_VERDICT__ !== 'unreproduced') {
     setVerdict(
-      "unreproduced",
+      'unreproduced',
       `bug not reproduced — runtime error: ${errAny?.message ?? String(err)}`,
     );
   }

--- a/src/layer1_wasm/php-12167/index.html
+++ b/src/layer1_wasm/php-12167/index.html
@@ -19,33 +19,78 @@
       crossorigin
     />
     <link rel="stylesheet" href="../_shared/style.css" />
-  </head>
-  <body>
-    <main>
-      <header>
-        <p class="kicker">Vivarium · Layer 1 · php-wasm</p>
-        <h1>Reproducing <a href="https://github.com/php/php-src/issues/12167">php/php-src#12167</a></h1>
-        <p class="lede">
+    <template id="bug-context">
+      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <div class="vh-drawer__body" id="vh-drawer-body">
+        <p>
           PHP's SimpleXML can find a processing-instruction node via
           <code>xpath("//processing-instruction()")</code>, but casting
           that node to string yields an empty value instead of the
-          PI's content. xpath returns the node — the count is
-          <em>one</em> — so the bug is purely in the string-cast path
-          for processing-instruction nodes.
+          PI's content. xpath returns the node — the count is one — so
+          the bug is purely in the string-cast path for
+          processing-instruction nodes.
         </p>
+        <p>
+          The script on this page builds a small XML document with one
+          processing instruction, runs the xpath query, casts the
+          returned node to string, and reports both the count and
+          the cast result. If the count is <code>1</code> and the
+          cast result is empty, the bug reproduces in the php-wasm
+          build this page loads.
+        </p>
+        <p>
+          This recipe also carries the <strong>"Try a fix"</strong>
+          panel below — Phase 7 B3's Path A. After the baseline run,
+          you can paste an alternative version of the script
+          (e.g. an AI-proposed userland fix) and re-run it through
+          the same in-browser PHP runtime. The full discussion of
+          the bug itself lives in the GitHub issue thread linked
+          below.
+        </p>
+      </div>
+      <hr class="vh-drawer__divider" />
+      <div class="vh-drawer__meta-grid">
+        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-val">php/php-src</span>
+        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-val">#12167</span>
+        <span class="vh-drawer__meta-key">Layer</span>
+        <span class="vh-drawer__meta-val">L1 · WASM</span>
+        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-val">php-wasm</span>
+      </div>
+    </template>
+  </head>
+  <body>
+    <main class="vh-main">
+      <header class="vh-main__header">
+        <div class="vh-main__header-text">
+          <p class="kicker">L1 · php-wasm</p>
+          <h1>Reproducing <a href="https://github.com/php/php-src/issues/12167">php/php-src#12167</a></h1>
+          <div class="vh-main__header-actions">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+              Bug context
+            </button>
+            <a class="vh-chip" href="https://github.com/php/php-src/issues/12167" target="_blank" rel="noreferrer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              Upstream issue
+            </a>
+          </div>
+        </div>
+        <div class="vh-main__header-aside">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+            Loading php-wasm runtime…
+          </div>
+          <p class="meta" id="meta"></p>
+        </div>
       </header>
 
-      <section>
-        <h2>Verdict</h2>
-        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
-          Loading php-wasm runtime…
-        </div>
-        <p class="meta" id="meta"></p>
-      </section>
-
-      <section>
-        <h2>Reproduction script</h2>
-        <pre><code id="repro-code"><span class="line"><span style="color:#F97583">&#x3C;?</span><span style="color:#79B8FF">php</span></span>
+      <div class="vh-main__cols">
+        <section class="vh-main__col vh-main__col--script">
+          <h2>Reproduction script</h2>
+          <pre><code id="repro-code"><span class="line"><span style="color:#F97583">&#x3C;?</span><span style="color:#79B8FF">php</span></span>
 <span class="line"><span style="color:#E1E4E8">$xml </span><span style="color:#F97583">=</span><span style="color:#9ECBFF"> '&#x3C;?xml version="1.0"?>&#x3C;foo>&#x3C;bar>&#x3C;?stylesheet hello ?>&#x3C;/bar>&#x3C;/foo>'</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"><span style="color:#E1E4E8">$sxe </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> simplexml_load_string</span><span style="color:#E1E4E8">($xml);</span></span>
 <span class="line"><span style="color:#E1E4E8">$pis </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> $sxe</span><span style="color:#F97583">-></span><span style="color:#B392F0">xpath</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"//processing-instruction()"</span><span style="color:#E1E4E8">);</span></span>
@@ -57,25 +102,16 @@
 <span class="line"><span style="color:#9ECBFF">  "pi_text"</span><span style="color:#F97583"> =></span><span style="color:#E1E4E8"> $pi_text,</span></span>
 <span class="line"><span style="color:#9ECBFF">  "pi_text_empty"</span><span style="color:#F97583"> =></span><span style="color:#E1E4E8"> $pi_text </span><span style="color:#F97583">===</span><span style="color:#9ECBFF"> ""</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#E1E4E8">]);</span></span></code></pre>
-      </section>
+        </section>
 
-      <section>
-        <h2>Output</h2>
-        <pre id="output">(running)</pre>
-      </section>
+        <section class="vh-main__col vh-main__col--output">
+          <h2>Output</h2>
+          <pre id="output">(running)</pre>
+        </section>
+      </div>
 
       <section id="path-a-mount" hidden></section>
 
-      <footer>
-        <p class="meta">
-          Runtime:
-          <a href="https://github.com/seanmorris/php-wasm">php-wasm</a>
-          loaded from
-          <a href="https://www.jsdelivr.com/package/npm/php-wasm">cdn.jsdelivr.net</a>.
-          Source:
-          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/php-12167">vivarium/src/layer1_wasm/php-12167</a>.
-        </p>
-      </footer>
     </main>
 
     <script type="module" src="./repro.js"></script>

--- a/src/layer1_wasm/php-12167/repro.ts
+++ b/src/layer1_wasm/php-12167/repro.ts
@@ -23,13 +23,14 @@
 // php-wasm runtime. The panel produces a Contract v1 verdict bundle
 // the visitor drops on /repro/compare for side-by-side review.
 
-import { enablePathA, type PathACapturedRun } from "../_shared/path_a.js";
-import { loadVivariumPhp, type PhpRunner } from "../_shared/php_loader.js";
+import { enablePathA, type PathACapturedRun } from '../_shared/path_a.js';
+import { loadVivariumPhp, type PhpRunner } from '../_shared/php_loader.js';
+import { enableRunner } from '../_shared/runner.js';
 import {
   setResult,
   setVerdict,
   type VivariumResultV1,
-} from "../_shared/verdict.js";
+} from '../_shared/verdict.js';
 
 const REPRO_CODE = `<?php
 $xml = '<?xml version="1.0"?><foo><bar><?stylesheet hello ?></bar></foo>';
@@ -52,14 +53,14 @@ interface ReproOutput {
   pi_text_empty: boolean;
 }
 
-const outputEl = document.getElementById("output");
-const metaEl = document.getElementById("meta");
-const reproCodeEl = document.getElementById("repro-code");
-const pathAMountEl = document.getElementById("path-a-mount");
+const outputEl = document.getElementById('output');
+const metaEl = document.getElementById('meta');
+const reproCodeEl = document.getElementById('repro-code');
+const pathAMountEl = document.getElementById('path-a-mount');
 
 if (!outputEl || !metaEl || !reproCodeEl) {
   throw new Error(
-    "php-12167: missing required DOM elements (#output, #meta, #repro-code).",
+    'php-12167: missing required DOM elements (#output, #meta, #repro-code).',
   );
 }
 
@@ -69,7 +70,7 @@ if (!outputEl || !metaEl || !reproCodeEl) {
 // fallback below kicks in only when the placeholder is still empty.
 if (!reproCodeEl.firstChild) {
   reproCodeEl.textContent = REPRO_CODE;
-  fetch("./repro.highlighted.html")
+  fetch('./repro.highlighted.html')
     .then((r) => (r.ok ? r.text() : null))
     .then((html) => {
       if (html) reproCodeEl.innerHTML = html;
@@ -78,7 +79,7 @@ if (!reproCodeEl.firstChild) {
 }
 
 function evaluate(result: ReproOutput): {
-  verdict: "reproduced" | "unreproduced";
+  verdict: 'reproduced' | 'unreproduced';
   message: string;
 } {
   // Bug reproduces iff xpath finds the PI node (count === 1) but
@@ -86,9 +87,9 @@ function evaluate(result: ReproOutput): {
   const reproduced = result.xpath_count === 1 && result.pi_text_empty;
   if (reproduced) {
     return {
-      verdict: "reproduced",
+      verdict: 'reproduced',
       message:
-        "bug reproduced — SimpleXML xpath returns the processing-instruction node, but casting it to string yields an empty value.",
+        'bug reproduced — SimpleXML xpath returns the processing-instruction node, but casting it to string yields an empty value.',
     };
   }
   if (
@@ -97,13 +98,13 @@ function evaluate(result: ReproOutput): {
     result.pi_text !== null
   ) {
     return {
-      verdict: "unreproduced",
+      verdict: 'unreproduced',
       message:
-        "bug not reproduced — SimpleXML now returns the PI content correctly (likely fixed upstream).",
+        'bug not reproduced — SimpleXML now returns the PI content correctly (likely fixed upstream).',
     };
   }
   return {
-    verdict: "unreproduced",
+    verdict: 'unreproduced',
     message: `bug not reproduced — unexpected outcome (xpath_count=${result.xpath_count}, pi_text=${JSON.stringify(result.pi_text)}).`,
   };
 }
@@ -116,7 +117,7 @@ async function captureRun(
   if (exitCode !== 0) {
     return {
       exitCode,
-      verdict: "unreproduced",
+      verdict: 'unreproduced',
       message: `php-wasm exited non-zero (code=${exitCode}); stdout=${stdout}`,
       stdout,
     };
@@ -127,7 +128,7 @@ async function captureRun(
   } catch (err: unknown) {
     return {
       exitCode,
-      verdict: "unreproduced",
+      verdict: 'unreproduced',
       message: `bug not reproduced — fix output was not valid JSON (${err instanceof Error ? err.message : String(err)})`,
       stdout,
     };
@@ -145,10 +146,10 @@ const startedAt = new Date();
 
 try {
   const { php, phpWasmVersion } = await loadVivariumPhp({
-    pendingText: "Loading php-wasm runtime and stdlib…",
+    pendingText: 'Loading php-wasm runtime and stdlib…',
   });
 
-  setVerdict("pending", "Running reproduction script…");
+  setVerdict('pending', 'Running reproduction script…');
   const baseline = await captureRun(php, REPRO_CODE);
 
   let baselineResult: ReproOutput;
@@ -160,22 +161,21 @@ try {
     );
   }
 
-  metaEl.textContent =
-    `PHP ${baselineResult.php_version} via php-wasm v${phpWasmVersion}.`;
+  metaEl.textContent = `PHP ${baselineResult.php_version} via php-wasm v${phpWasmVersion}.`;
   outputEl.textContent = JSON.stringify(baselineResult, null, 2);
 
   setVerdict(baseline.verdict, baseline.message);
 
   const finishedAt = new Date();
   const envelope: VivariumResultV1 = {
-    contract: "v1",
+    contract: 'v1',
     bug: {
-      project: "php",
+      project: 'php',
       issue: 12167,
-      upstream_url: "https://github.com/php/php-src/issues/12167",
+      upstream_url: 'https://github.com/php/php-src/issues/12167',
     },
     runtime: {
-      name: "php-wasm",
+      name: 'php-wasm',
       version: phpWasmVersion,
       extras: {
         php: baselineResult.php_version,
@@ -185,7 +185,7 @@ try {
       xpath_count: baselineResult.xpath_count,
       pi_text: baselineResult.pi_text,
       pi_text_empty: baselineResult.pi_text_empty,
-      reproduced: baseline.verdict === "reproduced",
+      reproduced: baseline.verdict === 'reproduced',
     },
     timing: {
       started_at: startedAt.toISOString(),
@@ -195,13 +195,24 @@ try {
   };
   setResult(envelope);
 
+  // Phase 8 V″ — wire the editable script + Run button (the in-place
+  // re-run affordance the runner offers, in the script column).
+  enableRunner({
+    slug: 'php-12167',
+    baselineSource: REPRO_CODE,
+    runFix: (source) => captureRun(php, source),
+  });
+
   // Phase 7 B3 — opt into Path A. The mount-point lives in the page
   // markup (`<section id="path-a-mount" hidden>`); reveal it before
   // mounting so the panel transitions from hidden to populated atomically.
+  // Path A overlaps with the runner conceptually (both re-run a pasted
+  // script), but Path A also captures verdict.json bundles for
+  // /repro/compare and is preserved here for the existing B3 walkthrough.
   if (pathAMountEl) {
-    pathAMountEl.removeAttribute("hidden");
+    pathAMountEl.removeAttribute('hidden');
     void enablePathA({
-      slug: "php-12167",
+      slug: 'php-12167',
       baselineSource: REPRO_CODE,
       baseline,
       runFix: (source) => captureRun(php, source),
@@ -212,9 +223,9 @@ try {
   const errAny = err as { stack?: string; message?: string } | null;
   outputEl.textContent =
     (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
-  if (globalThis.__VIVARIUM_VERDICT__ !== "unreproduced") {
+  if (globalThis.__VIVARIUM_VERDICT__ !== 'unreproduced') {
     setVerdict(
-      "unreproduced",
+      'unreproduced',
       `bug not reproduced — runtime error: ${errAny?.message ?? String(err)}`,
     );
   }

--- a/src/layer1_wasm/regex-779/index.html
+++ b/src/layer1_wasm/regex-779/index.html
@@ -19,36 +19,81 @@
       crossorigin
     />
     <link rel="stylesheet" href="../_shared/style.css" />
-  </head>
-  <body>
-    <main>
-      <header>
-        <p class="kicker">Vivarium · Layer 1 · Rust (wasm32-wasip1)</p>
-        <h1>Reproducing <a href="https://github.com/rust-lang/regex/issues/779">rust-lang/regex#779</a></h1>
-        <p class="lede">
+    <template id="bug-context">
+      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <div class="vh-drawer__body" id="vh-drawer-body">
+        <p>
           The Rust <code>regex</code> crate violates a basic regex
           algebra: <code>(re)+</code> should equal
           <code>(re)(re)*</code>, but with
           <code>(?m)(^|a)+</code> against the haystack
           <code>"a\naaa\n"</code> the two equivalent forms produce
           different match-iteration outputs. RE2 and Go's regexp
-          have the same divergence; PCRE2 gets it right, so this is
-          an algebraic regex-engine bug rather than a regex-language
-          ambiguity.
+          have the same divergence; PCRE2 gets it right, so this
+          is an algebraic regex-engine bug rather than a
+          regex-language ambiguity.
         </p>
+        <p>
+          The actual reproduction logic lives in <code>src/main.rs</code>
+          and ships as <code>repro.wasm</code>, built from
+          <code>Cargo.toml</code> at deploy time. The script panel
+          on the left shows the relevant excerpt; the output panel
+          shows the JSON envelope the wasm prints to stdout when it
+          runs.
+        </p>
+        <p>
+          Unlike the Pyodide / Ruby.wasm / php-wasm recipes, this
+          page does <strong>not</strong> ship an in-browser
+          edit-and-run affordance — the Rust source is compiled
+          into <code>repro.wasm</code> at build time, so live
+          editing would require re-compilation outside the browser.
+          To experiment with variations, fork the crate and rebuild
+          <code>repro.wasm</code>.
+        </p>
+      </div>
+      <hr class="vh-drawer__divider" />
+      <div class="vh-drawer__meta-grid">
+        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-val">rust-lang/regex</span>
+        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-val">#779</span>
+        <span class="vh-drawer__meta-key">Layer</span>
+        <span class="vh-drawer__meta-val">L1 · WASM</span>
+        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-val">Rust wasm32-wasip1</span>
+      </div>
+    </template>
+  </head>
+  <body>
+    <main class="vh-main">
+      <header class="vh-main__header">
+        <div class="vh-main__header-text">
+          <p class="kicker">L1 · Rust wasm32-wasip1</p>
+          <h1>Reproducing <a href="https://github.com/rust-lang/regex/issues/779">rust-lang/regex#779</a></h1>
+          <div class="vh-main__header-actions">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+              Bug context
+            </button>
+            <a class="vh-chip" href="https://github.com/rust-lang/regex/issues/779" target="_blank" rel="noreferrer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              Upstream issue
+            </a>
+          </div>
+        </div>
+        <div class="vh-main__header-aside">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+            Loading Rust wasm32-wasip1 artefact via WASI shim…
+          </div>
+          <p class="meta" id="meta"></p>
+        </div>
       </header>
 
-      <section>
-        <h2>Verdict</h2>
-        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
-          Loading Rust wasm32-wasip1 artefact via WASI shim…
-        </div>
-        <p class="meta" id="meta"></p>
-      </section>
-
-      <section>
-        <h2>Reproduction script (Rust)</h2>
-        <pre><code id="repro-code"><span class="line"><span style="color:#6A737D">// src/main.rs (excerpt — see this directory for the full crate)</span></span>
+      <div class="vh-main__cols">
+        <section class="vh-main__col vh-main__col--script">
+          <h2>Reproduction script (Rust)</h2>
+          <pre><code id="repro-code"><span class="line"><span style="color:#6A737D">// src/main.rs (excerpt — see this directory for the full crate)</span></span>
 <span class="line"><span style="color:#F97583">let</span><span style="color:#E1E4E8"> haystack </span><span style="color:#F97583">=</span><span style="color:#9ECBFF"> "a</span><span style="color:#79B8FF">\n</span><span style="color:#9ECBFF">aaa</span><span style="color:#79B8FF">\n</span><span style="color:#9ECBFF">"</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"><span style="color:#F97583">let</span><span style="color:#E1E4E8"> re_plus     </span><span style="color:#F97583">=</span><span style="color:#B392F0"> Regex</span><span style="color:#F97583">::</span><span style="color:#B392F0">new</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"(?m)(^|a)+"</span><span style="color:#E1E4E8">)</span><span style="color:#F97583">.</span><span style="color:#B392F0">unwrap</span><span style="color:#E1E4E8">();</span></span>
 <span class="line"><span style="color:#F97583">let</span><span style="color:#E1E4E8"> re_expanded </span><span style="color:#F97583">=</span><span style="color:#B392F0"> Regex</span><span style="color:#F97583">::</span><span style="color:#B392F0">new</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"(?m)(^|a)(^|a)*"</span><span style="color:#E1E4E8">)</span><span style="color:#F97583">.</span><span style="color:#B392F0">unwrap</span><span style="color:#E1E4E8">();</span></span>
@@ -59,24 +104,14 @@
 <span class="line"><span style="color:#F97583">    .</span><span style="color:#B392F0">map</span><span style="color:#E1E4E8">(</span><span style="color:#F97583">|</span><span style="color:#E1E4E8">m</span><span style="color:#F97583">|</span><span style="color:#E1E4E8"> (m</span><span style="color:#F97583">.</span><span style="color:#B392F0">start</span><span style="color:#E1E4E8">(), m</span><span style="color:#F97583">.</span><span style="color:#B392F0">end</span><span style="color:#E1E4E8">()))</span><span style="color:#F97583">.</span><span style="color:#B392F0">collect</span><span style="color:#F97583">::</span><span style="color:#E1E4E8">&#x3C;</span><span style="color:#B392F0">Vec</span><span style="color:#E1E4E8">&#x3C;_>>();</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#F97583">let</span><span style="color:#E1E4E8"> reproduced </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> matches_plus </span><span style="color:#F97583">!=</span><span style="color:#E1E4E8"> matches_expanded;</span></span></code></pre>
-      </section>
+        </section>
 
-      <section>
-        <h2>Output</h2>
-        <pre id="output">(running)</pre>
-      </section>
+        <section class="vh-main__col vh-main__col--output">
+          <h2>Output</h2>
+          <pre id="output">(running)</pre>
+        </section>
+      </div>
 
-      <footer>
-        <p class="meta">
-          Runtime:
-          Rust crate compiled to <code>wasm32-wasip1</code>, instantiated in-browser via
-          <a href="https://github.com/bjorn3/browser_wasi_shim">@bjorn3/browser_wasi_shim</a>
-          loaded from
-          <a href="https://www.jsdelivr.com/package/npm/@bjorn3/browser_wasi_shim">cdn.jsdelivr.net</a>.
-          Source:
-          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/regex-779">vivarium/src/layer1_wasm/regex-779</a>.
-        </p>
-      </footer>
     </main>
 
     <script type="module" src="./repro.js"></script>

--- a/src/layer1_wasm/ruby-21709/index.html
+++ b/src/layer1_wasm/ruby-21709/index.html
@@ -19,36 +19,73 @@
       crossorigin
     />
     <link rel="stylesheet" href="../_shared/style.css" />
-  </head>
-  <body>
-    <main>
-      <header>
-        <p class="kicker">Vivarium · Layer 1 · Ruby.wasm</p>
-        <h1>Reproducing <a href="https://bugs.ruby-lang.org/issues/21709">ruby/ruby#21709</a></h1>
-        <p class="lede">
+    <template id="bug-context">
+      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <div class="vh-drawer__body" id="vh-drawer-body">
+        <p>
           Ruby's Regexp interpolation rejects fragments of differing
           encodings, while String interpolation silently upgrades them
           to UTF-8. With <code>prefix = '\p{In_Arabic}'</code> and
           <code>suffix = prefix.encode('US-ASCII')</code>,
           <code>/#{prefix}#{suffix}/</code> raises a
-          <code>RegexpError</code> while <code>"#{prefix}#{suffix}"</code>
-          builds a UTF-8 string fine. The two interpolation forms
-          should agree on how to combine fragments of different
-          encodings — they don't.
+          <code>RegexpError</code> while
+          <code>"#{prefix}#{suffix}"</code> builds a UTF-8 string.
         </p>
+        <p>
+          The two interpolation forms should agree on how to combine
+          fragments of different encodings. The script on this page
+          attempts both, captures whether each raised, and returns
+          a JSON summary the verdict logic uses to decide reproduced
+          vs unreproduced.
+        </p>
+        <p>
+          The full discussion (motivation, fix progress) lives in the
+          GitHub issue thread linked below.
+        </p>
+      </div>
+      <hr class="vh-drawer__divider" />
+      <div class="vh-drawer__meta-grid">
+        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-val">ruby/ruby</span>
+        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-val">#21709</span>
+        <span class="vh-drawer__meta-key">Layer</span>
+        <span class="vh-drawer__meta-val">L1 · WASM</span>
+        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-val">Ruby.wasm</span>
+      </div>
+    </template>
+  </head>
+  <body>
+    <main class="vh-main">
+      <header class="vh-main__header">
+        <div class="vh-main__header-text">
+          <p class="kicker">L1 · Ruby.wasm</p>
+          <h1>Reproducing <a href="https://bugs.ruby-lang.org/issues/21709">ruby/ruby#21709</a></h1>
+          <div class="vh-main__header-actions">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+              Bug context
+            </button>
+            <a class="vh-chip" href="https://bugs.ruby-lang.org/issues/21709" target="_blank" rel="noreferrer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              Upstream issue
+            </a>
+          </div>
+        </div>
+        <div class="vh-main__header-aside">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+            Loading Ruby.wasm runtime…
+          </div>
+          <p class="meta" id="meta"></p>
+        </div>
       </header>
 
-      <section>
-        <h2>Verdict</h2>
-        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
-          Loading Ruby.wasm runtime…
-        </div>
-        <p class="meta" id="meta"></p>
-      </section>
-
-      <section>
-        <h2>Reproduction script</h2>
-        <pre><code id="repro-code"><span class="line"><span style="color:#F97583">require</span><span style="color:#9ECBFF"> "json"</span></span>
+      <div class="vh-main__cols">
+        <section class="vh-main__col vh-main__col--script">
+          <h2>Reproduction script</h2>
+          <pre><code id="repro-code"><span class="line"><span style="color:#F97583">require</span><span style="color:#9ECBFF"> "json"</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#FFAB70">result</span><span style="color:#E1E4E8"> = { </span><span style="color:#79B8FF">ruby_version:</span><span style="color:#79B8FF"> RUBY_VERSION</span><span style="color:#E1E4E8"> }</span></span>
 <span class="line"></span>
@@ -76,23 +113,14 @@
 <span class="line"><span style="color:#F97583">end</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#79B8FF">JSON</span><span style="color:#E1E4E8">.</span><span style="color:#B392F0">dump</span><span style="color:#E1E4E8">(result)</span></span></code></pre>
-      </section>
+        </section>
 
-      <section>
-        <h2>Output</h2>
-        <pre id="output">(running)</pre>
-      </section>
+        <section class="vh-main__col vh-main__col--output">
+          <h2>Output</h2>
+          <pre id="output">(running)</pre>
+        </section>
+      </div>
 
-      <footer>
-        <p class="meta">
-          Runtime:
-          <a href="https://github.com/ruby/ruby.wasm">Ruby.wasm</a>
-          loaded from
-          <a href="https://www.jsdelivr.com/package/npm/@ruby/wasm-wasi">cdn.jsdelivr.net</a>.
-          Source:
-          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/ruby-21709">vivarium/src/layer1_wasm/ruby-21709</a>.
-        </p>
-      </footer>
     </main>
 
     <script type="module" src="./repro.js"></script>

--- a/src/layer1_wasm/ruby-21709/repro.ts
+++ b/src/layer1_wasm/ruby-21709/repro.ts
@@ -14,12 +14,14 @@
 //   - "unreproduced" — the bug does NOT reproduce (the runtime ships a fix,
 //     or the runtime errored before producing a result).
 
-import { loadVivariumRuby } from "../_shared/ruby_loader.js";
+import type { PathACapturedRun } from '../_shared/path_a.js';
+import { loadVivariumRuby } from '../_shared/ruby_loader.js';
+import { enableRunner } from '../_shared/runner.js';
 import {
   setResult,
   setVerdict,
   type VivariumResultV1,
-} from "../_shared/verdict.js";
+} from '../_shared/verdict.js';
 
 const REPRO_CODE = String.raw`
 require "json"
@@ -65,13 +67,13 @@ interface RubyVM {
   eval(code: string): { toString(): string };
 }
 
-const outputEl = document.getElementById("output");
-const metaEl = document.getElementById("meta");
-const reproCodeEl = document.getElementById("repro-code");
+const outputEl = document.getElementById('output');
+const metaEl = document.getElementById('meta');
+const reproCodeEl = document.getElementById('repro-code');
 
 if (!outputEl || !metaEl || !reproCodeEl) {
   throw new Error(
-    "ruby-21709: missing required DOM elements (#output, #meta, #repro-code).",
+    'ruby-21709: missing required DOM elements (#output, #meta, #repro-code).',
   );
 }
 
@@ -81,7 +83,7 @@ if (!outputEl || !metaEl || !reproCodeEl) {
 // fallback below kicks in only when the placeholder is still empty.
 if (!reproCodeEl.firstChild) {
   reproCodeEl.textContent = REPRO_CODE;
-  fetch("./repro.highlighted.html")
+  fetch('./repro.highlighted.html')
     .then((r) => (r.ok ? r.text() : null))
     .then((html) => {
       if (html) reproCodeEl.innerHTML = html;
@@ -89,65 +91,103 @@ if (!reproCodeEl.firstChild) {
     .catch(() => {});
 }
 
+function evaluate(result: ReproOutput): {
+  verdict: 'reproduced' | 'unreproduced';
+  message: string;
+} {
+  const reproduced = !result.regexp_built && result.string_built;
+  if (reproduced) {
+    return {
+      verdict: 'reproduced',
+      message:
+        'bug reproduced — Regexp interpolation rejects mixed encodings while String interpolation silently upgrades.',
+    };
+  }
+  if (result.regexp_built && result.string_built) {
+    return {
+      verdict: 'unreproduced',
+      message:
+        'bug not reproduced — Regexp and String interpolation now agree (likely fixed upstream).',
+    };
+  }
+  return {
+    verdict: 'unreproduced',
+    message: `bug not reproduced — unexpected outcome (regexp_built=${result.regexp_built}, string_built=${result.string_built}).`,
+  };
+}
+
+async function captureRun(
+  rb: RubyVM,
+  source: string,
+): Promise<PathACapturedRun> {
+  try {
+    const jsonText = rb.eval(source).toString();
+    const result = JSON.parse(jsonText) as ReproOutput;
+    const ev = evaluate(result);
+    return {
+      exitCode: 0,
+      verdict: ev.verdict,
+      message: ev.message,
+      stdout: JSON.stringify(result, null, 2),
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      exitCode: 1,
+      verdict: 'unreproduced',
+      message: `runtime error: ${message}`,
+      stdout: message,
+    };
+  }
+}
+
 const startedAt = new Date();
 
 try {
   const { vm, rubyWasmVersion, rubyVersion } = await loadVivariumRuby({
-    pendingText: "Loading Ruby.wasm runtime and stdlib…",
+    pendingText: 'Loading Ruby.wasm runtime and stdlib…',
   });
 
-  setVerdict("pending", "Running reproduction script…");
+  setVerdict('pending', 'Running reproduction script…');
   const rb = vm as RubyVM;
-  const jsonText = rb.eval(REPRO_CODE).toString();
-  const result = JSON.parse(jsonText) as ReproOutput;
+  const baseline = await captureRun(rb, REPRO_CODE);
 
-  metaEl.textContent =
-    `Ruby ${result.ruby_version} via @ruby/${rubyVersion}-wasm-wasi v${rubyWasmVersion}.`;
-  outputEl.textContent = JSON.stringify(result, null, 2);
-
-  // Bug reproduces iff Regexp interpolation raises but String
-  // interpolation succeeds — the documented inconsistency.
-  const reproduced = !result.regexp_built && result.string_built;
-
-  if (reproduced) {
-    setVerdict(
-      "reproduced",
-      "bug reproduced — Regexp interpolation rejects mixed encodings while String interpolation silently upgrades.",
-    );
-  } else if (result.regexp_built && result.string_built) {
-    setVerdict(
-      "unreproduced",
-      "bug not reproduced — Regexp and String interpolation now agree (likely fixed upstream).",
-    );
-  } else {
-    setVerdict(
-      "unreproduced",
-      `bug not reproduced — unexpected outcome (regexp_built=${result.regexp_built}, string_built=${result.string_built}).`,
-    );
+  let baselineResult: ReproOutput | null = null;
+  try {
+    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
+  } catch {
+    outputEl.textContent = baseline.stdout;
+    setVerdict(baseline.verdict, baseline.message);
+    throw new Error(baseline.message);
   }
 
+  metaEl.textContent = `Ruby ${baselineResult.ruby_version} via @ruby/${rubyVersion}-wasm-wasi v${rubyWasmVersion}.`;
+  outputEl.textContent = baseline.stdout;
+  setVerdict(baseline.verdict, baseline.message);
+
   const finishedAt = new Date();
+  const reproduced = baseline.verdict === 'reproduced';
   const envelope: VivariumResultV1 = {
-    contract: "v1",
+    contract: 'v1',
     bug: {
-      project: "ruby",
+      project: 'ruby',
       issue: 21709,
-      upstream_url: "https://bugs.ruby-lang.org/issues/21709",
+      upstream_url: 'https://bugs.ruby-lang.org/issues/21709',
     },
     runtime: {
-      name: "ruby.wasm",
+      name: 'ruby.wasm',
       version: rubyWasmVersion,
       extras: {
-        ruby: result.ruby_version,
+        ruby: baselineResult.ruby_version,
         ruby_wasi_package: `@ruby/${rubyVersion}-wasm-wasi`,
       },
     },
     result: {
-      regexp_built: result.regexp_built,
-      regexp_raised: result.regexp_raised,
-      string_built: result.string_built,
-      string_encoding: result.string_encoding,
-      string_raised: result.string_raised,
+      regexp_built: baselineResult.regexp_built,
+      regexp_raised: baselineResult.regexp_raised,
+      string_built: baselineResult.string_built,
+      string_encoding: baselineResult.string_encoding,
+      string_raised: baselineResult.string_raised,
       reproduced,
     },
     timing: {
@@ -157,14 +197,21 @@ try {
     },
   };
   setResult(envelope);
+
+  // Phase 8 V″ — wire the editable script + Run button.
+  enableRunner({
+    slug: 'ruby-21709',
+    baselineSource: REPRO_CODE,
+    runFix: (source) => captureRun(rb, source),
+  });
 } catch (err: unknown) {
   console.error(err);
   const errAny = err as { stack?: string; message?: string } | null;
   outputEl.textContent =
     (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
-  if (globalThis.__VIVARIUM_VERDICT__ !== "unreproduced") {
+  if (globalThis.__VIVARIUM_VERDICT__ !== 'unreproduced') {
     setVerdict(
-      "unreproduced",
+      'unreproduced',
       `bug not reproduced — runtime error: ${errAny?.message ?? String(err)}`,
     );
   }


### PR DESCRIPTION

Replaces the single-column recipe page with a desktop two-pane split
(reproduction script ‖ output), a right-side overlay drawer that
carries the bug description, an editable script + Run/Reset/Edit
runner, and a slim header that pins script + output to the viewport
without page-level scroll. ADR-0035.

Shared:
- _shared/style.css — desktop @media (>=1024px) flex/grid layout
- _shared/runner.ts — Edit/Run/Reset wraps existing <pre> + textarea
- _shared/verdict.ts — pill renders short literals (LOADING…/RUNNING…/
  REPRODUCED/UNREPRODUCED), full message stays on
  __VIVARIUM_VERDICT_MESSAGE__
- _assets/chrome.js — drawer + wash construction, output-col h2 head
  wrap for height parity with script col

Per recipe (cpython, numpy, pandas, php, regex, ruby): restructure
<main> into vh-main / vh-main__cols, embed bug-context <template>,
remove in-page footer (runtime info now lives in drawer metadata).
regex-779 keeps the layout but skips the runner — its <pre> is a
hint, the actual reproduction is the pre-built repro.wasm.

Also: docs/components/{RecipeGallery,ProjectPage}.tsx rewrite the
production-host URL baked into recipes.json so the "Open ↗" button
points at the gallery's own host (fix: localhost dev was sending
the visitor to GitHub Pages).
