### PR TITLE
docs: trim Vivarium README to user / developer essentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,6 @@
 > A controlled environment for reproducing bugs — any language, any environment, any scale.
 > Part of [`aletheia-works`](https://github.com/aletheia-works): surfacing truth in the AI-generated code era.
 
----
-
-## 🚧 Status
-
-**Phase 6 — Usability and visual layer (in flight)**
-
-Phases 0–5 closed between 2026-04-26 and 2026-04-29. Layer 1 ships six
-WASM verticals (Python via Pyodide, Ruby.wasm, php-wasm, Rust on
-`wasm32-wasip1`); Layer 2 ships four Docker recipes published to
-`ghcr.io/aletheia-works/`; Layer 3 ships one `rr` recipe. Public specs
-(**Contract v1**, **Manifest v1**, **Recipes index v1**) and a
-**Vivarium MCP server** for AI agent clients are published.
-
-See [`docs/docs/roadmap.md`](docs/docs/roadmap.md) for the per-phase plan.
-
----
-
 ## Why This Project Exists
 
 In 2025-2026, open-source maintainers face a new crisis:
@@ -60,52 +43,9 @@ Public specs:
 
 Programmatic access:
 
-- **[`@aletheia-works/vivarium-mcp`](packages/mcp-server/)** — Model Context Protocol server exposing `list_recipes` / `get_recipe` / `lookup_verdict` to AI agent clients (Claude Code, Cline, Cursor, Continue, …). Dual-published to JSR (canonical) and npm (fallback).
+- **[`@aletheia-works/vivarium-mcp`](packages/mcp-server/)** — Model Context Protocol server exposing the catalogue + verdict-snapshot reads + branch-fix / fix-candidate scaffolding to AI agent clients (Claude Code, Cline, Cursor, Continue, …). Dual-published to JSR (canonical) and npm (fallback).
 
 The docs site is built with [rspress](https://rspress.rs) and deployed to GitHub Pages from [`docs/`](docs/) on every push to `main`. The rspress configuration and lockfile live in `docs/`; the markdown content lives in `docs/docs/`.
-
-## Development Philosophy
-
-This project is developed using an **AI-delegated workflow**:
-
-1. Humans define vision, direction, and make strategic decisions
-2. AI agents (Claude Code) implement and review in two distinct workflows,
-   with the human merging
-3. Automation infrastructure (GitHub Actions, Dependabot) runs continuously
-
-The project eats its own dog food:
-**an AI-slop-verification platform, developed by AI, reviewed by AI, with humans in the loop.**
-
-## Repository Structure
-
-```text
-vivarium/
-├── README.md                 # This file
-├── AGENTS.md                 # Standing instructions for AI coding agents
-├── CLAUDE.md                 # Claude Code-specific addenda
-├── mise.toml                 # Tool versions (bun, opentofu, python, ruby, php, rust)
-├── .gitignore
-├── .github/
-│   ├── workflows/            # CI/CD — thin callers into aletheia-works/.github reusables
-│   ├── labeler.yml           # Path-based label rules
-│   └── dependabot.yml        # Automated dependency updates (github-actions, terraform, bun)
-├── infra/
-│   └── github/               # GitHub Settings as Code (OpenTofu)
-│       ├── milestones.tf, labels.tf, branch_protection.tf, …
-│       └── README.md
-├── docs/                     # rspress docs site
-│   ├── public/spec/          # JSON Schemas — verdict.schema.json, manifest.schema.json
-│   ├── public/api/           # recipes.json, recipes.schema.json
-│   ├── scripts/              # build-time scripts (recipes-index generator)
-│   └── docs/                 # vision, architecture, roadmap, spec/, repro/
-├── packages/
-│   └── mcp-server/           # @aletheia-works/vivarium-mcp (JSR + npm dual publish)
-└── src/
-    ├── layer1_wasm/          # 6 Layer 1 recipes (Pyodide, Ruby.wasm, php-wasm, Rust)
-    ├── layer2_docker/        # 4 Layer 2 recipes (Docker images on GHCR)
-    ├── layer3_thirdway/      # 1 Layer 3 recipe (rr replay)
-    └── external_examples/    # reference Manifest v1 fixtures, one per layer
-```
 
 ## Getting Started
 
@@ -141,12 +81,3 @@ Issue and PR contributions to this repo are also welcome.
 ## License
 
 Apache License 2.0
-
-## Author
-
-Individual developer project.
-
----
-
-*This README evolves as the project moves through phases.*
-*Current phase: Phase 6.*


### PR DESCRIPTION

The root README had grown to include a few sections that either go
stale on every phase bump (the Status banner pinned at "Phase 6"
when AGENTS.md is already on Phase 8), restate what the GitHub UI
already shows (Repository Structure tree), or describe the project
philosophy in a way that does not help a reader either use or
extend Vivarium (Development Philosophy block, the
"This README evolves..." footer with another stale phase mention,
the Author block).

Drop those four sections + the trailing footer + the now-orphaned
"---" rules. What stays is what a first-time reader actually needs:
why the project exists, the vision, where the docs / specs / MCP
package live, getting started for maintainers and contributors,
the tech stack table, and the licence.

Tiny in-place fixup while we are here: extend the MCP package
description in the Documentation section to reflect the seven
tools the package now exposes (verdict-snapshot reads + branch-fix
+ fix-candidate scaffolding) instead of the original three-tool
listing.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/216).
* #218
* #217
* __->__ #216