### PR TITLE
ci(labeler): apply type:* label from PR title's Conventional Commits prefix

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,12 +1,3 @@
-# Path-based label rules for vivarium.
-# Consumed by .github/workflows/labeler.yml (actions/labeler).
-#
-# Rules map file-path patterns to labels defined in
-# infra/github/labels.tf. `type: *` labels are applied only where they
-# can be inferred mechanically (e.g. a purely doc change gets
-# `type: docs`); other `type: *` labels come from the conventional
-# commit prefix of the PR and are set by a separate automation.
-
 "scope: ci":
   - changed-files:
       - any-glob-to-any-file:
@@ -84,11 +75,21 @@
           - "src/layer2_docker/**"
           - "src/layer3_thirdway/**"
 
+# `type: *` labels are primarily set from the PR title's Conventional
+# Commits prefix by the inline title-parsing step in
+# .github/workflows/labeler.yml — `commitlint.yml` enforces that
+# prefix at PR open time, so the title is reliable.
+#
+# `type: docs` keeps a path-based fallback below: when every changed
+# file is markdown / docs, the path rule applies the label. The
+# title step still wins on conflicts (it removes any other `type: *`
+# before applying its own), so this is a fallback for the rare PR
+# that uses a non-`docs:` Conventional Commits type for a doc-only
+# change.
+
 "type: docs":
   # `any-glob-to-all-files` (not `-any-file`): apply only when every
-  # changed file matches one of these doc patterns. The previous
-  # `-any-file` form over-applied `type: docs` to any mixed PR that
-  # happened to touch a single markdown file. See Issue #115.
+  # changed file matches one of these doc patterns.
   - changed-files:
       - any-glob-to-all-files:
           - "**/*.md"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,8 +1,16 @@
 # Release notes category config for GitHub's auto-generated notes.
 # Used by `gh release create --generate-notes` from release.yml.
 #
-# Labels referenced here must exist in infra/github/labels.tf so that
-# PRs can be categorized automatically.
+# Labels referenced here must exist in infra/github/main.tf so that
+# PRs can be categorized automatically. `type: *` labels are applied
+# by the title-parsing step in .github/workflows/labeler.yml from the
+# PR's Conventional Commits prefix; `scope: *` labels are applied by
+# the path-based step in the same workflow.
+#
+# Categories are matched first-wins, so order matters. The current
+# order puts the most user-visible changes first (Features, Bug
+# Fixes), then internal-only changes (Refactoring, Tests,
+# Infrastructure, Maintenance), then "Other changes" as the catch-all.
 
 changelog:
   categories:
@@ -12,7 +20,7 @@ changelog:
     - title: Bug Fixes
       labels:
         - "type: bug"
-    - title: Performance
+    - title: Refactoring
       labels:
         - "type: refactor"
     - title: Documentation
@@ -25,7 +33,7 @@ changelog:
       labels:
         - "scope: infra"
         - "scope: ci"
-    - title: Dependencies
+    - title: Maintenance
       labels:
         - "type: chore"
     - title: Other changes

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,15 +1,34 @@
 name: PR Labeler
 
-# Applies labels to PRs based on changed file paths, driven by the rules
-# in .github/labeler.yml in this repo.
+# Applies labels to PRs from two complementary mechanical signals:
 #
-# `sync-labels: true` removes labels that the action previously applied
-# when the matching rule no longer matches (e.g. after a PR push removes
-# the last docs change). Manually applied labels are untouched.
+#   1. Changed file paths → `scope: *` labels (driven by the rules in
+#      .github/labeler.yml in this repo, consumed by actions/labeler).
+#   2. PR title's Conventional Commits prefix → `type: *` label (the
+#      inline step below; gh CLI driven). `release.yml` consumes the
+#      `type: *` labels for `gh release --generate-notes` so feature /
+#      fix / refactor PRs land in the right release-notes section
+#      instead of "Other changes".
+#
+# Both signals are mechanical (AGENTS.md §4.5 mechanical-labelling
+# policy). PR title is the right source for `type: *` because the
+# commitlint workflow already enforces the Conventional Commits
+# prefix at PR open time, so the prefix is reliable.
+#
+# `sync-labels: true` on the actions/labeler step removes labels the
+# action previously applied when the matching rule no longer matches
+# (e.g. after a PR push removes the last docs change). Manually
+# applied labels are untouched. The title-based step manages its own
+# `type: *` lifecycle (removes the stale one before applying the new
+# one when the title is edited).
+#
+# `edited` is in the trigger types so a title change after open
+# (e.g. feat → fix) re-fires the title step and the label updates
+# accordingly.
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened]
 
 permissions:
   contents: read
