### PR TITLE
chore(infra): gitignore CLAUDE.local.md for personal operating notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ temp/
 .claude/
 .aider*
 .cursor-server/
+CLAUDE.local.md
 
 # ─── Local-only docs (design/strategy memos) ───
 /_context/


### PR DESCRIPTION

Adds CLAUDE.local.md to the Claude Code / AI tools section of .gitignore.
The tracked CLAUDE.md covers vivarium implementation rules; CLAUDE.local.md
is reserved for project-scoped, local-only operating rules (e.g. how we
select issues to reproduce against upstream). Keeps repo CLAUDE.md focused
on implementation while still giving Claude Code a stable slot to load
personal usage rules from.
