### PR TITLE
docs: refresh MCP tool count + list (5 -> 7) across guides + roadmap

### DIFF
--- a/docs/docs/en/guide/use-from-ai-agent.mdx
+++ b/docs/docs/en/guide/use-from-ai-agent.mdx
@@ -17,7 +17,7 @@ import {
   <PageHero
     eyebrow="// GUIDE · AI AGENT"
     title="Drive the Vivarium MCP server from Claude Code, Cursor, or Cline."
-    sub="Vivarium ships an MCP (Model Context Protocol) server with five tools that let an agent search the catalogue, read verdict snapshots, and scaffold branch-fix verification end-to-end. No HTML scraping of the docs site required."
+    sub="Vivarium ships an MCP (Model Context Protocol) server with seven tools that let an agent search the catalogue, read verdict snapshots, scaffold a new recipe, and scaffold branch-fix / fix-candidate verification end-to-end. No HTML scraping of the docs site required."
   />
 
   <Section
@@ -28,7 +28,7 @@ import {
       The Vivarium MCP server (<code>@aletheia-works/vivarium-mcp</code>)
       speaks{' '}
       <a href="https://modelcontextprotocol.io">Model Context Protocol</a>{' '}
-      over stdio and exposes five tools:{' '}
+      over stdio and exposes seven tools:{' '}
       <code>list_recipes</code>, <code>get_recipe</code>,{' '}
       <code>lookup_verdict</code>, <code>match_error</code>, and{' '}
       <code>verify_branch_fix</code>. An agent can browse the catalogue,
@@ -111,7 +111,7 @@ bun run build
 
   <Section
     eyebrow="// 3 · TOOLS"
-    heading="All four go through the same stdio transport."
+    heading="All seven go through the same stdio transport."
   >
     <ul>
       <li>
@@ -150,6 +150,31 @@ bun run build
         plus the <code>gh workflow run branch-fix-verdict.yml</code>{' '}
         command the contributor runs. Full walkthrough:{' '}
         <a href="/vivarium/en/guide/compare-branch-fix">Verify a branch-fix</a>.
+      </li>
+      <li>
+        <strong><code>prepare_new_recipe(project, issue, title, base_image?, repo_owner?, layer?)</code></strong> —
+        scaffolding helper for authoring a brand-new recipe in one step.
+        Returns the validated slug, the exact{' '}
+        <code>mise run recipes:new</code> /{' '}
+        <code>mise run recipes:verify</code> commands, placeholder rows
+        for <code>docs/data/recipe-facets.json</code> and (only if
+        the project is new) <code>docs/data/projects.json</code>, the
+        commit-subject template, and a sequenced next-steps checklist.
+        Layer 2 has the canonical scaffolder; Layer 1 / 3 fall back to
+        copying from an existing recipe.
+      </li>
+      <li>
+        <strong><code>prepare_fix_candidate(slug, fork_url, branch, upstream_pr?, package?, purpose?)</code></strong> —
+        scaffolding helper for registering a fix-candidate spec on an
+        existing Layer 1 recipe so the page runs the fork branch's
+        wheel side-by-side with the released build (per ADR-0040).
+        Returns the <code>fix-candidate.json</code> content the agent
+        should write, the recommended commit subject + PR title, a
+        ready-to-paste PR body, and the exact <code>gh</code> /{' '}
+        <code>git</code> commands to fork-and-clone{' '}
+        <code>aletheia-works/vivarium</code>, branch off main, drop
+        the spec in, commit, push, and open the cross-repo PR. Layer 1
+        only (Layers 2 / 3 use <code>verify_branch_fix</code>).
       </li>
     </ul>
   </Section>

--- a/docs/docs/en/roadmap.mdx
+++ b/docs/docs/en/roadmap.mdx
@@ -24,7 +24,7 @@ import {
     items={[
       { value: '11', label: 'Recipes shipped', accent: 'teal' },
       { value: '3', label: 'Execution layers', accent: 'violet' },
-      { value: '5', label: 'MCP tools', accent: 'coral' },
+      { value: '7', label: 'MCP tools', accent: 'coral' },
       { value: '2', label: 'Locales (EN / JA)', accent: 'teal' },
     ]}
   />
@@ -59,7 +59,7 @@ import {
 
     <h3>AI agent integration</h3>
     <ul>
-      <li><strong>Vivarium MCP server</strong> — five tools (<code>list_recipes</code> / <code>get_recipe</code> / <code>lookup_verdict</code> / <code>match_error</code> / <code>verify_branch_fix</code>).</li>
+      <li><strong>Vivarium MCP server</strong> — seven tools (<code>list_recipes</code> / <code>get_recipe</code> / <code>lookup_verdict</code> / <code>match_error</code> / <code>verify_branch_fix</code> / <code>prepare_new_recipe</code> / <code>prepare_fix_candidate</code>).</li>
       <li><strong>AI-slop verification flow</strong> — match the error → open a recipe → paste a candidate fix → re-run → compare verdicts side-by-side, end-to-end.</li>
     </ul>
 

--- a/docs/docs/ja/guide/use-from-ai-agent.mdx
+++ b/docs/docs/ja/guide/use-from-ai-agent.mdx
@@ -17,7 +17,7 @@ import {
   <PageHero
     eyebrow="// GUIDE · AI エージェント"
     title="Vivarium MCP サーバを Claude Code / Cursor / Cline から呼ぶ。"
-    sub="Vivarium は MCP（Model Context Protocol）サーバを同梱しており、5 つのツールでカタログ全体をエージェントから機械的に検索・取得・branch-fix 検証できる。docs サイトを HTML スクレイプする必要はない。"
+    sub="Vivarium は MCP（Model Context Protocol）サーバを同梱しており、7 つのツールでカタログ全体をエージェントから機械的に検索・取得し、新規レシピ作成や branch-fix / fix-candidate 検証も足場まで一気に組める。docs サイトを HTML スクレイプする必要はない。"
   />
 
   <Section
@@ -27,7 +27,7 @@ import {
     <p>
       Vivarium MCP サーバ (<code>@aletheia-works/vivarium-mcp</code>) は{' '}
       <a href="https://modelcontextprotocol.io">Model Context Protocol</a>{' '}
-      の stdio トランスポート経由で 5 つのツールを提供します:{' '}
+      の stdio トランスポート経由で 7 つのツールを提供します:{' '}
       <code>list_recipes</code>、<code>get_recipe</code>、
       <code>lookup_verdict</code>、<code>match_error</code>、
       <code>verify_branch_fix</code>。
@@ -110,7 +110,7 @@ bun run build
 
   <Section
     eyebrow="// 3 · ツール一覧"
-    heading="5 つすべて MCP の標準 stdio 経由で呼べる。"
+    heading="7 つすべて MCP の標準 stdio 経由で呼べる。"
   >
     <ul>
       <li>
@@ -142,6 +142,29 @@ bun run build
         <code>gh workflow run branch-fix-verdict.yml</code> コマンドと
         <code>/repro/compare</code> deep-link を返す。フルウォークスルーは{' '}
         <a href="/vivarium/ja/guide/compare-branch-fix">「ブランチ修正を検証する」</a>。
+      </li>
+      <li>
+        <strong><code>prepare_new_recipe(project, issue, title, base_image?, repo_owner?, layer?)</code></strong> —
+        新しいレシピを 1 ステップで起こすための足場ヘルパー。
+        検証済 slug、<code>mise run recipes:new</code> /{' '}
+        <code>mise run recipes:verify</code> の正確なコマンド、
+        <code>docs/data/recipe-facets.json</code>（と新しいプロジェクトのみ
+        <code>docs/data/projects.json</code>）に追加する placeholder 行、
+        コミットメッセージのテンプレート、順序付き next-steps チェックリストを返す。
+        Layer 2 にだけ専用スキャフォルダがあり、Layer 1 / 3 は既存レシピを
+        コピーする運用。
+      </li>
+      <li>
+        <strong><code>prepare_fix_candidate(slug, fork_url, branch, upstream_pr?, package?, purpose?)</code></strong> —
+        既存の Layer 1 レシピに fix-candidate 仕様を登録するための足場ヘルパー
+        （ADR-0040）。レシピページが fork branch の wheel をリリース版と並べて
+        実行できるよう、エージェントが書き込むべき{' '}
+        <code>fix-candidate.json</code> の内容、推奨コミットメッセージ + PR タイトル、
+        貼ればそのまま使える PR 本文、そして{' '}
+        <code>aletheia-works/vivarium</code> を fork-clone → main から branch →
+        spec を置く → commit / push → cross-repo PR を開くまでの{' '}
+        <code>gh</code> / <code>git</code> コマンド一式を返す。Layer 1 専用
+        （Layer 2 / 3 は <code>verify_branch_fix</code> を使う）。
       </li>
     </ul>
   </Section>

--- a/docs/docs/ja/roadmap.mdx
+++ b/docs/docs/ja/roadmap.mdx
@@ -24,7 +24,7 @@ import {
     items={[
       { value: '11', label: 'Recipes shipped', accent: 'teal' },
       { value: '3', label: 'Execution layers', accent: 'violet' },
-      { value: '5', label: 'MCP tools', accent: 'coral' },
+      { value: '7', label: 'MCP tools', accent: 'coral' },
       { value: '2', label: 'Locales (EN / JA)', accent: 'teal' },
     ]}
   />
@@ -59,7 +59,7 @@ import {
 
     <h3>AI エージェント連携</h3>
     <ul>
-      <li><strong>Vivarium MCP サーバ</strong> — 5 つのツール (<code>list_recipes</code> / <code>get_recipe</code> / <code>lookup_verdict</code> / <code>match_error</code> / <code>verify_branch_fix</code>)。</li>
+      <li><strong>Vivarium MCP サーバ</strong> — 7 つのツール (<code>list_recipes</code> / <code>get_recipe</code> / <code>lookup_verdict</code> / <code>match_error</code> / <code>verify_branch_fix</code> / <code>prepare_new_recipe</code> / <code>prepare_fix_candidate</code>)。</li>
       <li><strong>AI-slop 検証フロー</strong> — エラーをマッチ → レシピを開く → 修正候補を貼って再実行 → verdict をサイドバイサイドで比較するエンドツーエンドの動線。</li>
     </ul>
 


### PR DESCRIPTION

Catalogue copies that still advertised "five tools" were stale by
two — `prepare_new_recipe` (PR #198 era) and `prepare_fix_candidate`
(PR #214) shipped after the original copy was written but the
visitor-facing surface never caught up. Bring the count and the
itemised list inline with what the MCP server actually exposes.

Files touched (en + ja both, kept symmetric):
- docs/docs/{en,ja}/guide/use-from-ai-agent.mdx
  * Hero sub copy: "five tools" -> "seven tools" with the new
    capabilities (new-recipe scaffolding, fix-candidate scaffolding)
    folded into the one-line summary.
  * Connect section: "exposes five tools:" -> "exposes seven tools:".
  * "// 3 · TOOLS" / "// 3 · ツール一覧" section: heading bumps from
    "All four / 5 つすべて" to "All seven / 7 つすべて", and the
    `<ul>` list grows two items describing prepare_new_recipe and
    prepare_fix_candidate (mirroring the @aletheia-works/vivarium-mcp
    README's tool table).
- docs/docs/{en,ja}/roadmap.mdx
  * KpiStrip "MCP tools" stat: 5 -> 7.
  * MCP-server bullet under "Now": tool list extended with the two
    new entries.

Source-of-truth audit pass against `packages/mcp-server/src/server.ts`
confirms the seven tools are real and currently registered. No
behaviour change; no schema change.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
