### PR TITLE
chore(mcp): bump @aletheia-works/vivarium-mcp to 0.1.1

### DIFF
--- a/packages/mcp-server/jsr.json
+++ b/packages/mcp-server/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@aletheia-works/vivarium-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aletheia-works/vivarium-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP server exposing the Vivarium reproduction catalogue (list_recipes, get_recipe, lookup_verdict, match_error, verify_branch_fix, prepare_new_recipe, prepare_fix_candidate) to AI agent clients (Claude Code, Cline, Cursor, Continue, etc.).",
   "license": "Apache-2.0",
   "homepage": "https://github.com/aletheia-works/vivarium/tree/main/packages/mcp-server",

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -41,14 +41,14 @@ import {
 } from './tools/verify_branch_fix.js';
 
 const SERVER_NAME = 'vivarium-mcp';
-// Keep in sync with package.json + jsr.json. Updated by the publish
-// workflow on tag push; unsynced values produce a confusing client
-// experience (the MCP `initialize` response carries this string).
-// Stays at 0.1.0 across the Phase 7 A5 + B3 tool additions because
-// the package has not been published to JSR / npm yet — bumping a
-// pre-publish version literal only confuses clients that ever see
-// a development build.
-const SERVER_VERSION = '0.1.0';
+// Keep in sync with package.json + jsr.json. The MCP `initialize`
+// handshake exposes this string to clients, so unsynced values across
+// these three files produce a confusing client experience. Bump the
+// patch component for additive changes within v0.x (additional tools,
+// description / surface refinements) — the project is still pre-1.0
+// and `prepare_fix_candidate` (Phase 8 / ADR-0040) is meaningful but
+// fully opt-in, so a minor bump would overstate the impact.
+const SERVER_VERSION = '0.1.1';
 
 export function createServer(): Server {
   const server = new Server(


### PR DESCRIPTION

The 0.1.0 release shipped on 2026-05-09 (mcp-server-v0.1.0 tag).
Since then the v1 tool surface has gained `prepare_fix_candidate`
(Phase 8 / ADR-0040) plus the audit-pass refresh of the package
description and PR-authoring conventions docs from PR #215. None
of those are breaking changes — additive tools and metadata only —
so a patch bump is the right shape; the project is still pre-1.0
and a minor bump would overstate the impact.

Bump the literal in three places that ship together:
- packages/mcp-server/package.json (npm registry advertised version)
- packages/mcp-server/jsr.json (JSR registry advertised version)
- packages/mcp-server/src/server.ts SERVER_VERSION (string the MCP
  initialize handshake exposes to clients)

Also correct the SERVER_VERSION comment, which was stuck at "the
package has not been published to JSR / npm yet" from before the
0.1.0 release shipped. The new comment explains the patch-vs-minor
policy for v0.x bumps so the next contributor does not have to
reverse-engineer it.

Pushing the `mcp-server-v0.1.1` tag after this lands triggers the
existing publish-mcp.yml workflow, which re-publishes to JSR and
npm via OIDC trusted publishing (no version literal change in the
workflow needed — it reads from package.json).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
