### PR TITLE
feat(wasm): add layer 1 reproduction for mpmath/mpmath#983

### DIFF
--- a/docs/data/projects.json
+++ b/docs/data/projects.json
@@ -50,6 +50,13 @@
       "homepage": "https://docs.rs/regex/",
       "github": "https://github.com/rust-lang/regex"
     },
+    "mpmath": {
+      "display_name": "mpmath",
+      "tagline": "Pure-Python arbitrary-precision arithmetic.",
+      "description": "Numerical-stability bugs that survive when mpmath is installed into Pyodide via micropip. The browser page and the host-Python repro.py share the exact same script and the same pinned wheel.",
+      "homepage": "https://mpmath.org/",
+      "github": "https://github.com/mpmath/mpmath"
+    },
     "bash": {
       "display_name": "bash",
       "tagline": "GNU bash and POSIX shell semantics.",

--- a/docs/data/recipe-facets.json
+++ b/docs/data/recipe-facets.json
@@ -49,6 +49,12 @@
       "severity": "footgun",
       "tags": ["bash", "command-substitution", "exit-code"]
     },
+    "mpmath-983": {
+      "language": "python",
+      "symptom": "solver-asymmetry-on-nonsingular-matrix",
+      "severity": "bug",
+      "tags": ["numerical-linear-algebra", "qr-solve", "householder", "arbitrary-precision"]
+    },
     "find-xargs-whitespace": {
       "language": "shell",
       "symptom": "whitespace-unsafe-pipeline",

--- a/docs/data/recipe-facets.json
+++ b/docs/data/recipe-facets.json
@@ -53,7 +53,12 @@
       "language": "python",
       "symptom": "solver-asymmetry-on-nonsingular-matrix",
       "severity": "bug",
-      "tags": ["numerical-linear-algebra", "qr-solve", "householder", "arbitrary-precision"]
+      "tags": [
+        "numerical-linear-algebra",
+        "qr-solve",
+        "householder",
+        "arbitrary-precision"
+      ]
     },
     "find-xargs-whitespace": {
       "language": "shell",

--- a/docs/public/api/projects.json
+++ b/docs/public/api/projects.json
@@ -67,6 +67,19 @@
       "github": "https://github.com/util-linux/util-linux"
     },
     {
+      "project": "mpmath",
+      "display_name": "mpmath",
+      "recipe_count": 1,
+      "layers": [
+        1
+      ],
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/mpmath/",
+      "tagline": "Pure-Python arbitrary-precision arithmetic.",
+      "description": "Numerical-stability bugs that survive when mpmath is installed into Pyodide via micropip. The browser page and the host-Python repro.py share the exact same script and the same pinned wheel.",
+      "homepage": "https://mpmath.org/",
+      "github": "https://github.com/mpmath/mpmath"
+    },
+    {
       "project": "node",
       "display_name": "Node.js",
       "recipe_count": 1,

--- a/docs/public/api/recipes.json
+++ b/docs/public/api/recipes.json
@@ -39,6 +39,24 @@
       "severity": "spec-violation"
     },
     {
+      "slug": "mpmath-983",
+      "layer": 1,
+      "project": "mpmath",
+      "issue": 983,
+      "title": "mpmath/mpmath#983",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/mpmath/983/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/mpmath-983",
+      "language": "python",
+      "tags": [
+        "numerical-linear-algebra",
+        "qr-solve",
+        "householder",
+        "arbitrary-precision"
+      ],
+      "symptom": "solver-asymmetry-on-nonsingular-matrix",
+      "severity": "bug"
+    },
+    {
       "slug": "numpy-28287",
       "layer": 1,
       "project": "numpy",

--- a/mise.toml
+++ b/mise.toml
@@ -157,12 +157,20 @@ bun run test
 # ── Native re-verification (run repros against host interpreters) ───────
 
 [tasks."repro:native:python"]
-description = "Run Python repros against host Python (Pyodide-equivalent pins)"
+description = "Run every src/layer1_wasm/*/repro.py against host Python (auto-discovered; PEP 723 inline metadata pins each script's deps)"
+shell = "bash -c"  # need `set -o pipefail` and `shopt`, neither in POSIX sh
 run = '''
-mise exec uv -- uv run --python 3.13 src/layer1_wasm/pandas-56679/repro.py
-mise exec uv -- uv run --python 3.13 src/layer1_wasm/numpy-28287/repro.py
-mise exec uv -- uv run --python 3.13 src/layer1_wasm/cpython-137205/repro.py
-mise exec uv -- uv run --python 3.13 src/layer1_wasm/astroid-2993/repro.py
+set -euo pipefail
+shopt -s nullglob
+matched=0
+for f in src/layer1_wasm/*/repro.py; do
+  matched=1
+  echo "== $f =="
+  mise exec uv -- uv run --python 3.13 "$f"
+done
+if [ "$matched" -eq 0 ]; then
+  echo "[repro:native:python] no src/layer1_wasm/*/repro.py found — nothing to run" >&2
+fi
 '''
 
 [tasks."repro:native:ruby"]

--- a/src/layer1_wasm/mpmath-983/README.md
+++ b/src/layer1_wasm/mpmath-983/README.md
@@ -1,0 +1,113 @@
+# Reproduction — mpmath/mpmath#983
+
+> Layer 1 reproduction page — second entry installing a third-party
+> Python package via `micropip` (after `astroid-2993`); first
+> reproduction targeting a numerical-linear-algebra bug. Conforms to
+> `vivarium-contract: v1`.
+
+## The bug
+
+[mpmath/mpmath#983](https://github.com/mpmath/mpmath/issues/983) —
+`mp.qr_solve(A, b)` raises `ValueError: matrix is numerically
+singular` on a well-conditioned 4×4 polynomial-interpolation system
+that `mp.lu_solve(A, b)` handles fine. Wolfram|Alpha confirms the
+matrix is invertible (condition number ≈695), so the issue is the
+**asymmetry** between the two solvers — qr_solve is wrong on a
+matrix that is not actually singular.
+
+```python
+from mpmath import mp
+
+A = mp.matrix([
+    [mp.one, -mp.pi / 20, (-mp.pi / 20) ** 2, (-mp.pi / 20) ** 3],
+    [mp.one, mp.zero, mp.zero, mp.zero],
+    [mp.one, mp.pi / 20, (mp.pi / 20) ** 2, (mp.pi / 20) ** 3],
+    [mp.one, mp.pi / 10, (mp.pi / 10) ** 2, (mp.pi / 10) ** 3],
+])
+b = mp.matrix([
+    [mp.sin(-mp.pi / 20)],
+    [mp.zero],
+    [mp.sin(mp.pi / 20)],
+    [mp.sin(mp.pi / 20)],
+])
+
+mp.qr_solve(A, b)   # ValueError: matrix is numerically singular
+mp.lu_solve(A, b)   # returns a finite solution
+```
+
+The suspected fix area is the Householder QR guard
+`if not abs(s) > ctx.eps:` in
+[`mpmath/matrices/linalg.py:333`](https://github.com/mpmath/mpmath/blob/master/mpmath/matrices/linalg.py#L333):
+the guard trips on a sub-eps intermediate sum that the LU path
+never sees. Lowering precision via `mp.dps = 10` keeps the sum
+above the new (looser) eps and works around the bug.
+
+## Why this bug
+
+- Pure Python — mpmath has no runtime dependencies beyond the
+  Python stdlib. No native extensions, no I/O, no thread-scheduler
+  dependence. Pyodide installs the wheel from PyPI via `micropip`
+  in seconds.
+- Reproduction is a fixed 4×4 system + two solver calls; verdict
+  reduces to a boolean (qr raised AND lu succeeded → bug). The
+  page emits a mechanically-distinguishable
+  `reproduced` / `unreproduced`.
+- Reported against mpmath 1.3.0; latest release at authoring time
+  is 1.4.1 (2026-03-15) and the bug still reproduces there. Pinning
+  in PEP 723 / `repro.ts` to that exact version locks the verdict
+  to a known-bad build, so the page flips to `unreproduced` only
+  when a new mpmath release lands an actual fix.
+- Demonstrates Vivarium handles **numerical-stability** bugs (a
+  category neither `cpython-137205` nor `pandas-56679` exercise)
+  while still fitting the Layer 1 envelope.
+
+## Files
+
+| File         | Role                                                              |
+| ------------ | ----------------------------------------------------------------- |
+| `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
+| `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
+| `repro.py`   | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. PEP 723 inline metadata pins `mpmath==1.4.1`. |
+
+## Verdict contract — `vivarium-contract: v1`
+
+The page conforms to the contract canonicalised in
+[`../_shared/verdict.ts`](../_shared/verdict.ts). The `result`
+field of the envelope reports `mp_dps`, `qr_solve_raised`,
+`lu_solve_succeeded`, and `asymmetry`.
+
+A `reproduced` verdict means **the bug reproduced** — `qr_solve`
+raised AND `lu_solve` succeeded on the same system. An
+`unreproduced` verdict means either the asymmetry collapsed
+(qr_solve accepted the system, or lu_solve also failed), or the
+runtime errored before producing a result.
+
+## Running locally — in-browser
+
+```bash
+cd src/layer1_wasm
+bun install
+bun run build
+python -m http.server -d . 8767
+# open http://localhost:8767/mpmath-983/
+```
+
+The page first preloads `micropip`, then installs `mpmath==1.4.1`
+from PyPI on the visitor's machine before running the reproduction.
+First-visit cold load is slower than recipes that exercise only
+Pyodide-bundled packages.
+
+## Native verification — same reproduction under a real CPython
+
+```bash
+mise install
+mise exec uv -- uv run src/layer1_wasm/mpmath-983/repro.py
+# verdict=reproduced — qr_solve raised on a system lu_solve handles fine
+```
+
+## Deployment
+
+Published to GitHub Pages at
+`https://aletheia-works.github.io/vivarium/repro/mpmath/983/` by the
+`deploy-docs` workflow.

--- a/src/layer1_wasm/mpmath-983/index.html
+++ b/src/layer1_wasm/mpmath-983/index.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="vivarium-contract" content="v1" />
+    <title>Vivarium · Reproducing mpmath/mpmath#983</title>
+    <!-- vivarium-chrome-injected -->
+    <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.asm.wasm" as="fetch" type="application/wasm" crossorigin />
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/python_stdlib.zip" as="fetch" crossorigin />
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide-lock.json" as="fetch" type="application/json" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <!-- Keep the version below in sync with DEFAULT_PYODIDE_VERSION in
+         ../_shared/loader.ts. -->
+    <link
+      rel="modulepreload"
+      href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.mjs"
+      crossorigin
+    />
+    <link rel="stylesheet" href="../_shared/style.css" />
+    <template id="bug-context">
+      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <div class="vh-drawer__body" id="vh-drawer-body">
+        <p>
+          A well-conditioned 4×4 polynomial-interpolation system —
+          which Wolfram|Alpha and <code>mp.lu_solve</code> both agree
+          is invertible (condition number ≈695) — makes
+          <code>mp.qr_solve(A, b)</code> raise
+          <code>ValueError: matrix is numerically singular</code>.
+          The two solvers disagree on a matrix that is not actually
+          singular.
+        </p>
+        <p>
+          The script on this page installs mpmath into Pyodide via
+          <code>micropip</code>, builds the system from the upstream
+          issue verbatim, and runs both solvers. If <code>qr_solve</code>
+          raises while <code>lu_solve</code> returns a finite
+          solution, the bug reproduces in the runtime currently
+          loaded in your browser tab.
+        </p>
+        <p>
+          The suspected fix area is the Householder QR guard
+          <code>if not abs(s) > ctx.eps:</code> in
+          <code>mpmath/matrices/linalg.py:333</code>; raising
+          precision via <code>mp.dps = 10</code> works around the
+          issue. The full discussion lives in the GitHub issue
+          thread linked below.
+        </p>
+      </div>
+      <hr class="vh-drawer__divider" />
+      <div class="vh-drawer__meta-grid">
+        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-val">mpmath/mpmath</span>
+        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-val">#983</span>
+        <span class="vh-drawer__meta-key">Layer</span>
+        <span class="vh-drawer__meta-val">L1 · WASM</span>
+        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-val">Pyodide v0.29.3</span>
+      </div>
+    </template>
+  </head>
+  <body>
+    <main class="vh-main">
+      <header class="vh-main__header">
+        <div class="vh-main__header-text">
+          <p class="kicker">L1 · Pyodide · mpmath</p>
+          <h1>Reproducing <a href="https://github.com/mpmath/mpmath/issues/983">mpmath/mpmath#983</a></h1>
+          <div class="vh-main__header-actions">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+              Bug context
+            </button>
+            <a class="vh-chip" href="https://github.com/mpmath/mpmath/issues/983" target="_blank" rel="noreferrer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              Upstream issue
+            </a>
+          </div>
+        </div>
+        <div class="vh-main__header-aside">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+            Loading Pyodide runtime…
+          </div>
+          <p class="meta" id="meta"></p>
+        </div>
+      </header>
+
+      <div class="vh-main__cols">
+        <section class="vh-main__col vh-main__col--script">
+          <h2>Reproduction script</h2>
+          <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> mpmath</span></span>
+<span class="line"><span style="color:#F97583">from</span><span style="color:#E1E4E8"> mpmath </span><span style="color:#F97583">import</span><span style="color:#E1E4E8"> mp</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">A </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> mp.matrix([</span></span>
+<span class="line"><span style="color:#E1E4E8">    [mp.one, </span><span style="color:#F97583">-</span><span style="color:#E1E4E8">mp.pi </span><span style="color:#F97583">/</span><span style="color:#79B8FF"> 20</span><span style="color:#E1E4E8">, (</span><span style="color:#F97583">-</span><span style="color:#E1E4E8">mp.pi </span><span style="color:#F97583">/</span><span style="color:#79B8FF"> 20</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">**</span><span style="color:#79B8FF"> 2</span><span style="color:#E1E4E8">, (</span><span style="color:#F97583">-</span><span style="color:#E1E4E8">mp.pi </span><span style="color:#F97583">/</span><span style="color:#79B8FF"> 20</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">**</span><span style="color:#79B8FF"> 3</span><span style="color:#E1E4E8">],</span></span>
+<span class="line"><span style="color:#E1E4E8">    [mp.one, mp.zero, mp.zero, mp.zero],</span></span>
+<span class="line"><span style="color:#E1E4E8">    [mp.one, mp.pi </span><span style="color:#F97583">/</span><span style="color:#79B8FF"> 20</span><span style="color:#E1E4E8">, (mp.pi </span><span style="color:#F97583">/</span><span style="color:#79B8FF"> 20</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">**</span><span style="color:#79B8FF"> 2</span><span style="color:#E1E4E8">, (mp.pi </span><span style="color:#F97583">/</span><span style="color:#79B8FF"> 20</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">**</span><span style="color:#79B8FF"> 3</span><span style="color:#E1E4E8">],</span></span>
+<span class="line"><span style="color:#E1E4E8">    [mp.one, mp.pi </span><span style="color:#F97583">/</span><span style="color:#79B8FF"> 10</span><span style="color:#E1E4E8">, (mp.pi </span><span style="color:#F97583">/</span><span style="color:#79B8FF"> 10</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">**</span><span style="color:#79B8FF"> 2</span><span style="color:#E1E4E8">, (mp.pi </span><span style="color:#F97583">/</span><span style="color:#79B8FF"> 10</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">**</span><span style="color:#79B8FF"> 3</span><span style="color:#E1E4E8">],</span></span>
+<span class="line"><span style="color:#E1E4E8">])</span></span>
+<span class="line"><span style="color:#E1E4E8">b </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> mp.matrix([</span></span>
+<span class="line"><span style="color:#E1E4E8">    [mp.sin(</span><span style="color:#F97583">-</span><span style="color:#E1E4E8">mp.pi </span><span style="color:#F97583">/</span><span style="color:#79B8FF"> 20</span><span style="color:#E1E4E8">)],</span></span>
+<span class="line"><span style="color:#E1E4E8">    [mp.zero],</span></span>
+<span class="line"><span style="color:#E1E4E8">    [mp.sin(mp.pi </span><span style="color:#F97583">/</span><span style="color:#79B8FF"> 20</span><span style="color:#E1E4E8">)],</span></span>
+<span class="line"><span style="color:#E1E4E8">    [mp.sin(mp.pi </span><span style="color:#F97583">/</span><span style="color:#79B8FF"> 20</span><span style="color:#E1E4E8">)],</span></span>
+<span class="line"><span style="color:#E1E4E8">])</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">result </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span style="color:#9ECBFF">    "mpmath_version"</span><span style="color:#E1E4E8">: mpmath.</span><span style="color:#79B8FF">__version__</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "python_version"</span><span style="color:#E1E4E8">: sys.version.split()[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
+<span class="line"><span style="color:#9ECBFF">    "mp_dps"</span><span style="color:#E1E4E8">: mp.dps,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "qr_solve_raised"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">False</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "qr_solve_error"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">None</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "lu_solve_succeeded"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">False</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "lu_solve_solution"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">None</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "asymmetry"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">False</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">try</span><span style="color:#E1E4E8">:</span></span>
+<span class="line"><span style="color:#E1E4E8">    mp.qr_solve(A, b)</span></span>
+<span class="line"><span style="color:#F97583">except</span><span style="color:#79B8FF"> ValueError</span><span style="color:#F97583"> as</span><span style="color:#E1E4E8"> e:</span></span>
+<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"qr_solve_raised"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> True</span></span>
+<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"qr_solve_error"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> str</span><span style="color:#E1E4E8">(e)[:</span><span style="color:#79B8FF">200</span><span style="color:#E1E4E8">]</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">try</span><span style="color:#E1E4E8">:</span></span>
+<span class="line"><span style="color:#E1E4E8">    x_lu </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> mp.lu_solve(A, b)</span></span>
+<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"lu_solve_succeeded"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> True</span></span>
+<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"lu_solve_solution"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> [mp.nstr(x_lu[i, </span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">], </span><span style="color:#79B8FF">6</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">for</span><span style="color:#E1E4E8"> i </span><span style="color:#F97583">in</span><span style="color:#79B8FF"> range</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">4</span><span style="color:#E1E4E8">)]</span></span>
+<span class="line"><span style="color:#F97583">except</span><span style="color:#79B8FF"> Exception</span><span style="color:#F97583"> as</span><span style="color:#E1E4E8"> e:</span></span>
+<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"lu_solve_solution"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#F97583"> f</span><span style="color:#9ECBFF">"lu_solve also raised: </span><span style="color:#79B8FF">{type</span><span style="color:#E1E4E8">(e).</span><span style="color:#79B8FF">__name__}</span><span style="color:#9ECBFF">: </span><span style="color:#79B8FF">{str</span><span style="color:#E1E4E8">(e)[:</span><span style="color:#79B8FF">120</span><span style="color:#E1E4E8">]</span><span style="color:#79B8FF">}</span><span style="color:#9ECBFF">"</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">result[</span><span style="color:#9ECBFF">"asymmetry"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> result[</span><span style="color:#9ECBFF">"qr_solve_raised"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">and</span><span style="color:#E1E4E8"> result[</span><span style="color:#9ECBFF">"lu_solve_succeeded"</span><span style="color:#E1E4E8">]</span></span>
+<span class="line"><span style="color:#E1E4E8">result</span></span></code></pre>
+        </section>
+
+        <section class="vh-main__col vh-main__col--output">
+          <h2>Output</h2>
+          <pre id="output">(running)</pre>
+        </section>
+      </div>
+
+    </main>
+
+    <script type="module" src="./repro.js"></script>
+  </body>
+</html>

--- a/src/layer1_wasm/mpmath-983/repro.py
+++ b/src/layer1_wasm/mpmath-983/repro.py
@@ -1,0 +1,110 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#   "mpmath==1.4.1",
+# ]
+# ///
+"""Vivarium Layer 1 reproduction — mpmath/mpmath#983, native variant.
+
+Mirrors the script that runs in `repro.ts` (under Pyodide) so a
+contributor can re-verify the bug against a real CPython interpreter
++ a real mpmath build:
+
+    mise install                                                    # one-time
+    mise exec uv -- uv run src/layer1_wasm/mpmath-983/repro.py
+
+PEP 723 inline metadata pins **mpmath 1.4.1** — the latest release
+at authoring time (2026-03-15). `uv run` reads the metadata and
+creates an ephemeral venv on first invocation; subsequent runs hit
+uv's cache.
+
+The 4x4 system below is the minimal example from the upstream issue.
+Wolfram|Alpha and `mp.lu_solve` agree it is solvable (condition
+number ≈695, well-conditioned), but `mp.qr_solve` raises
+``ValueError: matrix is numerically singular`` because the
+Householder QR path's `if not abs(s) > ctx.eps:` guard
+(`mpmath/matrices/linalg.py:333`) trips on a sub-eps intermediate
+sum that the LU path never sees. Working around with `mp.dps = 10`
+(lower precision than the default 15) makes the guard pass.
+
+Exits 0 on `pass` (bug REPRODUCED — qr_solve raised while lu_solve
+succeeded), 1 on `fail` (the asymmetry collapsed, likely fixed
+upstream).
+"""
+
+import json
+import sys
+
+import mpmath
+from mpmath import mp
+
+
+def build_system():
+    A = mp.matrix(
+        [
+            [mp.one, -mp.pi / 20, (-mp.pi / 20) ** 2, (-mp.pi / 20) ** 3],
+            [mp.one, mp.zero, mp.zero, mp.zero],
+            [mp.one, mp.pi / 20, (mp.pi / 20) ** 2, (mp.pi / 20) ** 3],
+            [mp.one, mp.pi / 10, (mp.pi / 10) ** 2, (mp.pi / 10) ** 3],
+        ]
+    )
+    b = mp.matrix(
+        [
+            [mp.sin(-mp.pi / 20)],
+            [mp.zero],
+            [mp.sin(mp.pi / 20)],
+            [mp.sin(mp.pi / 20)],
+        ]
+    )
+    return A, b
+
+
+A, b = build_system()
+
+result = {
+    "mpmath_version": mpmath.__version__,
+    "python_version": sys.version.split()[0],
+    "mp_dps": mp.dps,
+    "qr_solve_raised": False,
+    "qr_solve_error": None,
+    "lu_solve_succeeded": False,
+    "lu_solve_solution": None,
+    "asymmetry": False,
+}
+
+# qr_solve — expected to raise on the numerically-singular guard.
+try:
+    mp.qr_solve(A, b)
+except ValueError as e:
+    result["qr_solve_raised"] = True
+    result["qr_solve_error"] = str(e)[:200]
+
+# lu_solve — sanity check that the system *is* solvable. If lu_solve
+# also fails the matrix really is singular and qr_solve was right; the
+# bug is the asymmetry between the two solvers.
+try:
+    x_lu = mp.lu_solve(A, b)
+    result["lu_solve_succeeded"] = True
+    # mp.matrix repr is multi-line; flatten to a list of strings so the
+    # JSON output stays readable.
+    result["lu_solve_solution"] = [mp.nstr(x_lu[i, 0], 6) for i in range(4)]
+except Exception as e:
+    result["lu_solve_succeeded"] = False
+    result["lu_solve_solution"] = f"lu_solve also raised: {type(e).__name__}: {str(e)[:120]}"
+
+result["asymmetry"] = result["qr_solve_raised"] and result["lu_solve_succeeded"]
+
+print(json.dumps(result, indent=2))
+
+if result["asymmetry"]:
+    print(
+        "verdict=reproduced — qr_solve raised on a system lu_solve handles fine",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+else:
+    print(
+        "verdict=unreproduced — qr_solve and lu_solve no longer disagree (likely fixed upstream)",
+        file=sys.stderr,
+    )
+    sys.exit(1)

--- a/src/layer1_wasm/mpmath-983/repro.ts
+++ b/src/layer1_wasm/mpmath-983/repro.ts
@@ -1,0 +1,240 @@
+// Vivarium Layer 1 reproduction — mpmath/mpmath#983.
+//
+// `mp.qr_solve(A, b)` raises `ValueError: matrix is numerically
+// singular` on a well-conditioned 4×4 polynomial-interpolation
+// system that `mp.lu_solve(A, b)` handles fine. Wolfram|Alpha
+// confirms the matrix is invertible (condition number ≈ 695). The
+// Householder QR path's guard
+// `if not abs(s) > ctx.eps:` (mpmath/matrices/linalg.py:333) trips
+// on a sub-eps intermediate sum that the LU path never sees;
+// raising precision via `mp.dps = 10` works around it.
+//
+// Verdict semantics (per ADR-0008 / contract v1):
+//   - "reproduced" — qr_solve raised AND lu_solve succeeded on the
+//     same system (the upstream-reported asymmetry).
+//   - "unreproduced" — the two solvers no longer disagree (qr_solve
+//     accepted the system, or lu_solve also failed, or the runtime
+//     errored before producing a result).
+//
+// mpmath is **not** in Pyodide's bundled package set, so we install
+// it via `micropip` after the Pyodide bootstrap. mpmath has no
+// runtime dependencies beyond the Python stdlib, so the install is
+// a single pure-Python wheel from PyPI.
+
+import { loadVivariumPyodide } from '../_shared/loader.js';
+import type { PathACapturedRun } from '../_shared/path_a.js';
+import { enableRunner } from '../_shared/runner.js';
+import {
+  setResult,
+  setVerdict,
+  type VivariumResultV1,
+} from '../_shared/verdict.js';
+
+const REPRO_CODE = `
+import sys
+import mpmath
+from mpmath import mp
+
+A = mp.matrix([
+    [mp.one, -mp.pi / 20, (-mp.pi / 20) ** 2, (-mp.pi / 20) ** 3],
+    [mp.one, mp.zero, mp.zero, mp.zero],
+    [mp.one, mp.pi / 20, (mp.pi / 20) ** 2, (mp.pi / 20) ** 3],
+    [mp.one, mp.pi / 10, (mp.pi / 10) ** 2, (mp.pi / 10) ** 3],
+])
+b = mp.matrix([
+    [mp.sin(-mp.pi / 20)],
+    [mp.zero],
+    [mp.sin(mp.pi / 20)],
+    [mp.sin(mp.pi / 20)],
+])
+
+result = {
+    "mpmath_version": mpmath.__version__,
+    "python_version": sys.version.split()[0],
+    "mp_dps": mp.dps,
+    "qr_solve_raised": False,
+    "qr_solve_error": None,
+    "lu_solve_succeeded": False,
+    "lu_solve_solution": None,
+    "asymmetry": False,
+}
+
+try:
+    mp.qr_solve(A, b)
+except ValueError as e:
+    result["qr_solve_raised"] = True
+    result["qr_solve_error"] = str(e)[:200]
+
+try:
+    x_lu = mp.lu_solve(A, b)
+    result["lu_solve_succeeded"] = True
+    result["lu_solve_solution"] = [mp.nstr(x_lu[i, 0], 6) for i in range(4)]
+except Exception as e:
+    result["lu_solve_solution"] = f"lu_solve also raised: {type(e).__name__}: {str(e)[:120]}"
+
+result["asymmetry"] = result["qr_solve_raised"] and result["lu_solve_succeeded"]
+result
+`.trim();
+
+interface ReproOutput {
+  mpmath_version: string;
+  python_version: string;
+  mp_dps: number;
+  qr_solve_raised: boolean;
+  qr_solve_error: string | null;
+  lu_solve_succeeded: boolean;
+  lu_solve_solution: string[] | string | null;
+  asymmetry: boolean;
+}
+
+interface PyodideRuntime {
+  runPythonAsync(code: string): Promise<{
+    toJs(opts: { dict_converter: typeof Object.fromEntries }): ReproOutput;
+    destroy?(): void;
+  }>;
+}
+
+const outputEl = document.getElementById('output');
+const metaEl = document.getElementById('meta');
+const reproCodeEl = document.getElementById('repro-code');
+
+if (!outputEl || !metaEl || !reproCodeEl) {
+  throw new Error(
+    'mpmath-983: missing required DOM elements (#output, #meta, #repro-code).',
+  );
+}
+
+if (!reproCodeEl.firstChild) {
+  reproCodeEl.textContent = REPRO_CODE;
+  fetch('./repro.highlighted.html')
+    .then((r) => (r.ok ? r.text() : null))
+    .then((html) => {
+      if (html) reproCodeEl.innerHTML = html;
+    })
+    .catch(() => {});
+}
+
+function evaluate(result: ReproOutput): {
+  verdict: 'reproduced' | 'unreproduced';
+  message: string;
+} {
+  if (result.asymmetry) {
+    return {
+      verdict: 'reproduced',
+      message:
+        'bug reproduced — qr_solve raised on a system lu_solve handles fine.',
+    };
+  }
+  return {
+    verdict: 'unreproduced',
+    message:
+      'bug not reproduced — qr_solve and lu_solve no longer disagree on this system.',
+  };
+}
+
+async function captureRun(
+  runtime: PyodideRuntime,
+  source: string,
+): Promise<PathACapturedRun> {
+  try {
+    const proxy = await runtime.runPythonAsync(source);
+    const result = proxy.toJs({ dict_converter: Object.fromEntries });
+    proxy.destroy?.();
+    const ev = evaluate(result);
+    return {
+      exitCode: 0,
+      verdict: ev.verdict,
+      message: ev.message,
+      stdout: JSON.stringify(result, null, 2),
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      exitCode: 1,
+      verdict: 'unreproduced',
+      message: `runtime error: ${message}`,
+      stdout: message,
+    };
+  }
+}
+
+const startedAt = new Date();
+
+try {
+  const { pyodide, version } = await loadVivariumPyodide({
+    packages: ['micropip'],
+    pendingText: 'Loading Pyodide runtime and micropip…',
+  });
+
+  setVerdict('pending', 'Installing mpmath from PyPI…');
+  const runtime = pyodide as PyodideRuntime;
+  await runtime.runPythonAsync(`
+import micropip
+await micropip.install("mpmath==1.4.1")
+`);
+
+  setVerdict('pending', 'Running reproduction script…');
+  const baseline = await captureRun(runtime, REPRO_CODE);
+
+  let baselineResult: ReproOutput | null = null;
+  try {
+    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
+  } catch {
+    outputEl.textContent = baseline.stdout;
+    setVerdict(baseline.verdict, baseline.message);
+    throw new Error(baseline.message);
+  }
+
+  metaEl.textContent =
+    `mpmath ${baselineResult.mpmath_version} on Python ${baselineResult.python_version} ` +
+    `(mp.dps=${baselineResult.mp_dps}) via Pyodide v${version}.`;
+  outputEl.textContent = baseline.stdout;
+  setVerdict(baseline.verdict, baseline.message);
+
+  const finishedAt = new Date();
+  const envelope: VivariumResultV1 = {
+    contract: 'v1',
+    bug: {
+      project: 'mpmath',
+      issue: 983,
+      upstream_url: 'https://github.com/mpmath/mpmath/issues/983',
+    },
+    runtime: {
+      name: 'pyodide',
+      version,
+      extras: {
+        python: baselineResult.python_version,
+        mpmath: baselineResult.mpmath_version,
+      },
+    },
+    result: {
+      mp_dps: baselineResult.mp_dps,
+      qr_solve_raised: baselineResult.qr_solve_raised,
+      lu_solve_succeeded: baselineResult.lu_solve_succeeded,
+      asymmetry: baselineResult.asymmetry,
+    },
+    timing: {
+      started_at: startedAt.toISOString(),
+      finished_at: finishedAt.toISOString(),
+      duration_ms: finishedAt.getTime() - startedAt.getTime(),
+    },
+  };
+  setResult(envelope);
+
+  enableRunner({
+    slug: 'mpmath-983',
+    baselineSource: REPRO_CODE,
+    runFix: (source) => captureRun(runtime, source),
+  });
+} catch (err: unknown) {
+  console.error(err);
+  const errAny = err as { stack?: string; message?: string } | null;
+  outputEl.textContent =
+    (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
+  if (globalThis.__VIVARIUM_VERDICT__ !== 'unreproduced') {
+    setVerdict(
+      'unreproduced',
+      `bug not reproduced — runtime error: ${errAny?.message ?? String(err)}`,
+    );
+  }
+}

--- a/src/layer1_wasm/scripts/highlight-repros.ts
+++ b/src/layer1_wasm/scripts/highlight-repros.ts
@@ -55,6 +55,7 @@ const LAYER1_DIR = dirname(SCRIPT_DIR);
 const LANG_BY_PROJECT: Record<string, BundledLanguage> = {
   astroid: 'python',
   cpython: 'python',
+  mpmath: 'python',
   numpy: 'python',
   pandas: 'python',
   ruby: 'ruby',

--- a/src/layer1_wasm/tests/repro.spec.ts
+++ b/src/layer1_wasm/tests/repro.spec.ts
@@ -78,6 +78,14 @@ const cases: ReproCase[] = [
     expectedRuntimeName: "pyodide",
   },
   {
+    name: "mpmath-983 reproduction",
+    url: `${LAYER1}/mpmath-983/`,
+    expectedVerdict: "reproduced",
+    expectedBugProject: "mpmath",
+    expectedBugIssue: 983,
+    expectedRuntimeName: "pyodide",
+  },
+  {
     name: "numpy-28287 reproduction",
     url: `${LAYER1}/numpy-28287/`,
     expectedVerdict: "reproduced",


### PR DESCRIPTION

`mp.qr_solve(A, b)` raises `ValueError: matrix is numerically
singular` on a well-conditioned 4x4 polynomial-interpolation system
that `mp.lu_solve(A, b)` handles fine. Wolfram|Alpha confirms the
matrix is invertible (condition number ~695); the bug is the
asymmetry between the two solvers, not actual singularity.

Suspected fix area is the Householder QR guard
`if not abs(s) > ctx.eps:` in mpmath/matrices/linalg.py:333.
Lowering precision via `mp.dps = 10` works around the bug.

Recipe surface:

- src/layer1_wasm/mpmath-983/{index.html,repro.ts,repro.py,README.md}
- Pyodide v0.29.3 / Python 3.13.2 / mpmath 1.4.1 (latest, 2026-03-15)
- Installs mpmath via micropip — second Layer 1 recipe to use the
  micropip path established by astroid-2993 (PR #209)
- verdict=reproduced — captures qr_solve_raised && lu_solve_succeeded;
  the lu_solve solution matches Wolfram|Alpha's analytical answer

Wiring:

- docs/data/recipe-facets.json + projects.json — mpmath rows added
- docs/public/api/{recipes,projects}.json — regenerated via
  `bun run generate-index` + `generate-project-pages`
- src/layer1_wasm/scripts/highlight-repros.ts — `mpmath: 'python'`
  added to LANG_BY_PROJECT
- src/layer1_wasm/tests/repro.spec.ts — Playwright case added

Drive-by:

- mise.toml `repro:native:python` — switch from per-recipe explicit
  invocations to glob auto-discovery of `src/layer1_wasm/*/repro.py`
  (matches the existing rust:build / docker:build idiom — `shell =
  "bash -c"` + `set -euo pipefail` + `shopt -s nullglob`). New Layer
  1 Python recipes no longer need to touch this task. Verified
  locally: all 5 current repros (astroid, cpython, mpmath, numpy,
  pandas) discovered and exit 0.

Verified locally:

- Native: mise run repro:native:python → all 5 verdict=reproduced
- Browser (Preview MCP, http://localhost:8767/mpmath-983/):
  contract=v1, verdict=reproduced, runtime.name=pyodide,
  bug.project=mpmath, bug.issue=983, no console errors.
- Lint: mise run python:check / markdown:check pass (RUF002 on
  the 4x4 docstring fixed).
