### PR TITLE
ci(verdict): move reusable workflow into vivarium

### DIFF
--- a/.github/workflows/vivarium-verdict-self-test.yml
+++ b/.github/workflows/vivarium-verdict-self-test.yml
@@ -1,7 +1,7 @@
 name: vivarium-verdict self-test
 
 # Smoke-test the reusable verdict-capture workflow at
-# `aletheia-works/.github/.github/workflows/vivarium-verdict.yml`
+# `.github/workflows/vivarium-verdict.yml`
 # against one of Vivarium's own Layer 2 recipes. If this fails, the
 # reusable workflow itself is broken — consumer repos pulling it
 # via `uses:` would also fail. Intentionally a thin caller, not
@@ -31,6 +31,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   bash-local-shadows-exit:
@@ -39,6 +40,6 @@ jobs:
     # ships from the GHCR public registry on every main deploy,
     # so it has the lowest variance among the current Layer 2
     # entries.
-    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@2869d127c99b5cd8bcfb22d7ade8a31d1204019c # main
+    uses: ./.github/workflows/vivarium-verdict.yml
     with:
       slug: bash-local-shadows-exit

--- a/.github/workflows/vivarium-verdict.yml
+++ b/.github/workflows/vivarium-verdict.yml
@@ -1,0 +1,239 @@
+name: vivarium-verdict
+
+# Reusable workflow for capturing a Vivarium reproduction verdict.
+#
+# Any consumer repo can `uses:` this workflow to pull a published
+# `ghcr.io/aletheia-works/vivarium-<slug>` image, run it, capture
+# the verdict snapshot conforming to Vivarium Contract v1
+# (https://aletheia-works.github.io/vivarium/spec/contract-v1.html),
+# validate it against the published JSON Schema, assert the
+# captured verdict matches `expected_verdict`, and upload the
+# resulting `verdict.json` as a workflow artefact.
+#
+# Phase 5 sub-stream D per ADR-0013 (private memo). Tracking Issue:
+# https://github.com/aletheia-works/vivarium/issues/119.
+#
+# Caller example (consumer repo):
+#
+#   jobs:
+#     bash-issue:
+#       uses: aletheia-works/vivarium/.github/workflows/vivarium-verdict.yml@main
+#       with:
+#         slug: bash-local-shadows-exit
+#
+# Inputs:
+#   slug              (required) Vivarium recipe slug, e.g.
+#                     "bash-local-shadows-exit". Used to derive the
+#                     default image tag and to label artefacts and
+#                     log lines.
+#   image             (optional) Image override. Default empty,
+#                     resolved at runtime to
+#                     "ghcr.io/aletheia-works/vivarium-<slug>:latest".
+#   expected_verdict  (optional) "reproduced" or "unreproduced". Job fails if
+#                     the captured verdict does not match. Default
+#                     "reproduced" (i.e., the bug still reproduces).
+#   timeout_minutes   (optional) Job timeout in minutes. Default 5.
+#                     Most Layer 2 recipes complete in seconds; the
+#                     budget exists for image-pull + slow networks.
+#
+# This workflow has only `workflow_call` as a trigger. The thin
+# self-test caller at `vivarium-verdict-self-test.yml` exercises it
+# against one of Vivarium's own Layer 2 recipes.
+
+on:
+  workflow_call:
+    inputs:
+      slug:
+        description: 'Vivarium recipe slug, e.g. "bash-local-shadows-exit".'
+        required: true
+        type: string
+      image:
+        description: 'Image override. Default: ghcr.io/aletheia-works/vivarium-<slug>:latest.'
+        required: false
+        type: string
+        default: ''
+      expected_verdict:
+        description: 'Expected verdict ("reproduced" or "unreproduced"). Job fails if captured differs.'
+        required: false
+        type: string
+        default: 'reproduced'
+      timeout_minutes:
+        description: 'Job timeout in minutes.'
+        required: false
+        type: number
+        default: 5
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  verdict:
+    name: Capture verdict for ${{ inputs.slug }}
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+
+    steps:
+      - name: Setup Bun (for ajv-cli)
+        # ajv-cli is installed via `bun add --global` so it lands
+        # on PATH for subsequent run: steps. Same pattern the
+        # repro-regression / deploy-docs workflows use.
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install ajv-cli for verdict schema validation
+        run: bun add --global ajv-cli@5 ajv-formats
+
+      - name: Fetch contract v1 verdict schema
+        # Pull the canonical schema from GitHub Pages rather than
+        # vendoring it. The schema is locked at v1 by ADR-0014
+        # (private memo); v2 will land at a new URL with its own
+        # ADR.
+        run: |
+          set -euo pipefail
+          curl -sS --fail \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --retry 2 \
+            --retry-delay 2 \
+            -o /tmp/verdict.schema.json \
+            https://aletheia-works.github.io/vivarium/spec/verdict.schema.json
+
+      - name: Resolve image
+        id: resolve
+        env:
+          SLUG: ${{ inputs.slug }}
+          IMAGE_OVERRIDE: ${{ inputs.image }}
+        run: |
+          set -euo pipefail
+          if [ -n "$IMAGE_OVERRIDE" ]; then
+            image="$IMAGE_OVERRIDE"
+          else
+            image="ghcr.io/aletheia-works/vivarium-${SLUG}:latest"
+          fi
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "Resolved image: $image"
+
+      - name: Validate expected verdict
+        env:
+          EXPECTED: ${{ inputs.expected_verdict }}
+        run: |
+          set -euo pipefail
+          case "$EXPECTED" in
+            reproduced|unreproduced)
+              ;;
+            *)
+              echo "::error::expected_verdict must be 'reproduced' or 'unreproduced' (got '${EXPECTED}')."
+              exit 1
+              ;;
+          esac
+
+      - name: Log in to GHCR
+        if: startsWith(steps.resolve.outputs.image, 'ghcr.io/')
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image
+        env:
+          IMAGE: ${{ steps.resolve.outputs.image }}
+        run: docker pull "$IMAGE"
+
+      - name: Run reproduction and capture verdict
+        # Run the recipe, capture stdout / stderr / exit_code,
+        # build a Contract v1 verdict.json envelope. Verdict
+        # semantics follow Contract v1 Revision 3: exit_code 0 means
+        # the bug reproduces ("reproduced"); non-zero means the
+        # reproduction did not demonstrate the bug ("unreproduced").
+        id: capture
+        env:
+          IMAGE: ${{ steps.resolve.outputs.image }}
+        run: |
+          set -euo pipefail
+          stdout_file="$(mktemp)"
+          stderr_file="$(mktemp)"
+          set +e
+          docker run --rm "$IMAGE" >"$stdout_file" 2>"$stderr_file"
+          exit_code=$?
+          set -e
+
+          if [ "$exit_code" -eq 0 ]; then
+            verdict="reproduced"
+          else
+            verdict="unreproduced"
+          fi
+
+          # `image_digest` is the registry RepoDigest if available;
+          # for locally-built images it falls back to the local
+          # image ID. Empty string is allowed by the schema if
+          # neither can be resolved.
+          digest="$(docker image inspect \
+            --format='{{if .RepoDigests}}{{index .RepoDigests 0}}{{else}}{{.Id}}{{end}}' \
+            "$IMAGE" 2>/dev/null || echo "")"
+          captured_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          jq -n \
+            --arg verdict "$verdict" \
+            --arg image_tag "$IMAGE" \
+            --arg image_digest "$digest" \
+            --arg captured_at "$captured_at" \
+            --arg stdout "$(cat "$stdout_file")" \
+            --arg stderr_tail "$(tail -c 4096 "$stderr_file")" \
+            --argjson exit_code "$exit_code" \
+            '{
+              contract: "v1",
+              verdict: $verdict,
+              exit_code: $exit_code,
+              image_tag: $image_tag,
+              image_digest: $image_digest,
+              captured_at: $captured_at,
+              stdout: $stdout,
+              stderr_tail: $stderr_tail
+            }' > verdict.json
+
+          rm -f "$stdout_file" "$stderr_file"
+
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          echo "Captured verdict: $verdict (exit ${exit_code})"
+
+      - name: Validate verdict against contract v1 schema
+        # Single-source clause 4 of the contract v1 conformance
+        # check. A schema mismatch indicates either (a) the schema
+        # has evolved past v1 (unlikely, v1 is locked by ADR-0014)
+        # or (b) this workflow's envelope build drifted from the
+        # spec (a bug here, not in the recipe).
+        run: |
+          ajv validate \
+            --spec=draft2020 \
+            -c ajv-formats \
+            -s /tmp/verdict.schema.json \
+            -d verdict.json
+
+      - name: Assert verdict matches expected
+        env:
+          CAPTURED: ${{ steps.capture.outputs.verdict }}
+          EXPECTED: ${{ inputs.expected_verdict }}
+          EXIT_CODE: ${{ steps.capture.outputs.exit_code }}
+          SLUG: ${{ inputs.slug }}
+        run: |
+          if [ "$CAPTURED" != "$EXPECTED" ]; then
+            echo "::error::Vivarium verdict mismatch for ${SLUG}: captured=${CAPTURED} expected=${EXPECTED} (recipe exit_code=${EXIT_CODE}). Either the upstream bug shipped a fix, the recipe regressed, or expected_verdict input is stale."
+            exit 1
+          fi
+          echo "Vivarium verdict for ${SLUG}: ${CAPTURED} (matches expected)."
+
+      - name: Upload verdict.json artefact
+        # Always upload (even on failure) so a consumer's CI badge
+        # / debug flow can fetch the artefact even after a
+        # mismatch. 30-day retention matches GitHub's default for
+        # public repos.
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: verdict-${{ inputs.slug }}-${{ github.run_id }}
+          path: verdict.json
+          retention-days: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ vivarium/
 │   ├── CLAUDE.md          # Claude Code-specific addenda; auto-loads `@../AGENTS.md`
 │   └── rules/             # path-scoped operational rules (e.g. recipe-authoring.md)
 ├── .github/
