### PR TITLE
feat(ci): establish PAT-push branch-fix path via mise tasks

### DIFF
--- a/docs/docs/en/guide/compare-branch-fix.mdx
+++ b/docs/docs/en/guide/compare-branch-fix.mdx
@@ -143,11 +143,11 @@ import {
       items={[
         {
           lead: 'Build and push your branch-fix image.',
-          body: <>Apply the AI's candidate fix to your fork, build a Docker image with the recipe's <code>Dockerfile</code>, and push to a registry the GitHub Actions runner can pull from (a public ghcr.io / Docker Hub repo). The image-as-input boundary is the contract — Vivarium does not build your source, you do.</>,
+          body: <>Apply the AI's candidate fix to your fork, build a Docker image with the recipe's <code>Dockerfile</code>, and push to a registry the GitHub Actions runner can pull from (a public ghcr.io / Docker Hub repo). The image-as-input boundary is the contract — Vivarium does not build your source, you do. The <code>mise run branch-fix:publish</code> task wraps the build / push / logout cycle (see Callout below).</>,
         },
         {
           lead: 'Trigger the comparison workflow.',
-          body: <>Run <code>gh workflow run branch-fix-verdict.yml --repo aletheia-works/vivarium -f slug=&lt;slug&gt; -f branch_image=&lt;your-image-ref&gt;</code>. The workflow pulls your image, runs the reproduction inside it, captures a Contract v1 verdict, and uploads <code>branch-fix-verdict-&lt;slug&gt;-&lt;run_id&gt;</code> as an artefact.</>,
+          body: <>Run <code>mise run branch-fix:verdict &lt;slug&gt; &lt;your-image-ref&gt;</code>, or directly <code>gh workflow run branch-fix-verdict.yml --repo aletheia-works/vivarium -f slug=&lt;slug&gt; -f branch_image=&lt;your-image-ref&gt;</code>. The workflow pulls your image, runs the reproduction inside it, captures a Contract v1 verdict, and uploads <code>branch-fix-verdict-&lt;slug&gt;-&lt;run_id&gt;</code> as an artefact.</>,
         },
         {
           lead: 'Download the artefact zip.',
@@ -159,6 +159,22 @@ import {
         },
       ]}
     />
+    <Callout>
+      <strong>PAT-push helper for huge upstream builds.</strong>{' '}
+      Recipes wrapping projects whose build is too heavy for free-tier
+      GitHub Actions runners (Node.js, Chromium, etc.) need the binary
+      built locally first. Drop a <code>write:packages</code>-scoped{' '}
+      <a href="https://github.com/settings/tokens/new?scopes=write:packages">classic PAT</a>{' '}
+      (ghcr.io does not currently support fine-grained PATs for
+      container-registry auth) into{' '}
+      <code>~/.config/vivarium/ghcr-pat</code> (mode 0600), then{' '}
+      <code>mise run branch-fix:publish &lt;slug&gt; &lt;tag&gt; &lt;dockerfile&gt; &lt;context&gt;</code>{' '}
+      builds, pushes to <code>ghcr.io/&lt;your-user&gt;/vivarium-&lt;slug&gt;-fix:&lt;tag&gt;</code>,
+      and <code>docker logout</code>s — the credential never persists in
+      your docker config and the <code>gh</code> CLI auth state is left
+      untouched. <code>mise run ghcr:login</code> alone walks you through
+      the one-time PAT setup if the file is missing.
+    </Callout>
     <Callout>
       <strong>Agent-driven shortcut.</strong>{' '}
       <code>verify_branch_fix(slug)</code> on a Layer 2/3 slug returns

--- a/docs/docs/ja/guide/compare-branch-fix.mdx
+++ b/docs/docs/ja/guide/compare-branch-fix.mdx
@@ -142,11 +142,11 @@ import {
       items={[
         {
           lead: 'branch-fix イメージをビルドして push する。',
-          body: <>AI の候補修正を fork に当て、レシピの <code>Dockerfile</code> で Docker イメージをビルドし、GitHub Actions ランナーが pull できるレジストリ（公開 ghcr.io / Docker Hub repo）に push する。image-as-input の境界は contract — Vivarium はあなたのソースをビルドしない、あなたが行う。</>,
+          body: <>AI の候補修正を fork に当て、レシピの <code>Dockerfile</code> で Docker イメージをビルドし、GitHub Actions ランナーが pull できるレジストリ（公開 ghcr.io / Docker Hub repo）に push する。image-as-input の境界は contract — Vivarium はあなたのソースをビルドしない、あなたが行う。<code>mise run branch-fix:publish</code> タスクが build / push / logout のサイクルをラップする（下の Callout 参照）。</>,
         },
         {
           lead: '比較ワークフローを trigger する。',
-          body: <><code>gh workflow run branch-fix-verdict.yml --repo aletheia-works/vivarium -f slug=&lt;slug&gt; -f branch_image=&lt;your-image-ref&gt;</code> を実行する。ワークフローはあなたのイメージを pull、その中で再現を走らせ、Contract v1 verdict をキャプチャ、<code>branch-fix-verdict-&lt;slug&gt;-&lt;run_id&gt;</code> をアーティファクトとしてアップロードする。</>,
+          body: <><code>mise run branch-fix:verdict &lt;slug&gt; &lt;your-image-ref&gt;</code>、または直接 <code>gh workflow run branch-fix-verdict.yml --repo aletheia-works/vivarium -f slug=&lt;slug&gt; -f branch_image=&lt;your-image-ref&gt;</code> を実行する。ワークフローはあなたのイメージを pull、その中で再現を走らせ、Contract v1 verdict をキャプチャ、<code>branch-fix-verdict-&lt;slug&gt;-&lt;run_id&gt;</code> をアーティファクトとしてアップロードする。</>,
         },
         {
           lead: 'アーティファクト zip をダウンロード。',
@@ -158,6 +158,22 @@ import {
         },
       ]}
     />
+    <Callout>
+      <strong>巨大 upstream build 用 PAT-push ヘルパー。</strong>{' '}
+      無料 GitHub Actions ランナーには重すぎる upstream プロジェクト
+      （Node.js、Chromium 等）をラップしたレシピは、バイナリをローカルで
+      先にビルドする必要がある。<code>write:packages</code> スコープの{' '}
+      <a href="https://github.com/settings/tokens/new?scopes=write:packages">classic PAT</a>
+      （ghcr.io は現状 container-registry 認証で fine-grained PAT を
+      サポートしていない）を{' '}
+      <code>~/.config/vivarium/ghcr-pat</code>（mode 0600）に置き、{' '}
+      <code>mise run branch-fix:publish &lt;slug&gt; &lt;tag&gt; &lt;dockerfile&gt; &lt;context&gt;</code>{' '}
+      を実行すると、build → <code>ghcr.io/&lt;your-user&gt;/vivarium-&lt;slug&gt;-fix:&lt;tag&gt;</code>{' '}
+      に push → <code>docker logout</code> までやってくれる
+      — 認証情報は docker config に残らず、<code>gh</code> CLI の auth state も
+      触らない。<code>mise run ghcr:login</code> 単体で初回 PAT セットアップ
+      手順が表示される。
+    </Callout>
     <Callout>
       <strong>エージェント駆動のショートカット。</strong> Layer 2/3 の slug に対する
       <code>verify_branch_fix(slug)</code> は、コピペ可能な

--- a/mise.toml
+++ b/mise.toml
@@ -237,6 +237,102 @@ done
 echo "Done. Refresh http://localhost:3000/vivarium/repro/<slug>/ to see captured verdicts."
 '''
 
+# ── Branch-fix publish (Path B, PAT-push) ────────────────────────────────
+#
+# Some Layer 2 recipes wrap an upstream project whose build is too heavy
+# for free-tier GitHub Actions runners (Node.js, Chromium, etc.) — the
+# contributor builds the branch-fix image locally and pushes to their
+# own ghcr.io namespace before triggering branch-fix-verdict.yml.
+#
+# These tasks read a PAT from a per-user file (default
+# `${XDG_CONFIG_HOME:-~/.config}/vivarium/ghcr-pat`, mode 0600) and feed
+# it to `docker login --password-stdin`, then `docker logout` after the
+# push so the credential is never persisted in the docker config. The
+# `gh` CLI auth state is never touched — branch-fix push uses a
+# write:packages-scoped classic PAT, distinct from the all-purpose
+# `gh` token. (ghcr.io does not currently support fine-grained PATs
+# for container-registry auth, so a classic PAT is the only option.)
+
+[tasks."ghcr:login"]
+description = "Log in to ghcr.io using a write:packages-scoped PAT file (does not touch gh CLI auth state)"
+shell = "bash -c"
+run = '''
+set -euo pipefail
+pat_file="${VIVARIUM_GHCR_PAT_FILE:-${XDG_CONFIG_HOME:-$HOME/.config}/vivarium/ghcr-pat}"
+if [ ! -f "$pat_file" ]; then
+  cat <<EOF >&2
+ghcr.io PAT file not found: $pat_file
+
+One-time setup (ghcr.io requires a CLASSIC PAT; fine-grained PATs are
+not supported for container-registry auth as of this writing — see
+https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry):
+
+  1. https://github.com/settings/tokens/new?scopes=write:packages
+     - Note: e.g. "vivarium-ghcr-push"
+     - Expiration: 30 days (or shorter)
+     - Scopes: write:packages (auto-includes read:packages)
+  2. mkdir -p "\$(dirname "$pat_file")"
+  3. printf '%s' '<paste-token>' > "$pat_file" && chmod 600 "$pat_file"
+
+The file is read at push time only; the credential is dropped from the
+docker config immediately after \`branch-fix:publish\` completes.
+EOF
+  exit 1
+fi
+user="${GHCR_USER:-$(gh api user --jq .login 2>/dev/null || true)}"
+[ -z "$user" ] && { echo "Set GHCR_USER=<username> or run 'gh auth login'." >&2; exit 1; }
+docker login ghcr.io -u "$user" --password-stdin < "$pat_file"
+'''
+
+[tasks."branch-fix:publish"]
+description = "Build a branch-fix image and push to ghcr.io/<user>/vivarium-<slug>-fix:<tag>; auto-logout after push"
+depends = ["ghcr:login"]
+shell = "bash -c"
+usage = '''
+arg "<slug>"       help="recipe slug under src/layer2_docker/ (e.g. node-63041)"
+arg "<tag>"        help="image tag, typically the fix commit SHA (e.g. 04d86dab)"
+arg "<dockerfile>" help="path to the branch-fix Dockerfile"
+arg "<context>"    help="docker build context dir"
+'''
+run = '''
+set -euo pipefail
+slug="{{usage.slug}}"
+tag="{{usage.tag}}"
+dockerfile="{{usage.dockerfile}}"
+context="{{usage.context}}"
+user="${GHCR_USER:-$(gh api user --jq .login)}"
+img="ghcr.io/${user,,}/vivarium-${slug}-fix:${tag}"
+echo "==> docker build $img"
+docker build -t "$img" -f "$dockerfile" "$context"
+echo "==> docker push $img"
+docker push "$img"
+docker logout ghcr.io
+echo "$img"
+'''
+
+[tasks."branch-fix:verdict"]
+description = "Trigger aletheia-works/vivarium branch-fix-verdict.yml against a published image (thin wrapper over `gh workflow run`)"
+shell = "bash -c"
+usage = '''
+arg "<slug>"  help="recipe slug under src/layer2_docker/"
+arg "<image>" help="published image ref (e.g. ghcr.io/<user>/vivarium-<slug>-fix:<sha>)"
+flag "--expected <verdict>" help="expected branch-fix verdict (default: unreproduced)" default="unreproduced"
+'''
+run = '''
+set -euo pipefail
+slug="{{usage.slug}}"
+image="{{usage.image}}"
+expected="{{usage.expected}}"
+gh workflow run branch-fix-verdict.yml \
+  --repo aletheia-works/vivarium \
+  --field "slug=${slug}" \
+  --field "branch_image=${image}" \
+  --field "expected_verdict=${expected}"
+echo "Triggered. Tail with:"
+echo "  gh run list --repo aletheia-works/vivarium --workflow=branch-fix-verdict.yml --limit 1"
+echo "  gh run watch --repo aletheia-works/vivarium <run-id>"
+'''
+
 # ── Recipes catalogue index ──────────────────────────────────────────────
 
 [tasks."recipes:index"]


### PR DESCRIPTION

Some Layer 2 recipes wrap an upstream project whose build is too heavy
for free-tier GitHub Actions runners (Node.js — 60+ min on 8 vCPU,
Chromium, etc.). For those, the contributor must build the branch-fix
image locally and push to GHCR before triggering branch-fix-verdict.yml.
The pre-existing instructions amounted to "use a PAT with docker login"
— friction high enough that the path was effectively unused.

Adds three thin mise tasks:

- `ghcr:login` reads a write:packages-scoped classic PAT from
  `${VIVARIUM_GHCR_PAT_FILE:-${XDG_CONFIG_HOME:-~/.config}/vivarium/ghcr-pat}`
  (mode 0600) and feeds it to `docker login --password-stdin`. The
  `gh` CLI auth state is never touched — branch-fix push uses a
  registry-scoped PAT, distinct from the all-purpose `gh` token.
  ghcr.io does not currently support fine-grained PATs for
  container-registry auth, so a classic PAT is the only option.
- `branch-fix:publish <slug> <tag> <dockerfile> <context>` chains
  ghcr:login -> docker build -> docker push -> docker logout, so the
  PAT credential is dropped from the docker config immediately after
  use. Pushes to ghcr.io/<user>/vivarium-<slug>-fix:<tag>.
- `branch-fix:verdict <slug> <image> [--expected]` is a thin wrapper
  around \`gh workflow run branch-fix-verdict.yml\` for symmetry with
  the build/push half.

Updates docs/docs/{en,ja}/guide/compare-branch-fix.mdx with a
"PAT-push helper for huge upstream builds" callout next to the
existing Path B steps.

Composes with ADR-0020 §1 (image-as-input boundary) — the contract
that Vivarium does not build contributor source is unchanged; the
mise tasks only ergonomicize the contributor side of that boundary.
