### PR TITLE
feat(wasm): add layer 1 reproduction for pylint-dev/astroid#2993

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -9,7 +9,7 @@
     },
     {
       "name": "vivarium-layer1",
-      "runtimeExecutable": "C:\\Users\\Jam\\AppData\\Local\\mise\\installs\\uv\\0.11.11\\uv.exe",
+      "runtimeExecutable": "C:\\Users\\Jam\\AppData\\Local\\mise\\installs\\uv\\0.11.12\\uv.exe",
       "runtimeArgs": ["run", "--no-project", "--python", "3.13", "python", "-m", "http.server", "8767", "--directory", "src/layer1_wasm"],
       "port": 8767
     }

--- a/docs/data/projects.json
+++ b/docs/data/projects.json
@@ -1,6 +1,13 @@
 {
   "$comment": "Project-level metadata overlay for /repro/<project>/ landing pages. Hand-curated and reviewed in PR diff, mirroring the recipe-facets.json convention from ADR-0024 §1. Project keys must match the `project` field generate-recipes-index.ts derives from each recipe slug. Recipes whose project has no row here fall back to slug-as-display-name with no description.",
   "projects": {
+    "astroid": {
+      "display_name": "astroid",
+      "tagline": "AST library that powers pylint.",
+      "description": "Reproductions install astroid from PyPI via micropip into the Pyodide build that ships in the browser; pages also publish a CLI repro.py that runs against a host CPython pinned via mise.",
+      "homepage": "https://pylint.readthedocs.io/projects/astroid/",
+      "github": "https://github.com/pylint-dev/astroid"
+    },
     "cpython": {
       "display_name": "CPython",
       "tagline": "The reference Python interpreter.",

--- a/docs/data/recipe-facets.json
+++ b/docs/data/recipe-facets.json
@@ -1,6 +1,12 @@
 {
   "$comment": "Per-recipe facet overlay for the gallery. Per ADR-0024 §1: hand-curated, reviewed in PR diff, scales to ~50 rows. New recipe → add a row here AND in docs/docs/{en,ja}/repro/index.mdx's table fallback.",
   "facets": {
+    "astroid-2993": {
+      "language": "python",
+      "symptom": "memory-error-on-fuzzed-input",
+      "severity": "crash",
+      "tags": ["ast", "type-comment", "fuzzing", "oss-fuzz"]
+    },
     "cpython-137205": {
       "language": "python",
       "symptom": "fk-pragma-silently-dropped",

--- a/docs/public/api/projects.json
+++ b/docs/public/api/projects.json
@@ -2,6 +2,19 @@
   "index": "v1",
   "projects": [
     {
+      "project": "astroid",
+      "display_name": "astroid",
+      "recipe_count": 1,
+      "layers": [
+        1
+      ],
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/astroid/",
+      "tagline": "AST library that powers pylint.",
+      "description": "Reproductions install astroid from PyPI via micropip into the Pyodide build that ships in the browser; pages also publish a CLI repro.py that runs against a host CPython pinned via mise.",
+      "homepage": "https://pylint.readthedocs.io/projects/astroid/",
+      "github": "https://github.com/pylint-dev/astroid"
+    },
+    {
       "project": "bash",
       "display_name": "bash",
       "recipe_count": 1,

--- a/docs/public/api/recipes.json
+++ b/docs/public/api/recipes.json
@@ -3,6 +3,24 @@
   "contract": "v1",
   "recipes": [
     {
+      "slug": "astroid-2993",
+      "layer": 1,
+      "project": "astroid",
+      "issue": 2993,
+      "title": "pylint-dev/astroid#2993",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/astroid/2993/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/astroid-2993",
+      "language": "python",
+      "tags": [
+        "ast",
+        "type-comment",
+        "fuzzing",
+        "oss-fuzz"
+      ],
+      "symptom": "memory-error-on-fuzzed-input",
+      "severity": "crash"
+    },
+    {
       "slug": "cpython-137205",
       "layer": 1,
       "project": "cpython",

--- a/mise.toml
+++ b/mise.toml
@@ -162,6 +162,7 @@ run = '''
 mise exec uv -- uv run --python 3.13 src/layer1_wasm/pandas-56679/repro.py
 mise exec uv -- uv run --python 3.13 src/layer1_wasm/numpy-28287/repro.py
 mise exec uv -- uv run --python 3.13 src/layer1_wasm/cpython-137205/repro.py
+mise exec uv -- uv run --python 3.13 src/layer1_wasm/astroid-2993/repro.py
 '''
 
 [tasks."repro:native:ruby"]

--- a/src/layer1_wasm/astroid-2993/README.md
+++ b/src/layer1_wasm/astroid-2993/README.md
@@ -1,0 +1,102 @@
+# Reproduction — pylint-dev/astroid#2993
+
+> Layer 1 reproduction page — first entry in Vivarium's Layer 1
+> Pyodide gallery to install a third-party Python package via
+> `micropip` (astroid is not bundled in Pyodide's package set).
+> Conforms to `vivarium-contract: v1`.
+
+## The bug
+
+[pylint-dev/astroid#2993](https://github.com/pylint-dev/astroid/issues/2993)
+— `astroid.builder.parse(code)` raises an unhandled `MemoryError`
+(or `RecursionError`, depending on the runtime) when fed a fuzzed
+type comment whose value is `i` followed by a long run of `{`
+characters:
+
+```python
+import astroid
+code = "a=b # type:i" + "{" * 270
+astroid.builder.parse(code)
+# MemoryError (or RecursionError) — propagates out of `parse`
+```
+
+The fuzzed input is from OSS-Fuzz; the upstream issue references the
+internal report at <https://issues.oss-fuzz.com/issues/489780714>.
+CPython's compiler walks the type-comment expression recursively and
+either runs out of stack or memory; astroid does not catch the
+runtime error in its type-comment parser, so the exception
+propagates out of `parse` and crashes any tool built on it (pylint,
+IDE plugins, etc.).
+
+The expected fix mirrors astroid's #2762 fix for f-strings (shipped
+in 4.1.2): catch `MemoryError`/`RecursionError` in the type-comment
+parser and treat the comment as opaque.
+
+## Why this bug
+
+- Pure Python — astroid has only one required dependency
+  (`typing-extensions`, already bundled by Pyodide). No native
+  extensions, no I/O, no thread-scheduler dependence.
+- Reproduction is a single `astroid.builder.parse(code)` call;
+  verdict reduces to a boolean (did `parse` raise an unhandled
+  runtime error or not).
+- Reported against astroid 4.1.x. Latest release at authoring time
+  is 4.1.2 (2026-03-22) and the bug still reproduces there; pinning
+  in PEP 723 / `repro.ts` to that exact version locks the verdict
+  to a known-bad build, so the page flips to `unreproduced` only
+  when a new astroid release lands an actual fix.
+- Demonstrates Vivarium handles bugs in upstream projects whose
+  packages are not pre-bundled in Pyodide — the page installs
+  astroid from PyPI via `micropip` after the runtime bootstraps.
+
+## Files
+
+| File         | Role                                                              |
+| ------------ | ----------------------------------------------------------------- |
+| `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
+| `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
+| `repro.py`   | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. PEP 723 inline metadata pins `astroid==4.1.2`. |
+
+## Verdict contract — `vivarium-contract: v1`
+
+The page conforms to the contract canonicalised in
+[`../_shared/verdict.ts`](../_shared/verdict.ts). The `result` field
+of the envelope reports `nested_braces`, `exception_type`, and
+`crashed`.
+
+A `reproduced` verdict means **the bug reproduced** —
+`astroid.builder.parse` raised an unhandled `MemoryError` /
+`RecursionError` (or any non-`AstroidSyntaxError`). An
+`unreproduced` verdict means either upstream landed a graceful catch
+(`AstroidSyntaxError` or clean return), or the runtime errored
+before producing a result.
+
+## Running locally — in-browser
+
+```bash
+cd src/layer1_wasm
+bun install
+bun run build
+python -m http.server -d . 8767
+# open http://localhost:8767/astroid-2993/
+```
+
+The page first preloads `micropip`, then installs `astroid==4.1.2`
+from PyPI on the visitor's machine before running the reproduction.
+First-visit cold load is slower than recipes that exercise only
+Pyodide-bundled packages.
+
+## Native verification — same reproduction under a real CPython
+
+```bash
+mise install
+mise exec uv -- uv run src/layer1_wasm/astroid-2993/repro.py
+# verdict=reproduced — astroid.builder.parse raised MemoryError on a fuzzed type comment
+```
+
+## Deployment
+
+Published to GitHub Pages at
+`https://aletheia-works.github.io/vivarium/repro/astroid/2993/` by
+the `deploy-docs` workflow.

--- a/src/layer1_wasm/astroid-2993/index.html
+++ b/src/layer1_wasm/astroid-2993/index.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="vivarium-contract" content="v1" />
+    <title>Vivarium · Reproducing pylint-dev/astroid#2993</title>
+    <!-- vivarium-chrome-injected -->
+    <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.asm.wasm" as="fetch" type="application/wasm" crossorigin />
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/python_stdlib.zip" as="fetch" crossorigin />
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide-lock.json" as="fetch" type="application/json" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <!-- Keep the version below in sync with DEFAULT_PYODIDE_VERSION in
+         ../_shared/loader.ts. -->
+    <link
+      rel="modulepreload"
+      href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.mjs"
+      crossorigin
+    />
+    <link rel="stylesheet" href="../_shared/style.css" />
+    <template id="bug-context">
+      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <div class="vh-drawer__body" id="vh-drawer-body">
+        <p>
+          A fuzzed type comment such as
+          <code>a=b # type:i{{{...{{</code> — `i` followed by a long
+          run of <code>{</code> characters — makes
+          <code>astroid.builder.parse</code> raise an unhandled
+          <code>MemoryError</code> (or <code>RecursionError</code>,
+          depending on the runtime). The crash propagates out of any
+          tool built on astroid, including pylint and most IDE
+          plugins.
+        </p>
+        <p>
+          The script on this page installs astroid into Pyodide via
+          <code>micropip</code>, feeds it the fuzzed input, and
+          watches for an unhandled exception. If
+          <code>astroid.builder.parse</code> raises anything other
+          than <code>AstroidSyntaxError</code>, the bug reproduces in
+          the runtime currently loaded in your browser tab.
+        </p>
+        <p>
+          The expected fix mirrors astroid's #2762 fix for f-strings
+          (shipped in 4.1.2): catch
+          <code>MemoryError</code>/<code>RecursionError</code> in the
+          type-comment parser and treat the comment as opaque. The
+          full discussion lives in the GitHub issue thread linked
+          below.
+        </p>
+      </div>
+      <hr class="vh-drawer__divider" />
+      <div class="vh-drawer__meta-grid">
+        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-val">pylint-dev/astroid</span>
+        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-val">#2993</span>
+        <span class="vh-drawer__meta-key">Layer</span>
+        <span class="vh-drawer__meta-val">L1 · WASM</span>
+        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-val">Pyodide v0.29.3</span>
+      </div>
+    </template>
+  </head>
+  <body>
+    <main class="vh-main">
+      <header class="vh-main__header">
+        <div class="vh-main__header-text">
+          <p class="kicker">L1 · Pyodide · astroid</p>
+          <h1>Reproducing <a href="https://github.com/pylint-dev/astroid/issues/2993">pylint-dev/astroid#2993</a></h1>
+          <div class="vh-main__header-actions">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+              Bug context
+            </button>
+            <a class="vh-chip" href="https://github.com/pylint-dev/astroid/issues/2993" target="_blank" rel="noreferrer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              Upstream issue
+            </a>
+          </div>
+        </div>
+        <div class="vh-main__header-aside">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+            Loading Pyodide runtime…
+          </div>
+          <p class="meta" id="meta"></p>
+        </div>
+      </header>
+
+      <div class="vh-main__cols">
+        <section class="vh-main__col vh-main__col--script">
+          <h2>Reproduction script</h2>
+          <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> astroid</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#79B8FF">NESTED</span><span style="color:#F97583"> =</span><span style="color:#79B8FF"> 270</span></span>
+<span class="line"><span style="color:#E1E4E8">code </span><span style="color:#F97583">=</span><span style="color:#9ECBFF"> "a=b # type:i"</span><span style="color:#F97583"> +</span><span style="color:#9ECBFF"> "{"</span><span style="color:#F97583"> *</span><span style="color:#79B8FF"> NESTED</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">result </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span style="color:#9ECBFF">    "astroid_version"</span><span style="color:#E1E4E8">: astroid.</span><span style="color:#79B8FF">__version__</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "python_version"</span><span style="color:#E1E4E8">: sys.version.split()[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
+<span class="line"><span style="color:#9ECBFF">    "nested_braces"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">NESTED</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "exception_type"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">None</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "exception_message"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">None</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "crashed"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">False</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">try</span><span style="color:#E1E4E8">:</span></span>
+<span class="line"><span style="color:#E1E4E8">    astroid.builder.parse(code)</span></span>
+<span class="line"><span style="color:#F97583">except</span><span style="color:#E1E4E8"> astroid.exceptions.AstroidSyntaxError </span><span style="color:#F97583">as</span><span style="color:#E1E4E8"> e:</span></span>
+<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"exception_type"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#9ECBFF"> "AstroidSyntaxError"</span></span>
+<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"exception_message"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> str</span><span style="color:#E1E4E8">(e)[:</span><span style="color:#79B8FF">200</span><span style="color:#E1E4E8">]</span></span>
+<span class="line"><span style="color:#F97583">except</span><span style="color:#E1E4E8"> (</span><span style="color:#79B8FF">MemoryError</span><span style="color:#E1E4E8">, </span><span style="color:#79B8FF">RecursionError</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">as</span><span style="color:#E1E4E8"> e:</span></span>
+<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"exception_type"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> type</span><span style="color:#E1E4E8">(e).</span><span style="color:#79B8FF">__name__</span></span>
+<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"exception_message"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> str</span><span style="color:#E1E4E8">(e)[:</span><span style="color:#79B8FF">200</span><span style="color:#E1E4E8">]</span></span>
+<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"crashed"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> True</span></span>
+<span class="line"><span style="color:#F97583">except</span><span style="color:#79B8FF"> Exception</span><span style="color:#F97583"> as</span><span style="color:#E1E4E8"> e:</span></span>
+<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"exception_type"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> type</span><span style="color:#E1E4E8">(e).</span><span style="color:#79B8FF">__name__</span></span>
+<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"exception_message"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> str</span><span style="color:#E1E4E8">(e)[:</span><span style="color:#79B8FF">200</span><span style="color:#E1E4E8">]</span></span>
+<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"crashed"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> True</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">result</span></span></code></pre>
+        </section>
+
+        <section class="vh-main__col vh-main__col--output">
+          <h2>Output</h2>
+          <pre id="output">(running)</pre>
+        </section>
+      </div>
+
+    </main>
+
+    <script type="module" src="./repro.js"></script>
+  </body>
+</html>

--- a/src/layer1_wasm/astroid-2993/repro.py
+++ b/src/layer1_wasm/astroid-2993/repro.py
@@ -1,0 +1,90 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#   "astroid==4.1.2",
+# ]
+# ///
+"""Vivarium Layer 1 reproduction — pylint-dev/astroid#2993, native variant.
+
+Mirrors the script that runs in `repro.ts` (under Pyodide) so a
+contributor can re-verify the bug against a real CPython interpreter
++ a real astroid build:
+
+    mise install                                                    # one-time
+    mise exec uv -- uv run src/layer1_wasm/astroid-2993/repro.py
+
+PEP 723 inline metadata pins **astroid 4.1.2** — the latest release at
+authoring time. `uv run` reads the metadata and creates an ephemeral
+venv on first invocation; subsequent runs hit uv's cache.
+
+The fuzzed input is a single-line assignment with a type comment
+``# type:i{{{...{{`` whose value is `i` followed by a long run of
+``{`` characters. CPython's compiler walks the type-comment expression
+recursively and either runs out of stack (RecursionError) or memory
+(MemoryError); astroid does not catch either, so the exception
+propagates out of ``astroid.builder.parse``. The expected fix —
+mirroring the f-string fix in #2762 / 4.1.2 — is for astroid to catch
+the runtime error in its type-comment parser and treat the comment as
+opaque.
+
+Exits 0 on `pass` (bug REPRODUCED — astroid raised), 1 on `fail` (bug
+not reproduced — astroid returned cleanly or raised the expected
+``AstroidSyntaxError``).
+"""
+
+import json
+import sys
+
+import astroid
+
+# ~270 nested `{` mirrors the fuzz from the upstream issue; in CPython
+# 3.13 this exceeds the compiler's stack budget. Pyodide WASM hits the
+# same threshold because it uses the same CPython source.
+NESTED = 270
+CODE = "a=b # type:i" + "{" * NESTED
+
+result = {
+    "astroid_version": astroid.__version__,
+    "python_version": sys.version.split()[0],
+    "nested_braces": NESTED,
+    "exception_type": None,
+    "exception_message": None,
+    "crashed": False,
+}
+
+try:
+    astroid.builder.parse(CODE)
+except astroid.exceptions.AstroidSyntaxError as e:
+    # Graceful: astroid wrapped the underlying SyntaxError in its own
+    # exception type. Not the bug.
+    result["exception_type"] = "AstroidSyntaxError"
+    result["exception_message"] = str(e)[:200]
+except (MemoryError, RecursionError) as e:
+    # The bug: astroid leaked the underlying CPython runtime error
+    # instead of catching it the way #2762 / 4.1.2 did for f-strings.
+    result["exception_type"] = type(e).__name__
+    result["exception_message"] = str(e)[:200]
+    result["crashed"] = True
+except Exception as e:
+    # Any other unhandled exception is also the bug — astroid should
+    # not surface arbitrary parser errors to its callers.
+    result["exception_type"] = type(e).__name__
+    result["exception_message"] = str(e)[:200]
+    result["crashed"] = True
+
+print(json.dumps(result, indent=2))
+
+if result["crashed"]:
+    print(
+        f"verdict=reproduced — astroid.builder.parse raised "
+        f"{result['exception_type']} on a fuzzed type comment",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+else:
+    print(
+        "verdict=unreproduced — astroid handled the fuzzed type comment "
+        "without an unhandled runtime error (likely fixed upstream)",
+        file=sys.stderr,
+    )
+    sys.exit(1)

--- a/src/layer1_wasm/astroid-2993/repro.ts
+++ b/src/layer1_wasm/astroid-2993/repro.ts
@@ -1,0 +1,234 @@
+// Vivarium Layer 1 reproduction — pylint-dev/astroid#2993.
+//
+// `astroid.builder.parse(code)` raises an unhandled `MemoryError` (or
+// `RecursionError`, depending on the runtime) when fed a fuzzed type
+// comment like `a=b # type:i{{{{...{{`. CPython's compiler walks the
+// type-comment expression recursively; astroid does not catch the
+// runtime error, so it propagates out of `parse` and crashes any
+// caller (pylint, IDE plugins, etc.).
+//
+// The expected fix mirrors astroid's #2762 fix for f-strings (shipped
+// in 4.1.2): catch `MemoryError`/`RecursionError` in the type-comment
+// parser and treat the comment as opaque.
+//
+// Verdict semantics (per ADR-0008 / contract v1):
+//   - "reproduced" — `astroid.builder.parse` raised an unhandled
+//     `MemoryError` / `RecursionError` (or any non-`AstroidSyntaxError`).
+//   - "unreproduced" — `parse` returned cleanly, or raised
+//     `AstroidSyntaxError` (which would mean upstream landed a
+//     graceful catch).
+//
+// astroid is **not** in Pyodide's bundled package set, so we install
+// it via `micropip` after the Pyodide bootstrap. Its only required
+// dep — `typing-extensions` — is already bundled, so the install is
+// a single pure-Python wheel from PyPI.
+
+import { loadVivariumPyodide } from '../_shared/loader.js';
+import type { PathACapturedRun } from '../_shared/path_a.js';
+import { enableRunner } from '../_shared/runner.js';
+import {
+  setResult,
+  setVerdict,
+  type VivariumResultV1,
+} from '../_shared/verdict.js';
+
+// 270 nested `{` mirrors the fuzz from the upstream issue. The exact
+// threshold at which CPython's compiler runs out of stack is
+// implementation-dependent; 270 reproduces reliably on the Python
+// 3.13 build Pyodide v0.29.3 ships. Hardcoded inside the template
+// literal so the build-time syntax highlighter (which does not
+// expand ${…} substitutions) renders the source visitors run.
+const REPRO_CODE = `
+import sys
+import astroid
+
+NESTED = 270
+code = "a=b # type:i" + "{" * NESTED
+
+result = {
+    "astroid_version": astroid.__version__,
+    "python_version": sys.version.split()[0],
+    "nested_braces": NESTED,
+    "exception_type": None,
+    "exception_message": None,
+    "crashed": False,
+}
+
+try:
+    astroid.builder.parse(code)
+except astroid.exceptions.AstroidSyntaxError as e:
+    result["exception_type"] = "AstroidSyntaxError"
+    result["exception_message"] = str(e)[:200]
+except (MemoryError, RecursionError) as e:
+    result["exception_type"] = type(e).__name__
+    result["exception_message"] = str(e)[:200]
+    result["crashed"] = True
+except Exception as e:
+    result["exception_type"] = type(e).__name__
+    result["exception_message"] = str(e)[:200]
+    result["crashed"] = True
+
+result
+`.trim();
+
+interface ReproOutput {
+  astroid_version: string;
+  python_version: string;
+  nested_braces: number;
+  exception_type: string | null;
+  exception_message: string | null;
+  crashed: boolean;
+}
+
+interface PyodideRuntime {
+  runPythonAsync(code: string): Promise<{
+    toJs(opts: { dict_converter: typeof Object.fromEntries }): ReproOutput;
+    destroy?(): void;
+  }>;
+}
+
+const outputEl = document.getElementById('output');
+const metaEl = document.getElementById('meta');
+const reproCodeEl = document.getElementById('repro-code');
+
+if (!outputEl || !metaEl || !reproCodeEl) {
+  throw new Error(
+    'astroid-2993: missing required DOM elements (#output, #meta, #repro-code).',
+  );
+}
+
+if (!reproCodeEl.firstChild) {
+  reproCodeEl.textContent = REPRO_CODE;
+  fetch('./repro.highlighted.html')
+    .then((r) => (r.ok ? r.text() : null))
+    .then((html) => {
+      if (html) reproCodeEl.innerHTML = html;
+    })
+    .catch(() => {});
+}
+
+function evaluate(result: ReproOutput): {
+  verdict: 'reproduced' | 'unreproduced';
+  message: string;
+} {
+  if (result.crashed) {
+    return {
+      verdict: 'reproduced',
+      message: `bug reproduced — astroid.builder.parse raised ${result.exception_type} on a fuzzed type comment.`,
+    };
+  }
+  return {
+    verdict: 'unreproduced',
+    message:
+      'bug not reproduced — astroid handled the fuzzed type comment without an unhandled runtime error.',
+  };
+}
+
+async function captureRun(
+  runtime: PyodideRuntime,
+  source: string,
+): Promise<PathACapturedRun> {
+  try {
+    const proxy = await runtime.runPythonAsync(source);
+    const result = proxy.toJs({ dict_converter: Object.fromEntries });
+    proxy.destroy?.();
+    const ev = evaluate(result);
+    return {
+      exitCode: 0,
+      verdict: ev.verdict,
+      message: ev.message,
+      stdout: JSON.stringify(result, null, 2),
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      exitCode: 1,
+      verdict: 'unreproduced',
+      message: `runtime error: ${message}`,
+      stdout: message,
+    };
+  }
+}
+
+const startedAt = new Date();
+
+try {
+  // micropip is bundled with Pyodide; astroid + typing-extensions are
+  // pulled from PyPI on first run. typing-extensions is already in the
+  // Pyodide package set so micropip resolves it without a download.
+  const { pyodide, version } = await loadVivariumPyodide({
+    packages: ['micropip'],
+    pendingText: 'Loading Pyodide runtime and micropip…',
+  });
+
+  setVerdict('pending', 'Installing astroid from PyPI…');
+  const runtime = pyodide as PyodideRuntime;
+  await runtime.runPythonAsync(`
+import micropip
+await micropip.install("astroid==4.1.2")
+`);
+
+  setVerdict('pending', 'Running reproduction script…');
+  const baseline = await captureRun(runtime, REPRO_CODE);
+
+  let baselineResult: ReproOutput | null = null;
+  try {
+    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
+  } catch {
+    outputEl.textContent = baseline.stdout;
+    setVerdict(baseline.verdict, baseline.message);
+    throw new Error(baseline.message);
+  }
+
+  metaEl.textContent =
+    `astroid ${baselineResult.astroid_version} on Python ${baselineResult.python_version} ` +
+    `via Pyodide v${version}.`;
+  outputEl.textContent = baseline.stdout;
+  setVerdict(baseline.verdict, baseline.message);
+
+  const finishedAt = new Date();
+  const envelope: VivariumResultV1 = {
+    contract: 'v1',
+    bug: {
+      project: 'astroid',
+      issue: 2993,
+      upstream_url: 'https://github.com/pylint-dev/astroid/issues/2993',
+    },
+    runtime: {
+      name: 'pyodide',
+      version,
+      extras: {
+        python: baselineResult.python_version,
+        astroid: baselineResult.astroid_version,
+      },
+    },
+    result: {
+      nested_braces: baselineResult.nested_braces,
+      exception_type: baselineResult.exception_type,
+      crashed: baselineResult.crashed,
+    },
+    timing: {
+      started_at: startedAt.toISOString(),
+      finished_at: finishedAt.toISOString(),
+      duration_ms: finishedAt.getTime() - startedAt.getTime(),
+    },
+  };
+  setResult(envelope);
+
+  enableRunner({
+    slug: 'astroid-2993',
+    baselineSource: REPRO_CODE,
+    runFix: (source) => captureRun(runtime, source),
+  });
+} catch (err: unknown) {
+  console.error(err);
+  const errAny = err as { stack?: string; message?: string } | null;
+  outputEl.textContent =
+    (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
+  if (globalThis.__VIVARIUM_VERDICT__ !== 'unreproduced') {
+    setVerdict(
+      'unreproduced',
+      `bug not reproduced — runtime error: ${errAny?.message ?? String(err)}`,
+    );
+  }
+}

--- a/src/layer1_wasm/scripts/highlight-repros.ts
+++ b/src/layer1_wasm/scripts/highlight-repros.ts
@@ -53,6 +53,7 @@ const LAYER1_DIR = dirname(SCRIPT_DIR);
 // before the first hyphen identifies the project, which in turn pins
 // the source language for Layer 1 recipes.
 const LANG_BY_PROJECT: Record<string, BundledLanguage> = {
+  astroid: 'python',
   cpython: 'python',
   numpy: 'python',
   pandas: 'python',

--- a/src/layer1_wasm/tests/repro.spec.ts
+++ b/src/layer1_wasm/tests/repro.spec.ts
@@ -70,6 +70,14 @@ const cases: ReproCase[] = [
     expectedRuntimeName: "pyodide",
   },
   {
+    name: "astroid-2993 reproduction",
+    url: `${LAYER1}/astroid-2993/`,
+    expectedVerdict: "reproduced",
+    expectedBugProject: "astroid",
+    expectedBugIssue: 2993,
+    expectedRuntimeName: "pyodide",
+  },
+  {
     name: "numpy-28287 reproduction",
     url: `${LAYER1}/numpy-28287/`,
     expectedVerdict: "reproduced",


### PR DESCRIPTION

`astroid.builder.parse(code)` raises an unhandled MemoryError /
RecursionError on a fuzzed type comment whose value is `i` followed
by ~270 nested `{` characters. The crash propagates out of any
tool built on astroid (pylint, IDE plugins, etc.).

Recipe surface:

- src/layer1_wasm/astroid-2993/{index.html,repro.ts,repro.py,README.md}
- Pyodide v0.29.3 / Python 3.13.2 / astroid 4.1.2; first Layer 1
  recipe to install a third-party package via micropip
- verdict=reproduced — captures `MemoryError: Parser stack overflowed`

Wiring:

- docs/data/recipe-facets.json + projects.json — astroid rows added
- docs/public/api/{recipes,projects}.json — regenerated via
  `bun run generate-index` + `generate-project-pages`
- src/layer1_wasm/scripts/highlight-repros.ts — `astroid: 'python'`
  added to LANG_BY_PROJECT
- src/layer1_wasm/tests/repro.spec.ts — Playwright case added
- mise.toml `repro:native:python` — appends repro.py invocation

Drive-by:

- .claude/launch.json — bump pinned uv install path from 0.11.11 to
  0.11.12 so `preview_start { name: "vivarium-layer1" }` resolves on
  the current local mise install (the prior 0.11.11 directory has
  rolled forward and ENOENTs at preview-spawn time).

Verified locally via Preview MCP at http://localhost:8767/astroid-2993/:
contract=v1, verdict=reproduced, runtime.name=pyodide,
bug.project=astroid, bug.issue=2993, no console errors.
