### PR TITLE
fix(ci): pin bunx npm to @latest to avoid ENEEDAUTH on OIDC publish

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -16,13 +16,17 @@ name: publish-mcp
 # after fixing CI plumbing (does not change the version literal).
 #
 # Toolchain: Bun end-to-end. Install / build / test all run on Bun;
-# the npm-side publish goes through `bunx npm publish --provenance`
-# because Bun does not yet support npm OIDC trusted publishing
-# directly (oven-sh/bun#15601, OPEN as of 2026-04). `bunx npm`
-# fetches and runs the npm CLI through Bun without needing a
-# separate Node install — the workflow does not call
-# `actions/setup-node`. JSR publish runs through `bunx jsr publish`,
-# which uses OIDC automatically when `id-token: write` is granted.
+# the npm-side publish goes through `bunx npm@latest publish
+# --provenance` because Bun does not yet support npm OIDC trusted
+# publishing directly (oven-sh/bun#15601, OPEN as of 2026-04).
+# `bunx npm@latest` fetches and runs the npm CLI through Bun without
+# needing a separate Node install — the workflow does not call
+# `actions/setup-node`. The `@latest` tag is load-bearing: bare
+# `bunx npm` resolves a cached older minor (observed 11.13.0) whose
+# trusted-publishing path masks real failures as ENEEDAUTH
+# (npm/cli#9088); pinning to the latest npm avoids that footgun.
+# JSR publish runs through `bunx jsr publish`, which uses OIDC
+# automatically when `id-token: write` is granted.
 
 on:
   push:
@@ -76,7 +80,7 @@ jobs:
           bun run test
 
       - name: Publish to npm (provenance via OIDC trusted publishing, npm CLI run through bunx)
-        run: bunx npm publish --provenance --access public
+        run: bunx npm@latest publish --provenance --access public
         env:
           # Tells the npm CLI which registry to authenticate against; in
           # combination with `id-token: write` permissions and


### PR DESCRIPTION

Bare `bunx npm` resolved a cached npm 11.13.0 in CI whose
trusted-publishing code path masks real failures as ENEEDAUTH
(npm/cli#9088). Pin to `bunx npm@latest publish` so the runner
fetches the current npm CLI (>= 11.14.1 at write time) on every
run. This unblocks the @aletheia-works/vivarium-mcp 0.1.0 publish
that has been failing on the mcp-server-v0.1.0 tag.

No version literal change; package.json / jsr.json stay at 0.1.0.
