### PR TITLE
ci(deps): group Dependabot updates per ecosystem + run daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "03:00"
       timezone: "Asia/Tokyo"
     labels:
@@ -25,14 +24,20 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    # Roll every GitHub Actions update into a single weekly PR
+    # instead of one per action; reviewing the SHA-pinned bumps
+    # together cuts merge overhead substantially.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     open-pull-requests-limit: 5
 
   # ─── OpenTofu providers ──────────────────────
   - package-ecosystem: "terraform"
     directory: "/infra/github"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "03:00"
       timezone: "Asia/Tokyo"
     labels:
@@ -42,6 +47,10 @@ updates:
     commit-message:
       prefix: "chore(infra)"
       include: "scope"
+    groups:
+      terraform-providers:
+        patterns:
+          - "*"
     open-pull-requests-limit: 3
 
   # ─── bun — packages/mcp-server ───────────────
@@ -52,8 +61,7 @@ updates:
   - package-ecosystem: "bun"
     directory: "/packages/mcp-server"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "03:00"
       timezone: "Asia/Tokyo"
     labels:
@@ -69,6 +77,10 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    groups:
+      mcp-server-deps:
+        patterns:
+          - "*"
     open-pull-requests-limit: 5
 
   # Future ecosystems to enable in Phase 1+:


### PR DESCRIPTION

Two changes to .github/dependabot.yml:

1. Group every update inside an ecosystem into a single PR per
   day instead of one PR per dependency. Review-overhead-driven:
   the GitHub Actions ecosystem alone often queues five-plus
   separate update PRs at once (one per SHA-pinned action), each
   with the same reviewer pattern (verify the new SHA matches the
   comment, run CI, merge). Bundling them lets the reviewer batch
   the work into a single sit-down.

   Adds `groups:` blocks with a single `*` pattern per ecosystem:
   - github-actions  -> group `github-actions`
   - terraform       -> group `terraform-providers`
   - bun (mcp-server) -> group `mcp-server-deps`

2. Tighten the schedule from `weekly` (Monday 03:00 JST) to
   `daily` (03:00 JST). The grouping change above means daily no
   longer translates into a flood of PRs — at most one PR per
   ecosystem per day. Catching upstream releases the day they
   ship is more useful than letting them backlog for a week.

The existing per-ecosystem `ignore` rules (skip semver-major
bumps), labels, commit-message prefixes, and PR limits are
unchanged.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
