### PR TITLE
chore(actions): unify all upload-artifact callers to v7.0.1

### DIFF
--- a/.github/workflows/branch-fix-verdict.yml
+++ b/.github/workflows/branch-fix-verdict.yml
@@ -228,7 +228,7 @@ jobs:
           } >>"$GITHUB_STEP_SUMMARY"
 
       - name: Upload verdict bundle
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: branch-fix-verdict-${{ inputs.slug }}-${{ github.run_id }}
           path: verdict-bundle/

--- a/.github/workflows/repro-regression.yml
+++ b/.github/workflows/repro-regression.yml
@@ -414,7 +414,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Browser name in the artefact prevents one matrix slot from
           # clobbering another's report when multiple slots fail.

--- a/.github/workflows/seed-state.yml
+++ b/.github/workflows/seed-state.yml
@@ -63,7 +63,7 @@ jobs:
           echo "Resources in state: ${resource_count}"
 
       - name: Upload terraform-state artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: terraform-state
           path: ./state/terraform.tfstate

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Per-engine report name avoids artefact-upload collisions
           # when multiple matrix slots fail in the same run.


### PR DESCRIPTION

Dependabot's group bump took the four `actions/upload-artifact`
references in this repo (test-docs, branch-fix-verdict,
repro-regression, seed-state) from v4.4.2 to v4.6.2 — the latest
inside v4.x — but the project's `ignore: version-update:semver-
major` policy prevents Dependabot from crossing the v4 -> v7
boundary on its own.

v7.0.1 has been the GA actions/upload-artifact for several
months; the v4 line is on its way to retirement. Pin all four
callers to the same v7.0.1 SHA so the four upload sites stay in
lockstep and Dependabot resumes its grouped bumps from a single
known version.

Files touched:
- .github/workflows/branch-fix-verdict.yml
- .github/workflows/repro-regression.yml
- .github/workflows/seed-state.yml
- .github/workflows/test-docs.yml

Audit pass on the rest of the SHA-pinned actions in this repo
shows everything else is already on the latest GA tag the
ecosystem has shipped (checkout v6.0.2, configure-pages v6.0.0,
deploy-pages v5.0.0, github-script v9.0.0, labeler v6.1.0,
upload-pages-artifact v5.0.0, download-artifact v8.0.1,
mise-action v4.0.1, setup-bun v2.2.0, claude-code-action v1).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