@@ -25,3 +44,56 @@ jobs:
         uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:
           sync-labels: true
+
+      - name: Label based on PR title (Conventional Commits)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Extract the Conventional Commits type from `type(scope)?(!)?: subject`.
+          ctype=$(printf '%s' "$PR_TITLE" | sed -nE 's/^([a-z]+)(\([^)]+\))?!?: .*/\1/p')
+
+          if [ -z "$ctype" ]; then
+            echo "::warning::PR title is not Conventional Commits; skipping type label."
+            echo "  title: $PR_TITLE"
+            exit 0
+          fi
+
+          # CC-type → repo label. Aligns with release.yml categories
+          # and the labels declared in infra/github/main.tf.
+          case "$ctype" in
+            feat)                          label="type: feature"  ;;
+            fix)                           label="type: bug"      ;;
+            docs)                          label="type: docs"     ;;
+            refactor|perf)                 label="type: refactor" ;;
+            test)                          label="type: test"     ;;
+            chore|build|ci|revert|style)   label="type: chore"    ;;
+            *)
+              echo "::warning::Unmapped Conventional Commits type '$ctype' in PR title: $PR_TITLE"
+              exit 0
+              ;;
+          esac
+
+          # Remove any other `type: *` label first — the title may
+          # have been edited (e.g. feat → fix), and we want exactly
+          # one `type: *` per PR so release.yml categorises it
+          # deterministically.
+          mapfile -t stale < <(
+            gh pr view "$PR_NUMBER" --repo "$REPO" \
+              --json labels --jq '.labels[].name' \
+              | grep '^type: ' || true
+          )
+          for old in "${stale[@]}"; do
+            [ -z "$old" ] && continue
+            if [ "$old" != "$label" ]; then
+              echo "Removing stale label: $old"
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$old"
+            fi
+          done
+
+          echo "Applying label: $label"
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$label"


### PR DESCRIPTION

The v0.1.0 release notes (just published) showed only the
"Infrastructure & CI" and "Other changes" sections populated —
all the `feat:` / `fix:` / `refactor:` PRs landed in "Other"
because the `type: *` labels release.yml needs were never being
applied. `labeler.yml` (config) only carried path-based
`scope: *` rules + a single `type: docs` heuristic; the
"separate automation" the comment promised for other `type: *`
labels did not actually exist.

This PR completes the mechanical-labelling policy AGENTS.md §4.5
described:

- .github/workflows/labeler.yml: adds an inline gh-CLI step after
  the existing actions/labeler step. Parses the PR title's
  Conventional Commits prefix (`type(scope)?(!)?: subject`) and
  applies the matching `type: *` label. Removes any other
  `type: *` first so a title rename (e.g. feat → fix) lands on
  the correct single label. `edited` added to trigger types so
  title changes refire the step.

  Custom inline step rather than swapping in a third-party
  title-aware labeler (srvaroa/labeler is the obvious candidate
  but its last release is 2025-02 — too quiet to depend on for
  this small a footprint). actions/labeler does not support PR
  title matching natively (only changed-files / branch / head-
  branch / base-branch); head-branch matching does not fit our
  workflow because Sapling's `sl pr submit` auto-generates
  `pr<NUM>` branches that carry no Conventional Commits prefix.

- .github/labeler.yml: kept the existing path rules unchanged.
  `type: docs` stays as a path-based fallback for the rare PR
  that uses a non-`docs:` Conventional Commits type for a
  doc-only change; the title step always wins on conflict (it
  removes any other `type: *` before applying its own).

- .github/release.yml: renamed two categories to be honest about
  what they hold — "Performance" → "Refactoring"
  (`type: refactor` covers both perf and refactor in our
  mapping), "Dependencies" → "Maintenance" (`type: chore`
  is broader than just deps). Added a header note about the
  first-wins ordering and where the upstream labels come from.

Mapping (CC type → repo label):
  feat              → type: feature
  fix               → type: bug
  docs              → type: docs
  refactor | perf   → type: refactor
  test              → type: test
  chore | build | ci | revert | style → type: chore

Forward-only fix — no backfill of historical PR labels. The next
release after this lands will have categorized notes for every
PR with a Conventional Commits title (which commitlint enforces
anyway, so all of them).
