### PR TITLE
fix(repro): update astroid pathological type-comment probe

### DIFF
--- a/src/layer1_wasm/astroid-2993/README.md
+++ b/src/layer1_wasm/astroid-2993/README.md
@@ -9,37 +9,36 @@
 
 [pylint-dev/astroid#2993](https://github.com/pylint-dev/astroid/issues/2993)
 — `astroid.builder.parse(code)` raises an unhandled `MemoryError`
-(or `RecursionError`, depending on the runtime) when fed a fuzzed
-type comment whose value is `i` followed by a long run of `{`
-characters:
+when fed a fuzzed type comment whose value is `i` followed by a long
+run of `{` characters:
 
 ```python
 import astroid
-code = "a=b # type:i" + "{" * 270
+code = "a = b # type:i" + "{" * 200
 astroid.builder.parse(code)
-# MemoryError (or RecursionError) — propagates out of `parse`
+# MemoryError — propagates out of `parse`
 ```
 
 The fuzzed input is from OSS-Fuzz; the upstream issue references the
 internal report at <https://issues.oss-fuzz.com/issues/489780714>.
 CPython's compiler walks the type-comment expression recursively and
-either runs out of stack or memory; astroid does not catch the
-runtime error in its type-comment parser, so the exception
-propagates out of `parse` and crashes any tool built on it (pylint,
-IDE plugins, etc.).
+runs out of memory; astroid 4.1.2 does not cut off pathological
+nesting before parsing, so the exception propagates out of `parse`
+and crashes any tool built on it (pylint, IDE plugins, etc.).
 
-The expected fix mirrors astroid's #2762 fix for f-strings (shipped
-in 4.1.2): catch `MemoryError`/`RecursionError` in the type-comment
-parser and treat the comment as opaque.
+The expected fix detects pathological nesting before calling Python's
+parser, skips the invalid type comment, and still parses deeply nested
+but valid type comments.
 
 ## Why this bug
 
 - Pure Python — astroid has only one required dependency
   (`typing-extensions`, already bundled by Pyodide). No native
   extensions, no I/O, no thread-scheduler dependence.
-- Reproduction is a single `astroid.builder.parse(code)` call;
-  verdict reduces to a boolean (did `parse` raise an unhandled
-  runtime error or not).
+- Reproduction is a small set of `astroid.builder.parse(code)` calls:
+  assignment and function pathological type comments must not crash
+  after the fix, while a deeply nested but valid type comment must
+  still parse.
 - Reported against astroid 4.1.x. Latest release at authoring time
   is 4.1.2 (2026-03-22) and the bug still reproduces there; pinning
   in PEP 723 / `repro.ts` to that exact version locks the verdict
@@ -76,19 +75,20 @@ fix-candidate panel intentionally does not surface a separate
 would mis-cue a successful fix as a failure (the fix candidate
 *should* not reproduce — that is the desired outcome). Visitors
 read each variant's outcome from the JSON inside its own `<pre>`
-(`crashed: true|false`, `exception_type`).
+(`crashed: true|false`, `skipped_pathological`,
+`valid_control_parsed`, and per-case details).
 
 The `result` field of `__VIVARIUM_RESULT__` keeps the legacy
 `nested_braces` / `exception_type` / `crashed` fields and additively
-gains `result.baseline` and `result.fix_candidate` sub-objects, each
-with that variant's own verdict + parsed astroid version.
+gains `skipped_pathological`, `valid_control_parsed`, `cases`,
+`result.baseline`, and `result.fix_candidate`, with each variant's
+own verdict + parsed astroid version.
 
 A `reproduced` verdict means **the bug reproduced** in that variant —
-`astroid.builder.parse` raised an unhandled `MemoryError` /
-`RecursionError` (or any non-`AstroidSyntaxError`). An
-`unreproduced` verdict means either the variant ships a graceful catch
-(`AstroidSyntaxError` or clean return), or the runtime errored
-before producing a result.
+a pathological type comment crashed `astroid.builder.parse`. An
+`unreproduced` verdict means the pathological assignment and function
+type comments were skipped before parsing and the valid deep-nesting
+control still parsed, or the runtime errored before producing a result.
 
 ## Two-variant fix verification
 
@@ -99,7 +99,7 @@ disappearing under the in-flight upstream PR in one page load:
 | Variant         | Source                                                   | Expected outcome |
 | --------------- | -------------------------------------------------------- | ---------------- |
 | `baseline`      | `astroid==4.1.2` from PyPI                               | `crashed: true`  |
