### PR TITLE
ci(repro-regression): matrix Playwright across chromium / firefox / webkit

### DIFF
--- a/.github/workflows/repro-regression.yml
+++ b/.github/workflows/repro-regression.yml
@@ -85,8 +85,18 @@ concurrency:
 
 jobs:
   regression:
+    # One runner per browser engine so each Playwright project gets
+    # its own Pyodide memory budget (~1 GB resident with the heavier
+    # recipes); a single runner exercising all three serially would
+    # OOM. `fail-fast: false` lets each browser run to completion
+    # even if a sibling fails — flaky engines stay isolated.
+    name: regression (${{ matrix.browser }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
     defaults:
       run:
         working-directory: src/layer1_wasm
@@ -388,18 +398,17 @@ jobs:
             echo "Layer 3 reproduction ${slug}: build OK; tracked verdict=${verdict}"
           done
 
-      - name: Install Playwright browsers
-        # `--with-deps` brings in the system libraries Chromium needs
-        # (libnss3, libatk-bridge, etc.). The runner is fresh so the
-        # apt step is unavoidable; total step time is ~30 s.
-        run: bunx playwright install --with-deps chromium
+      - name: Install Playwright browser (${{ matrix.browser }})
+        # `--with-deps` brings in the system libraries the engine
+        # needs. Each matrix slot installs only its own browser.
+        run: bunx playwright install --with-deps ${{ matrix.browser }}
 
-      - name: Run Playwright regression suite
+      - name: Run Playwright regression suite (${{ matrix.browser }})
         # `playwright.config.ts` auto-starts `python -m http.server`
         # on the layer1 root, so the test cases can hit
         # `/_shared/_test/`, `/pandas-56679/`, `/numpy-28287/`.
-        # Python 3 is preinstalled on `ubuntu-latest` runners.
-        run: bun run test
+        # `--project=<name>` selects the matrix slot's browser.
+        run: bun run test -- --project=${{ matrix.browser }}
         env:
           CI: 'true'
 
@@ -407,6 +416,8 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: playwright-report-${{ github.run_id }}
+          # Browser name in the artefact prevents one matrix slot from
+          # clobbering another's report when multiple slots fail.
+          name: playwright-report-${{ matrix.browser }}-${{ github.run_id }}
           path: src/layer1_wasm/playwright-report/
           retention-days: 14

--- a/src/layer1_wasm/playwright.config.ts
+++ b/src/layer1_wasm/playwright.config.ts
@@ -81,10 +81,23 @@ export default defineConfig({
     },
   ],
 
+  // Three engines exercised. CI runs each project in its own
+  // matrix slot (per .github/workflows/repro-regression.yml) via
+  // `--project=<name>`, so the wall-clock stays on one browser even
+  // though Pyodide is heavy enough that running them serially in one
+  // worker would OOM the runner.
   projects: [
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
     },
   ],
 });


### PR DESCRIPTION

Mirror the docs E2E pattern (test-docs.yml) so the Layer 1
regression suite exercises every wasm-capable browser engine
without inflating the wall-clock time. Each matrix slot is its
own runner, so each engine gets a clean Pyodide memory budget;
running all three serially in one runner would OOM (the
playwright config still keeps `workers: 1` for that reason).

playwright.config.ts:
- Add firefox and webkit projects alongside the existing chromium.

repro-regression.yml:
- Add `strategy.matrix.browser: [chromium, firefox, webkit]` with
  `fail-fast: false` so a flaky engine does not silence the others.
- Install only the matrix slot's browser via
  `bunx playwright install --with-deps ${{ matrix.browser }}`.
- Run the suite scoped to that engine via
  `bun run test -- --project=${{ matrix.browser }}`.
- Include the browser name in the failure-report artefact name so
  multiple failed matrix slots do not clobber each other's report.

Cost: roughly 3x the runner-minutes per workflow trigger. Wall-
clock unchanged (3 runners in parallel). The tradeoff is the same
one the docs E2E suite already accepted.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/223).
* #224
* __->__ #223