-│   ├── workflows/         # CI/CD — thin callers into aletheia-works/.github reusables
+│   ├── workflows/         # CI/CD — mostly thin callers, plus Vivarium-owned reusable workflows
 │   ├── dependabot.yml
 │   ├── labeler.yml        # path-based label rules (mechanical)
 │   └── release.yml
@@ -194,11 +194,11 @@ PRs is legitimate housekeeping.
 
 ### 4.7 Organisation-level reusable workflows
 
-Shared CI logic (commitlint, release notes, etc.) lives in
-`aletheia-works/.github` as `workflow_call` reusables. Consuming repos —
-including this one — host only thin caller workflows plus any
-`workflow_run` listeners. If a workflow here starts duplicating logic that
-would belong in the org, flag it for promotion rather than copying.
+Shared cross-repo CI logic (commitlint, release notes, etc.) lives in
+`aletheia-works/.github` as `workflow_call` reusables. Vivarium-specific
+reusable workflows, such as verdict capture tied to Contract v1, live in this
+repository. If a workflow here starts duplicating logic that would belong in
+the org, flag it for promotion rather than copying.
 
 ### 4.8 GitHub Actions: latest versions, pinned by SHA
 

--- a/docs/docs/en/guide/integrate-with-your-repo.mdx
+++ b/docs/docs/en/guide/integrate-with-your-repo.mdx
@@ -48,7 +48,7 @@ import {
     </p>
     <Callout>
       You don't copy any Vivarium source. The reusable workflow is maintained
-      org-side, so you only carry the <code>uses:</code> link — Vivarium-side
+      in the Vivarium repository, so you only carry the <code>uses:</code> link —
       improvements ride along automatically.
     </Callout>
   </Section>
@@ -124,7 +124,7 @@ on:
 
 jobs:
   bash-issue:
-    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    uses: aletheia-works/vivarium/.github/workflows/vivarium-verdict.yml@main
     with:
       slug: bash-local-shadows-exit
 `}</code></pre>
@@ -141,11 +141,11 @@ jobs:
     </p>
     <pre><code>{`jobs:
   bash-issue:
-    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    uses: aletheia-works/vivarium/.github/workflows/vivarium-verdict.yml@main
     with:
       slug: bash-local-shadows-exit
   pandas-issue:
-    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    uses: aletheia-works/vivarium/.github/workflows/vivarium-verdict.yml@main
     with:
       slug: pandas-56679
 `}</code></pre>

--- a/docs/docs/en/spec/consumer-workflow.md
+++ b/docs/docs/en/spec/consumer-workflow.md
@@ -4,8 +4,8 @@
 > verify a Vivarium-hosted bug reproduction in their own CI —
 > without copying any Vivarium internals.
 
-The workflow lives at
-[`aletheia-works/.github/.github/workflows/vivarium-verdict.yml`](https://github.com/aletheia-works/.github/blob/main/.github/workflows/vivarium-verdict.yml).
+The workflow lives in this repository at
+[`aletheia-works/vivarium/.github/workflows/vivarium-verdict.yml`](https://github.com/aletheia-works/vivarium/blob/main/.github/workflows/vivarium-verdict.yml).
 It pulls the published `ghcr.io/aletheia-works/vivarium-<slug>`
 image, runs the recipe, captures a `verdict.json` matching
 [Contract v1](./contract-v1.md), validates it against the
@@ -18,7 +18,7 @@ expected.
 ```yaml
 jobs:
   bash-issue:
-    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    uses: aletheia-works/vivarium/.github/workflows/vivarium-verdict.yml@main
     with:
       slug: bash-local-shadows-exit
 ```
@@ -56,7 +56,7 @@ write:
 ```yaml
 jobs:
   fixed-detector:
-    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    uses: aletheia-works/vivarium/.github/workflows/vivarium-verdict.yml@main
     with:
       slug: my-favourite-recipe
       expected_verdict: reproduced  # default; spelled out for clarity

--- a/docs/docs/ja/guide/integrate-with-your-repo.mdx
+++ b/docs/docs/ja/guide/integrate-with-your-repo.mdx
@@ -46,7 +46,7 @@ import {
       「このバグはもう追跡しなくてよい」のシグナルになります。
     </p>
     <Callout>
-      Vivarium 本体のソースをコピーしません。再利用可能ワークフローが組織側で
+      Vivarium 本体のソースをコピーしません。再利用可能ワークフローが Vivarium リポジトリ側で
       保守されているので、こちらは <code>uses:</code> のリンクだけ持っておけば、
       Vivarium 側の改善が自動で乗ります。
     </Callout>
@@ -122,7 +122,7 @@ on:
 
 jobs:
   bash-issue:
-    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    uses: aletheia-works/vivarium/.github/workflows/vivarium-verdict.yml@main
     with:
       slug: bash-local-shadows-exit
 `}</code></pre>
@@ -138,11 +138,11 @@ jobs:
     </p>
     <pre><code>{`jobs:
   bash-issue:
-    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    uses: aletheia-works/vivarium/.github/workflows/vivarium-verdict.yml@main
     with:
       slug: bash-local-shadows-exit
   pandas-issue:
-    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    uses: aletheia-works/vivarium/.github/workflows/vivarium-verdict.yml@main
     with:
       slug: pandas-56679
 `}</code></pre>

--- a/docs/docs/ja/spec/consumer-workflow.md
+++ b/docs/docs/ja/spec/consumer-workflow.md
@@ -4,7 +4,7 @@
 > 自分の CI 内で Vivarium ホスト型バグ再現を検証できる再利用可能 GitHub Actions ワークフロー。
 
 ワークフローは
-[`aletheia-works/.github/.github/workflows/vivarium-verdict.yml`](https://github.com/aletheia-works/.github/blob/main/.github/workflows/vivarium-verdict.yml)
+[`aletheia-works/vivarium/.github/workflows/vivarium-verdict.yml`](https://github.com/aletheia-works/vivarium/blob/main/.github/workflows/vivarium-verdict.yml)
 に配置されている。
 公開済みの `ghcr.io/aletheia-works/vivarium-<slug>` イメージをプルし、
 レシピを実行し、[Contract v1](./contract-v1.md) に準拠する `verdict.json` をキャプチャし、
@@ -17,7 +17,7 @@
 ```yaml
 jobs:
   bash-issue:
-    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    uses: aletheia-works/vivarium/.github/workflows/vivarium-verdict.yml@main
     with:
       slug: bash-local-shadows-exit
 ```
@@ -53,7 +53,7 @@ jobs:
 ```yaml
 jobs:
   fixed-detector:
-    uses: aletheia-works/.github/.github/workflows/vivarium-verdict.yml@main
+    uses: aletheia-works/vivarium/.github/workflows/vivarium-verdict.yml@main
     with:
       slug: my-favourite-recipe
       expected_verdict: reproduced  # デフォルト; 明確にするため明示


### PR DESCRIPTION
## Summary

- move the reusable vivarium-verdict workflow into the Vivarium repository
- point the self-test at the local reusable workflow and grant GHCR read permission
- update consumer workflow docs and AGENTS.md to match the new owner

Follow-up to #119. Paired with https://github.com/aletheia-works/.github/pull/36.

## Review focus

- [x] Confirm external uses examples now point at aletheia-works/vivarium.
- [x] Confirm the self-test still calls the reusable workflow without a cross-repo SHA.
- [x] Confirm GHCR auth remains available through packages: read.

## Process notes

- AI-authored? Yes, the ai: generated label is set on this PR.
- Scope-creep check: the diff still matches the title and linked Issue.