-| `fix-candidate` | Wheel under `./wheels/`, built from the fork branch the upstream PR is opened from. Currently `JamBalaya56562/astroid@claude/fix-astroid-2993-wVitv` (see [PR #1](https://github.com/JamBalaya56562/astroid/pull/1)). | `crashed: false` |
+| `fix-candidate` | Wheel under `./wheels/`, built from the fork branch opened as [pylint-dev/astroid#3049](https://github.com/pylint-dev/astroid/pull/3049). Currently `JamBalaya56562/astroid@claude/fix-astroid-2993-wVitv`. | `crashed: false`, `skipped_pathological: true`, `valid_control_parsed: true` |
 
 The two runs share the same Pyodide instance — between variants the
 runtime calls `micropip.uninstall("astroid")`, drops `astroid*` from
@@ -153,8 +153,8 @@ Verify both variants natively before pushing:
 
 ```bash
 mise exec uv -- uv run src/layer1_wasm/astroid-2993/verify_fix.py
-# verdict=fix-candidate-confirmed — baseline still reproduces
-#   and the fix candidate flips the verdict to unreproduced.
+# verdict=fix-candidate-confirmed — baseline still reproduces and
+#   the fix candidate skips pathological type comments before parsing.
 ```
 
 ## Running locally — in-browser
@@ -177,7 +177,7 @@ Pyodide-bundled packages.
 ```bash
 mise install
 mise exec uv -- uv run src/layer1_wasm/astroid-2993/repro.py
-# verdict=reproduced — astroid.builder.parse raised MemoryError on a fuzzed type comment
+# verdict=reproduced — astroid.builder.parse raised MemoryError on a pathological type comment
 ```
 
 ## Deployment

--- a/src/layer1_wasm/astroid-2993/fix-candidate.json
+++ b/src/layer1_wasm/astroid-2993/fix-candidate.json
@@ -7,5 +7,5 @@
     "url": "https://github.com/JamBalaya56562/astroid",
     "ref": "claude/fix-astroid-2993-wVitv"
   },
-  "upstream_pr": "https://github.com/JamBalaya56562/astroid/pull/1"
+  "upstream_pr": "https://github.com/pylint-dev/astroid/pull/3049"
 }

--- a/src/layer1_wasm/astroid-2993/index.html
+++ b/src/layer1_wasm/astroid-2993/index.html
@@ -25,29 +25,23 @@
       <div class="vh-drawer__body" id="vh-drawer-body">
         <p>
           A fuzzed type comment such as
-          <code>a=b # type:i{{{...{{</code> — `i` followed by a long
+          <code>a = b # type:i{{{...{{</code> — `i` followed by a long
           run of <code>{</code> characters — makes
           <code>astroid.builder.parse</code> raise an unhandled
-          <code>MemoryError</code> (or <code>RecursionError</code>,
-          depending on the runtime). The crash propagates out of any
-          tool built on astroid, including pylint and most IDE
-          plugins.
+          <code>MemoryError</code>. The crash propagates out of any tool
+          built on astroid, including pylint and most IDE plugins.
         </p>
         <p>
           The script on this page installs astroid into Pyodide via
-          <code>micropip</code>, feeds it the fuzzed input, and
-          watches for an unhandled exception. If
-          <code>astroid.builder.parse</code> raises anything other
-          than <code>AstroidSyntaxError</code>, the bug reproduces in
-          the runtime currently loaded in your browser tab.
+          <code>micropip</code>, feeds it assignment and function type
+          comments with pathological nesting, and checks whether the
+          comments crash parsing or are skipped as invalid.
         </p>
         <p>
-          The expected fix mirrors astroid's #2762 fix for f-strings
-          (shipped in 4.1.2): catch
-          <code>MemoryError</code>/<code>RecursionError</code> in the
-          type-comment parser and treat the comment as opaque. The
-          full discussion lives in the GitHub issue thread linked
-          below.
+          The expected fix detects pathological nesting before calling
+          Python's parser, treats that type comment as opaque, and still
+          parses deeply nested but valid type comments. The full
+          discussion lives in the GitHub issue and PR linked below.
         </p>
       </div>
       <hr class="vh-drawer__divider" />
@@ -78,7 +72,7 @@
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
               Upstream issue
             </a>
-            <a class="vh-chip" href="https://github.com/JamBalaya56562/astroid/pull/1" target="_blank" rel="noreferrer">
+            <a class="vh-chip" href="https://github.com/pylint-dev/astroid/pull/3049" target="_blank" rel="noreferrer">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><line x1="6" y1="9" x2="6" y2="21"/></svg>
               Fix candidate PR
             </a>
@@ -98,31 +92,86 @@
           <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
 <span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> astroid</span></span>
 <span class="line"></span>
-<span class="line"><span style="color:#79B8FF">NESTED</span><span style="color:#F97583"> =</span><span style="color:#79B8FF"> 270</span></span>
-<span class="line"><span style="color:#E1E4E8">code </span><span style="color:#F97583">=</span><span style="color:#9ECBFF"> "a=b # type:i"</span><span style="color:#F97583"> +</span><span style="color:#9ECBFF"> "{"</span><span style="color:#F97583"> *</span><span style="color:#79B8FF"> NESTED</span></span>
+<span class="line"><span style="color:#79B8FF">NESTED</span><span style="color:#F97583"> =</span><span style="color:#79B8FF"> 200</span></span>
+<span class="line"><span style="color:#79B8FF">VALID_DEPTH</span><span style="color:#F97583"> =</span><span style="color:#79B8FF"> 20</span></span>
+<span class="line"></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">def</span><span style="color:#B392F0"> case_result</span><span style="color:#E1E4E8">(name, code, inspect):</span></span>
+<span class="line"><span style="color:#E1E4E8">    out </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span style="color:#9ECBFF">        "name"</span><span style="color:#E1E4E8">: name,</span></span>
+<span class="line"><span style="color:#9ECBFF">        "exception_type"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">None</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">        "exception_message"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">None</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">        "crashed"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">False</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    }</span></span>
+<span class="line"><span style="color:#F97583">    try</span><span style="color:#E1E4E8">:</span></span>
+<span class="line"><span style="color:#E1E4E8">        module </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> astroid.builder.parse(code)</span></span>
+<span class="line"><span style="color:#E1E4E8">        out.update(inspect(module))</span></span>
+<span class="line"><span style="color:#F97583">    except</span><span style="color:#E1E4E8"> astroid.exceptions.AstroidSyntaxError </span><span style="color:#F97583">as</span><span style="color:#E1E4E8"> e:</span></span>
+<span class="line"><span style="color:#E1E4E8">        out[</span><span style="color:#9ECBFF">"exception_type"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#9ECBFF"> "AstroidSyntaxError"</span></span>
+<span class="line"><span style="color:#E1E4E8">        out[</span><span style="color:#9ECBFF">"exception_message"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> str</span><span style="color:#E1E4E8">(e)[:</span><span style="color:#79B8FF">200</span><span style="color:#E1E4E8">]</span></span>
+<span class="line"><span style="color:#F97583">    except</span><span style="color:#E1E4E8"> (</span><span style="color:#79B8FF">MemoryError</span><span style="color:#E1E4E8">, </span><span style="color:#79B8FF">RecursionError</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">as</span><span style="color:#E1E4E8"> e:</span></span>
+<span class="line"><span style="color:#E1E4E8">        out[</span><span style="color:#9ECBFF">"exception_type"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> type</span><span style="color:#E1E4E8">(e).</span><span style="color:#79B8FF">__name__</span></span>
+<span class="line"><span style="color:#E1E4E8">        out[</span><span style="color:#9ECBFF">"exception_message"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> str</span><span style="color:#E1E4E8">(e)[:</span><span style="color:#79B8FF">200</span><span style="color:#E1E4E8">]</span></span>
+<span class="line"><span style="color:#E1E4E8">        out[</span><span style="color:#9ECBFF">"crashed"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> True</span></span>
+<span class="line"><span style="color:#F97583">    except</span><span style="color:#79B8FF"> Exception</span><span style="color:#F97583"> as</span><span style="color:#E1E4E8"> e:</span></span>
+<span class="line"><span style="color:#E1E4E8">        out[</span><span style="color:#9ECBFF">"exception_type"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> type</span><span style="color:#E1E4E8">(e).</span><span style="color:#79B8FF">__name__</span></span>
+<span class="line"><span style="color:#E1E4E8">        out[</span><span style="color:#9ECBFF">"exception_message"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> str</span><span style="color:#E1E4E8">(e)[:</span><span style="color:#79B8FF">200</span><span style="color:#E1E4E8">]</span></span>
+<span class="line"><span style="color:#E1E4E8">        out[</span><span style="color:#9ECBFF">"crashed"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> True</span></span>
+<span class="line"><span style="color:#F97583">    return</span><span style="color:#E1E4E8"> out</span></span>
+<span class="line"></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">def</span><span style="color:#B392F0"> inspect_assignment</span><span style="color:#E1E4E8">(module):</span></span>
+<span class="line"><span style="color:#F97583">    return</span><span style="color:#E1E4E8"> {</span><span style="color:#9ECBFF">"type_annotation_is_none"</span><span style="color:#E1E4E8">: module.body[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">].type_annotation </span><span style="color:#F97583">is</span><span style="color:#79B8FF"> None</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">def</span><span style="color:#B392F0"> inspect_function</span><span style="color:#E1E4E8">(module):</span></span>
+<span class="line"><span style="color:#E1E4E8">    node </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> module.body[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">]</span></span>
+<span class="line"><span style="color:#F97583">    return</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span style="color:#9ECBFF">        "type_comment_returns_is_none"</span><span style="color:#E1E4E8">: node.type_comment_returns </span><span style="color:#F97583">is</span><span style="color:#79B8FF"> None</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">        "type_comment_args_is_none"</span><span style="color:#E1E4E8">: node.type_comment_args </span><span style="color:#F97583">is</span><span style="color:#79B8FF"> None</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    }</span></span>
+<span class="line"></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">def</span><span style="color:#B392F0"> inspect_valid_assignment</span><span style="color:#E1E4E8">(module):</span></span>
+<span class="line"><span style="color:#F97583">    return</span><span style="color:#E1E4E8"> {</span><span style="color:#9ECBFF">"type_annotation_is_present"</span><span style="color:#E1E4E8">: module.body[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">].type_annotation </span><span style="color:#F97583">is</span><span style="color:#F97583"> not</span><span style="color:#79B8FF"> None</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">assignment_code </span><span style="color:#F97583">=</span><span style="color:#9ECBFF"> "a = b # type:i"</span><span style="color:#F97583"> +</span><span style="color:#9ECBFF"> "{"</span><span style="color:#F97583"> *</span><span style="color:#79B8FF"> NESTED</span></span>
+<span class="line"><span style="color:#E1E4E8">function_code </span><span style="color:#F97583">=</span><span style="color:#9ECBFF"> "def func():</span><span style="color:#79B8FF">\n</span><span style="color:#9ECBFF">    # type: i"</span><span style="color:#F97583"> +</span><span style="color:#9ECBFF"> "{"</span><span style="color:#F97583"> *</span><span style="color:#79B8FF"> NESTED</span><span style="color:#F97583"> +</span><span style="color:#9ECBFF"> "</span><span style="color:#79B8FF">\n</span><span style="color:#9ECBFF">    pass</span><span style="color:#79B8FF">\n</span><span style="color:#9ECBFF">"</span></span>
+<span class="line"><span style="color:#E1E4E8">valid_inner </span><span style="color:#F97583">=</span><span style="color:#9ECBFF"> "List["</span><span style="color:#F97583"> *</span><span style="color:#79B8FF"> VALID_DEPTH</span><span style="color:#F97583"> +</span><span style="color:#9ECBFF"> "int"</span><span style="color:#F97583"> +</span><span style="color:#9ECBFF"> "]"</span><span style="color:#F97583"> *</span><span style="color:#79B8FF"> VALID_DEPTH</span></span>
+<span class="line"><span style="color:#E1E4E8">valid_code </span><span style="color:#F97583">=</span><span style="color:#F97583"> f</span><span style="color:#9ECBFF">"a = b # type: </span><span style="color:#79B8FF">{</span><span style="color:#E1E4E8">valid_inner</span><span style="color:#79B8FF">}</span><span style="color:#9ECBFF">"</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">assignment </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> case_result(</span><span style="color:#9ECBFF">"pathological_assignment"</span><span style="color:#E1E4E8">, assignment_code, inspect_assignment)</span></span>
+<span class="line"><span style="color:#E1E4E8">function </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> case_result(</span><span style="color:#9ECBFF">"pathological_function"</span><span style="color:#E1E4E8">, function_code, inspect_function)</span></span>
+<span class="line"><span style="color:#E1E4E8">valid_control </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> case_result(</span><span style="color:#9ECBFF">"valid_deep_nesting"</span><span style="color:#E1E4E8">, valid_code, inspect_valid_assignment)</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">pathological_cases </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> [assignment, function]</span></span>
+<span class="line"><span style="color:#E1E4E8">crashed </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> any</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">bool</span><span style="color:#E1E4E8">(case[</span><span style="color:#9ECBFF">"crashed"</span><span style="color:#E1E4E8">]) </span><span style="color:#F97583">for</span><span style="color:#E1E4E8"> case </span><span style="color:#F97583">in</span><span style="color:#E1E4E8"> pathological_cases)</span></span>
+<span class="line"><span style="color:#E1E4E8">skipped_pathological </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> (</span></span>
+<span class="line"><span style="color:#E1E4E8">    assignment.get(</span><span style="color:#9ECBFF">"type_annotation_is_none"</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">is</span><span style="color:#79B8FF"> True</span></span>
+<span class="line"><span style="color:#F97583">    and</span><span style="color:#E1E4E8"> function.get(</span><span style="color:#9ECBFF">"type_comment_returns_is_none"</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">is</span><span style="color:#79B8FF"> True</span></span>
+<span class="line"><span style="color:#F97583">    and</span><span style="color:#E1E4E8"> function.get(</span><span style="color:#9ECBFF">"type_comment_args_is_none"</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">is</span><span style="color:#79B8FF"> True</span></span>
+<span class="line"><span style="color:#E1E4E8">)</span></span>
+<span class="line"><span style="color:#E1E4E8">valid_control_parsed </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> valid_control.get(</span><span style="color:#9ECBFF">"type_annotation_is_present"</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">is</span><span style="color:#79B8FF"> True</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#E1E4E8">result </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> {</span></span>
 <span class="line"><span style="color:#9ECBFF">    "astroid_version"</span><span style="color:#E1E4E8">: astroid.</span><span style="color:#79B8FF">__version__</span><span style="color:#E1E4E8">,</span></span>
 <span class="line"><span style="color:#9ECBFF">    "python_version"</span><span style="color:#E1E4E8">: sys.version.split()[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
 <span class="line"><span style="color:#9ECBFF">    "nested_braces"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">NESTED</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#9ECBFF">    "exception_type"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">None</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#9ECBFF">    "exception_message"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">None</span><span style="color:#E1E4E8">,</span></span>
-<span class="line"><span style="color:#9ECBFF">    "crashed"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">False</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "valid_depth"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">VALID_DEPTH</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "exception_type"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">next</span><span style="color:#E1E4E8">(</span></span>
+<span class="line"><span style="color:#E1E4E8">        (case[</span><span style="color:#9ECBFF">"exception_type"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">for</span><span style="color:#E1E4E8"> case </span><span style="color:#F97583">in</span><span style="color:#E1E4E8"> pathological_cases </span><span style="color:#F97583">if</span><span style="color:#E1E4E8"> case[</span><span style="color:#9ECBFF">"crashed"</span><span style="color:#E1E4E8">]),</span></span>
+<span class="line"><span style="color:#79B8FF">        None</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">    ),</span></span>
+<span class="line"><span style="color:#9ECBFF">    "crashed"</span><span style="color:#E1E4E8">: crashed,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "skipped_pathological"</span><span style="color:#E1E4E8">: skipped_pathological,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "valid_control_parsed"</span><span style="color:#E1E4E8">: valid_control_parsed,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "cases"</span><span style="color:#E1E4E8">: {</span></span>
+<span class="line"><span style="color:#9ECBFF">        "assignment"</span><span style="color:#E1E4E8">: assignment,</span></span>
+<span class="line"><span style="color:#9ECBFF">        "function"</span><span style="color:#E1E4E8">: function,</span></span>
+<span class="line"><span style="color:#9ECBFF">        "valid_control"</span><span style="color:#E1E4E8">: valid_control,</span></span>
+<span class="line"><span style="color:#E1E4E8">    },</span></span>
 <span class="line"><span style="color:#E1E4E8">}</span></span>
-<span class="line"></span>
-<span class="line"><span style="color:#F97583">try</span><span style="color:#E1E4E8">:</span></span>
-<span class="line"><span style="color:#E1E4E8">    astroid.builder.parse(code)</span></span>
-<span class="line"><span style="color:#F97583">except</span><span style="color:#E1E4E8"> astroid.exceptions.AstroidSyntaxError </span><span style="color:#F97583">as</span><span style="color:#E1E4E8"> e:</span></span>
-<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"exception_type"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#9ECBFF"> "AstroidSyntaxError"</span></span>
-<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"exception_message"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> str</span><span style="color:#E1E4E8">(e)[:</span><span style="color:#79B8FF">200</span><span style="color:#E1E4E8">]</span></span>
-<span class="line"><span style="color:#F97583">except</span><span style="color:#E1E4E8"> (</span><span style="color:#79B8FF">MemoryError</span><span style="color:#E1E4E8">, </span><span style="color:#79B8FF">RecursionError</span><span style="color:#E1E4E8">) </span><span style="color:#F97583">as</span><span style="color:#E1E4E8"> e:</span></span>
-<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"exception_type"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> type</span><span style="color:#E1E4E8">(e).</span><span style="color:#79B8FF">__name__</span></span>
-<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"exception_message"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> str</span><span style="color:#E1E4E8">(e)[:</span><span style="color:#79B8FF">200</span><span style="color:#E1E4E8">]</span></span>
-<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"crashed"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> True</span></span>
-<span class="line"><span style="color:#F97583">except</span><span style="color:#79B8FF"> Exception</span><span style="color:#F97583"> as</span><span style="color:#E1E4E8"> e:</span></span>
-<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"exception_type"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> type</span><span style="color:#E1E4E8">(e).</span><span style="color:#79B8FF">__name__</span></span>
-<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"exception_message"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> str</span><span style="color:#E1E4E8">(e)[:</span><span style="color:#79B8FF">200</span><span style="color:#E1E4E8">]</span></span>
-<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"crashed"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> True</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#E1E4E8">result</span></span></code></pre>
         </section>

--- a/src/layer1_wasm/astroid-2993/repro.py
+++ b/src/layer1_wasm/astroid-2993/repro.py
@@ -17,19 +17,16 @@ PEP 723 inline metadata pins **astroid 4.1.2** — the latest release at
 authoring time. `uv run` reads the metadata and creates an ephemeral
 venv on first invocation; subsequent runs hit uv's cache.
 
-The fuzzed input is a single-line assignment with a type comment
-``# type:i{{{...{{`` whose value is `i` followed by a long run of
-``{`` characters. CPython's compiler walks the type-comment expression
-recursively and either runs out of stack (RecursionError) or memory
-(MemoryError); astroid does not catch either, so the exception
-propagates out of ``astroid.builder.parse``. The expected fix —
-mirroring the f-string fix in #2762 / 4.1.2 — is for astroid to catch
-the runtime error in its type-comment parser and treat the comment as
-opaque.
+The fuzzed inputs are assignment and function type comments whose
+values are ``i`` followed by 200 unclosed ``{`` characters. Older
+astroid versions hand the comments to CPython's parser and leak the
+resulting ``MemoryError``. The fix candidate should detect this
+pathological nesting before parsing, skip the invalid type comment, and
+still parse deeply nested but valid type comments.
 
-Exits 0 on `pass` (bug REPRODUCED — astroid raised), 1 on `fail` (bug
-not reproduced — astroid returned cleanly or raised the expected
-``AstroidSyntaxError``).
+Exits 0 on `pass` (bug REPRODUCED — a pathological type comment
+crashed astroid), 1 on `fail` (bug not reproduced — both pathological
+comments were skipped and the valid deep-nesting control still parsed).
 """
 
 import json
@@ -37,54 +34,107 @@ import sys
 
 import astroid
 
-# ~270 nested `{` mirrors the fuzz from the upstream issue; in CPython
-# 3.13 this exceeds the compiler's stack budget. Pyodide WASM hits the
-# same threshold because it uses the same CPython source.
-NESTED = 270
-CODE = "a=b # type:i" + "{" * NESTED
+NESTED = 200
+VALID_DEPTH = 20
+
+
+def case_result(name: str, code: str, inspect) -> dict[str, object]:
+    out: dict[str, object] = {
+        "name": name,
+        "exception_type": None,
+        "exception_message": None,
+        "crashed": False,
+    }
+    try:
+        module = astroid.builder.parse(code)
+        out.update(inspect(module))
+    except astroid.exceptions.AstroidSyntaxError as e:
+        out["exception_type"] = "AstroidSyntaxError"
+        out["exception_message"] = str(e)[:200]
+    except (MemoryError, RecursionError) as e:
+        out["exception_type"] = type(e).__name__
+        out["exception_message"] = str(e)[:200]
+        out["crashed"] = True
+    except Exception as e:
+        out["exception_type"] = type(e).__name__
+        out["exception_message"] = str(e)[:200]
+        out["crashed"] = True
+    return out
+
+
+def inspect_assignment(module) -> dict[str, object]:
+    return {"type_annotation_is_none": module.body[0].type_annotation is None}
+
+
+def inspect_function(module) -> dict[str, object]:
+    node = module.body[0]
+    return {
+        "type_comment_returns_is_none": node.type_comment_returns is None,
+        "type_comment_args_is_none": node.type_comment_args is None,
+    }
+
+
+def inspect_valid_assignment(module) -> dict[str, object]:
+    return {"type_annotation_is_present": module.body[0].type_annotation is not None}
+
+
+assignment_code = "a = b # type:i" + "{" * NESTED
+function_code = "def func():\n    # type: i" + "{" * NESTED + "\n    pass\n"
+valid_inner = "List[" * VALID_DEPTH + "int" + "]" * VALID_DEPTH
+valid_code = f"a = b # type: {valid_inner}"
+
+assignment = case_result("pathological_assignment", assignment_code, inspect_assignment)
+function = case_result("pathological_function", function_code, inspect_function)
+valid_control = case_result("valid_deep_nesting", valid_code, inspect_valid_assignment)
+
+pathological_cases = [assignment, function]
+crashed = any(bool(case["crashed"]) for case in pathological_cases)
+skipped_pathological = (
+    assignment.get("type_annotation_is_none") is True
+    and function.get("type_comment_returns_is_none") is True
+    and function.get("type_comment_args_is_none") is True
+)
+valid_control_parsed = valid_control.get("type_annotation_is_present") is True
 
 result = {
     "astroid_version": astroid.__version__,
     "python_version": sys.version.split()[0],
     "nested_braces": NESTED,
-    "exception_type": None,
-    "exception_message": None,
-    "crashed": False,
+    "valid_depth": VALID_DEPTH,
+    "exception_type": next(
+        (case["exception_type"] for case in pathological_cases if case["crashed"]),
+        None,
+    ),
+    "crashed": crashed,
+    "skipped_pathological": skipped_pathological,
+    "valid_control_parsed": valid_control_parsed,
+    "cases": {
+        "assignment": assignment,
+        "function": function,
+        "valid_control": valid_control,
+    },
 }
-
-try:
-    astroid.builder.parse(CODE)
-except astroid.exceptions.AstroidSyntaxError as e:
-    # Graceful: astroid wrapped the underlying SyntaxError in its own
-    # exception type. Not the bug.
-    result["exception_type"] = "AstroidSyntaxError"
-    result["exception_message"] = str(e)[:200]
-except (MemoryError, RecursionError) as e:
-    # The bug: astroid leaked the underlying CPython runtime error
-    # instead of catching it the way #2762 / 4.1.2 did for f-strings.
-    result["exception_type"] = type(e).__name__
-    result["exception_message"] = str(e)[:200]
-    result["crashed"] = True
-except Exception as e:
-    # Any other unhandled exception is also the bug — astroid should
-    # not surface arbitrary parser errors to its callers.
-    result["exception_type"] = type(e).__name__
-    result["exception_message"] = str(e)[:200]
-    result["crashed"] = True
 
 print(json.dumps(result, indent=2))
 
-if result["crashed"]:
+if crashed:
     print(
         f"verdict=reproduced — astroid.builder.parse raised "
-        f"{result['exception_type']} on a fuzzed type comment",
+        f"{result['exception_type']} on a pathological type comment",
         file=sys.stderr,
     )
     sys.exit(0)
+elif skipped_pathological and valid_control_parsed:
+    print(
+        "verdict=unreproduced — astroid skipped pathological type "
+        "comments before parsing and kept valid deep nesting intact",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 else:
     print(
-        "verdict=unreproduced — astroid handled the fuzzed type comment "
-        "without an unhandled runtime error (likely fixed upstream)",
+        "verdict=unreproduced — astroid no longer crashes, but the "
+        "pathological-skip or valid-control assertions did not all pass",
         file=sys.stderr,
     )
     sys.exit(1)

--- a/src/layer1_wasm/astroid-2993/repro.ts
+++ b/src/layer1_wasm/astroid-2993/repro.ts
@@ -1,31 +1,30 @@
 // Vivarium Layer 1 reproduction — pylint-dev/astroid#2993.
 //
-// `astroid.builder.parse(code)` raises an unhandled `MemoryError` (or
-// `RecursionError`, depending on the runtime) when fed a fuzzed type
-// comment like `a=b # type:i{{{{...{{`. CPython's compiler walks the
-// type-comment expression recursively; astroid does not catch the
-// runtime error, so it propagates out of `parse` and crashes any
-// caller (pylint, IDE plugins, etc.).
+// `astroid.builder.parse(code)` raises an unhandled `MemoryError`
+// when fed a fuzzed type comment like `a = b # type:i{{{{...{{`.
+// CPython's compiler walks the type-comment expression recursively;
+// astroid 4.1.2 does not cut off pathological nesting before parsing,
+// so the runtime error propagates out of `parse` and crashes any caller
+// (pylint, IDE plugins, etc.).
 //
-// The expected fix mirrors astroid's #2762 fix for f-strings (shipped
-// in 4.1.2): catch `MemoryError`/`RecursionError` in the type-comment
-// parser and treat the comment as opaque. The fix candidate this page
-// renders side-by-side is the in-flight upstream PR
-// (https://github.com/JamBalaya56562/astroid/pull/1) — built into a
-// pure-Python wheel committed under `./wheels/` and installed into
-// the same Pyodide tab so visitors can compare the before/after
-// verdict in one page load.
+// The expected fix detects pathological type-comment nesting up front,
+// skips that invalid type comment without parsing it, and still parses
+// deeply nested but valid type comments. The fix candidate this page
+// renders side-by-side is upstream PR #3049
+// (https://github.com/pylint-dev/astroid/pull/3049) — built into a
+// pure-Python wheel under `./wheels/` and installed into the same
+// Pyodide tab so visitors can compare the before/after verdict in one
+// page load.
 //
 // Verdict semantics (per ADR-0008 / contract v1) — applied to each
 // variant card individually; the top-level `#verdict` pill mirrors the
 // **baseline** variant so the existing Contract v1 single-verdict
 // surface (`__VIVARIUM_VERDICT__`, `data-verdict`) keeps its prior
 // meaning and downstream consumers do not need to branch.
-//   - "reproduced" — `astroid.builder.parse` raised an unhandled
-//     `MemoryError` / `RecursionError` (or any non-`AstroidSyntaxError`).
-//   - "unreproduced" — `parse` returned cleanly, or raised
-//     `AstroidSyntaxError` (which would mean upstream landed a
-//     graceful catch).
+//   - "reproduced" — a pathological type comment crashed
+//     `astroid.builder.parse`.
+//   - "unreproduced" — both pathological comments were skipped before
+//     parsing and the valid deep-nesting control still parsed.
 
 import { loadVivariumPyodide } from '../_shared/loader.js';
 import type { PathACapturedRun } from '../_shared/path_a.js';
@@ -36,52 +35,123 @@ import {
   type VivariumResultV1,
 } from '../_shared/verdict.js';
 
-// 270 nested `{` mirrors the fuzz from the upstream issue. The exact
-// threshold at which CPython's compiler runs out of stack is
-// implementation-dependent; 270 reproduces reliably on the Python
-// 3.13 build Pyodide v0.29.3 ships. Hardcoded inside the template
-// literal so the build-time syntax highlighter (which does not
-// expand ${…} substitutions) renders the source visitors run.
+// 200 nested `{` matches the minimized upstream regression test in
+// PR #3049. Hardcoded inside the template literal so the build-time
+// syntax highlighter (which does not expand ${…} substitutions)
+// renders the source visitors run.
 const REPRO_CODE = `
 import sys
 import astroid
 
-NESTED = 270
-code = "a=b # type:i" + "{" * NESTED
+NESTED = 200
+VALID_DEPTH = 20
+
+
+def case_result(name, code, inspect):
+    out = {
+        "name": name,
+        "exception_type": None,
+        "exception_message": None,
+        "crashed": False,
+    }
+    try:
+        module = astroid.builder.parse(code)
+        out.update(inspect(module))
+    except astroid.exceptions.AstroidSyntaxError as e:
+        out["exception_type"] = "AstroidSyntaxError"
+        out["exception_message"] = str(e)[:200]
+    except (MemoryError, RecursionError) as e:
+        out["exception_type"] = type(e).__name__
+        out["exception_message"] = str(e)[:200]
+        out["crashed"] = True
+    except Exception as e:
+        out["exception_type"] = type(e).__name__
+        out["exception_message"] = str(e)[:200]
+        out["crashed"] = True
+    return out
+
+
+def inspect_assignment(module):
+    return {"type_annotation_is_none": module.body[0].type_annotation is None}
+
+
+def inspect_function(module):
+    node = module.body[0]
+    return {
+        "type_comment_returns_is_none": node.type_comment_returns is None,
+        "type_comment_args_is_none": node.type_comment_args is None,
+    }
+
+
+def inspect_valid_assignment(module):
+    return {"type_annotation_is_present": module.body[0].type_annotation is not None}
+
+
+assignment_code = "a = b # type:i" + "{" * NESTED
+function_code = "def func():\\n    # type: i" + "{" * NESTED + "\\n    pass\\n"
+valid_inner = "List[" * VALID_DEPTH + "int" + "]" * VALID_DEPTH
+valid_code = f"a = b # type: {valid_inner}"
+
+assignment = case_result("pathological_assignment", assignment_code, inspect_assignment)
+function = case_result("pathological_function", function_code, inspect_function)
+valid_control = case_result("valid_deep_nesting", valid_code, inspect_valid_assignment)
+
+pathological_cases = [assignment, function]
+crashed = any(bool(case["crashed"]) for case in pathological_cases)
+skipped_pathological = (
+    assignment.get("type_annotation_is_none") is True
+    and function.get("type_comment_returns_is_none") is True
+    and function.get("type_comment_args_is_none") is True
+)
+valid_control_parsed = valid_control.get("type_annotation_is_present") is True
 
 result = {
     "astroid_version": astroid.__version__,
     "python_version": sys.version.split()[0],
     "nested_braces": NESTED,
-    "exception_type": None,
-    "exception_message": None,
-    "crashed": False,
+    "valid_depth": VALID_DEPTH,
+    "exception_type": next(
+        (case["exception_type"] for case in pathological_cases if case["crashed"]),
+        None,
+    ),
+    "crashed": crashed,
+    "skipped_pathological": skipped_pathological,
+    "valid_control_parsed": valid_control_parsed,
+    "cases": {
+        "assignment": assignment,
+        "function": function,
+        "valid_control": valid_control,
+    },
 }
-
-try:
-    astroid.builder.parse(code)
-except astroid.exceptions.AstroidSyntaxError as e:
-    result["exception_type"] = "AstroidSyntaxError"
-    result["exception_message"] = str(e)[:200]
-except (MemoryError, RecursionError) as e:
-    result["exception_type"] = type(e).__name__
-    result["exception_message"] = str(e)[:200]
-    result["crashed"] = True
-except Exception as e:
-    result["exception_type"] = type(e).__name__
-    result["exception_message"] = str(e)[:200]
-    result["crashed"] = True
 
 result
 `.trim();
+
+interface ReproCaseOutput {
+  name: string;
+  exception_type: string | null;
+  exception_message: string | null;
+  crashed: boolean;
+  type_annotation_is_none?: boolean;
+  type_comment_returns_is_none?: boolean;
+  type_comment_args_is_none?: boolean;
+  type_annotation_is_present?: boolean;
+}
 
 interface ReproOutput {
   astroid_version: string;
   python_version: string;
   nested_braces: number;
+  valid_depth: number;
   exception_type: string | null;
-  exception_message: string | null;
   crashed: boolean;
+  skipped_pathological: boolean;
+  valid_control_parsed: boolean;
+  cases: {
+    assignment: ReproCaseOutput;
+    function: ReproCaseOutput;
+    valid_control: ReproCaseOutput;
+  };
 }
 
 interface PyodideRuntime {
@@ -135,31 +205,51 @@ function evaluate(result: ReproOutput): {
   if (result.crashed) {
     return {
       verdict: 'reproduced',
-      message: `bug reproduced — astroid.builder.parse raised ${result.exception_type} on a fuzzed type comment.`,
+      message: `bug reproduced — astroid.builder.parse raised ${result.exception_type} on a pathological type comment.`,
+    };
+  }
+  if (result.skipped_pathological && result.valid_control_parsed) {
+    return {
+      verdict: 'unreproduced',
+      message:
+        'bug not reproduced — astroid skipped pathological type comments before parsing and kept valid deep nesting intact.',
     };
   }
   return {
     verdict: 'unreproduced',
     message:
-      'bug not reproduced — astroid handled the fuzzed type comment without an unhandled runtime error.',
+      'bug not reproduced — astroid no longer crashes, but the pathological-skip or valid-control assertions did not all pass.',
+  };
+}
+
+function normalizeCase(result: ReproCaseOutput): ReproCaseOutput {
+  return {
+    ...result,
+    exception_type: result.exception_type ?? null,
+    exception_message: result.exception_message ?? null,
   };
 }
 
 // Re-shape the dict that came back through `pyodide.toJs(...)` so the
 // stringified form is symmetric across the baseline and fix-candidate
 // variants. Pyodide maps Python `None` to JS `undefined`, and
-// `JSON.stringify` strips `undefined`-valued keys — so a clean run that
-// left `exception_type` / `exception_message` at None would render as
-// a 4-field object while a crashing run renders as 6 fields. Normalising
-// here keeps both panels comparable at a glance.
+// `JSON.stringify` strips `undefined`-valued keys. Normalising here
+// keeps both panels comparable at a glance.
 function normalize(result: ReproOutput): ReproOutput {
   return {
     astroid_version: result.astroid_version,
     python_version: result.python_version,
     nested_braces: result.nested_braces,
+    valid_depth: result.valid_depth,
     exception_type: result.exception_type ?? null,
-    exception_message: result.exception_message ?? null,
     crashed: result.crashed,
+    skipped_pathological: result.skipped_pathological,
+    valid_control_parsed: result.valid_control_parsed,
+    cases: {
+      assignment: normalizeCase(result.cases.assignment),
+      function: normalizeCase(result.cases.function),
+      valid_control: normalizeCase(result.cases.valid_control),
+    },
   };
 }
 
@@ -275,14 +365,21 @@ await micropip.install("astroid==4.1.2")
       },
       result: {
         nested_braces: baselineParsed.nested_braces,
+        valid_depth: baselineParsed.valid_depth,
         exception_type: baselineParsed.exception_type,
         crashed: baselineParsed.crashed,
+        skipped_pathological: baselineParsed.skipped_pathological,
+        valid_control_parsed: baselineParsed.valid_control_parsed,
+        cases: baselineParsed.cases,
         baseline: {
           spec: 'astroid==4.1.2',
           verdict: baselineCapture.verdict,
           astroid_version: baselineParsed.astroid_version,
           exception_type: baselineParsed.exception_type,
           crashed: baselineParsed.crashed,
+          skipped_pathological: baselineParsed.skipped_pathological,
+          valid_control_parsed: baselineParsed.valid_control_parsed,
+          cases: baselineParsed.cases,
         },
         fix_candidate:
           fixParsed && fixCapture && manifest
@@ -294,6 +391,9 @@ await micropip.install("astroid==4.1.2")
                 astroid_version: fixParsed.astroid_version,
                 exception_type: fixParsed.exception_type,
                 crashed: fixParsed.crashed,
+                skipped_pathological: fixParsed.skipped_pathological,
+                valid_control_parsed: fixParsed.valid_control_parsed,
+                cases: fixParsed.cases,
                 upstream_pr: manifest.upstream_pr ?? null,
               }
             : null,

--- a/src/layer1_wasm/astroid-2993/verify_fix.py
+++ b/src/layer1_wasm/astroid-2993/verify_fix.py
@@ -11,9 +11,10 @@ venvs:
 
 1. ``baseline`` — ``astroid==4.1.2`` from PyPI (the build under which
    the bug was filed; should still ``reproduced``).
-2. ``fix-candidate`` — a fork+branch the upstream PR is opened from
+2. ``fix-candidate`` — the fork+branch opened as upstream PR #3049
    (currently ``JamBalaya56562/astroid@claude/fix-astroid-2993-wVitv``);
-   should flip to ``unreproduced``.
+   should flip to ``unreproduced`` by skipping pathological type
+   comments before parsing while still parsing valid deep nesting.
 
 The output is a single JSON envelope on stdout listing both verdicts,
 so a maintainer can see the **before / after** of the candidate fix in
@@ -42,7 +43,8 @@ import sys
 import textwrap
 from datetime import datetime, timezone
 
-NESTED = 270
+NESTED = 200
+VALID_DEPTH = 20
 
 VARIANTS: list[dict[str, str]] = [
     {
@@ -53,7 +55,7 @@ VARIANTS: list[dict[str, str]] = [
     },
     {
         "name": "fix-candidate",
-        "label": "JamBalaya56562/astroid@claude/fix-astroid-2993-wVitv",
+        "label": "pylint-dev/astroid#3049",
         "spec": (
             "astroid @ git+https://github.com/JamBalaya56562/astroid"
             "@claude/fix-astroid-2993-wVitv"
@@ -64,36 +66,88 @@ VARIANTS: list[dict[str, str]] = [
 
 # Per-variant probe; runs in a uv-managed ephemeral venv that has the
 # variant's astroid spec installed. Mirrors repro.py's exception
-# taxonomy so the per-variant verdicts are directly comparable.
+# taxonomy and fixed-behavior assertions so the per-variant verdicts
+# are directly comparable.
 PROBE = textwrap.dedent(
     f"""
     import json, sys
     import astroid
 
     NESTED = {NESTED}
-    code = "a=b # type:i" + "{{" * NESTED
+    VALID_DEPTH = {VALID_DEPTH}
+
+    def case_result(name, code, inspect):
+        out = {{
+            "name": name,
+            "exception_type": None,
+            "exception_message": None,
+            "crashed": False,
+        }}
+        try:
+            module = astroid.builder.parse(code)
+            out.update(inspect(module))
+        except astroid.exceptions.AstroidSyntaxError as e:
+            out["exception_type"] = "AstroidSyntaxError"
+            out["exception_message"] = str(e)[:200]
+        except (MemoryError, RecursionError) as e:
+            out["exception_type"] = type(e).__name__
+            out["exception_message"] = str(e)[:200]
+            out["crashed"] = True
+        except Exception as e:
+            out["exception_type"] = type(e).__name__
+            out["exception_message"] = str(e)[:200]
+            out["crashed"] = True
+        return out
+
+    def inspect_assignment(module):
+        return {{"type_annotation_is_none": module.body[0].type_annotation is None}}
+
+    def inspect_function(module):
+        node = module.body[0]
+        return {{
+            "type_comment_returns_is_none": node.type_comment_returns is None,
+            "type_comment_args_is_none": node.type_comment_args is None,
+        }}
+
+    def inspect_valid_assignment(module):
+        return {{"type_annotation_is_present": module.body[0].type_annotation is not None}}
+
+    assignment_code = "a = b # type:i" + "{{" * NESTED
+    function_code = "def func():\\n    # type: i" + "{{" * NESTED + "\\n    pass\\n"
+    valid_inner = "List[" * VALID_DEPTH + "int" + "]" * VALID_DEPTH
+    valid_code = f"a = b # type: {{valid_inner}}"
+
+    assignment = case_result("pathological_assignment", assignment_code, inspect_assignment)
+    function = case_result("pathological_function", function_code, inspect_function)
+    valid_control = case_result("valid_deep_nesting", valid_code, inspect_valid_assignment)
+
+    pathological_cases = [assignment, function]
+    crashed = any(bool(case["crashed"]) for case in pathological_cases)
+    skipped_pathological = (
+        assignment.get("type_annotation_is_none") is True
+        and function.get("type_comment_returns_is_none") is True
+        and function.get("type_comment_args_is_none") is True
+    )
+    valid_control_parsed = valid_control.get("type_annotation_is_present") is True
 
     out = {{
         "astroid_version": astroid.__version__,
         "python_version": sys.version.split()[0],
         "nested_braces": NESTED,
-        "exception_type": None,
-        "exception_message": None,
-        "crashed": False,
+        "valid_depth": VALID_DEPTH,
+        "exception_type": next(
+            (case["exception_type"] for case in pathological_cases if case["crashed"]),
+            None,
+        ),
+        "crashed": crashed,
+        "skipped_pathological": skipped_pathological,
+        "valid_control_parsed": valid_control_parsed,
+        "cases": {{
+            "assignment": assignment,
+            "function": function,
+            "valid_control": valid_control,
+        }},
     }}
-    try:
-        astroid.builder.parse(code)
-    except astroid.exceptions.AstroidSyntaxError as e:
-        out["exception_type"] = "AstroidSyntaxError"
-        out["exception_message"] = str(e)[:200]
-    except (MemoryError, RecursionError) as e:
-        out["exception_type"] = type(e).__name__
-        out["exception_message"] = str(e)[:200]
-        out["crashed"] = True
-    except Exception as e:
-        out["exception_type"] = type(e).__name__
-        out["exception_message"] = str(e)[:200]
-        out["crashed"] = True
 
     print(json.dumps(out))
     """
@@ -139,6 +193,10 @@ def run_variant(variant: dict[str, str]) -> dict[str, object]:
         return record
     record.update(result)
     record["verdict"] = "reproduced" if result["crashed"] else "unreproduced"
+    record["fixed_assertions_passed"] = (
+        result.get("skipped_pathological") is True
+        and result.get("valid_control_parsed") is True
+    )
     return record
 
 
@@ -162,6 +220,12 @@ def main() -> int:
     print(json.dumps(envelope, indent=2))
 
     mismatches = [v for v in variants if v["verdict"] != v["expected"]]
+    assertion_failures = [
+        v
+        for v in variants
+        if v["name"] == "fix-candidate" and v.get("fixed_assertions_passed") is not True
+    ]
+    mismatches.extend(assertion_failures)
     if mismatches:
         print(
             "\nverdict=mismatch — variants did not match expected verdicts: "
@@ -175,7 +239,7 @@ def main() -> int:
 
     print(
         "\nverdict=fix-candidate-confirmed — baseline still reproduces and "
-        "the fix candidate flips the verdict to unreproduced.",
+        "the fix candidate skips pathological type comments before parsing.",
         file=sys.stderr,
     )
     return 0


### PR DESCRIPTION
## Summary

- update the astroid#2993 Layer 1 probe to match pylint-dev/astroid#3049
- assert the fix skips pathological assignment/function type comments before parsing
- keep a valid deep-nesting control so the probe does not bless over-broad skipping
- point the fix-candidate metadata and page link at the upstream PR

## Validation

- `python -m py_compile src/layer1_wasm/astroid-2993/repro.py src/layer1_wasm/astroid-2993/verify_fix.py`
- TypeScript no-emit check for `src/layer1_wasm`
- `mise run repro:build:ts`
- `mise run repro:build:wheels`
- native baseline via uv: `astroid==4.1.2` reproduces with `MemoryError`
- native two-variant verification: fix candidate skips pathological comments and keeps valid deep nesting parsed
- `mise run markdown:check`
- targeted Playwright: `astroid-2993 reproduction produces reproduced` on Chromium

## Notes

Full `mise run ci:repro` could not complete in this local sandbox: Playwright's webServer could not find `uv` via PATH, and the all-browser run timed out after prestarting the servers with the resolved `uv.exe`. The changed astroid Chromium case passed with the same local servers.
