### PR TITLE
refactor(docs): remove legacy reproduction url compatibility

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,7 +1,7 @@
 name: deploy-docs
 
-# Builds the rspress docs site and deploys to GitHub Pages, alongside any
-# Layer 1 (browser-native) PoC pages.
+# Builds the rspress docs site and deploys to GitHub Pages, alongside
+# browser-native reproduction pages.
 #
 # Prerequisites (one-time setup):
 # - Repo Settings → Pages → Source: "GitHub Actions".
@@ -27,15 +27,9 @@ name: deploy-docs
 #   entry's `page_url` in `docs/public/api/recipes.json` so the bundling
 #   step shares the canonical mapping with the rest of the catalogue.
 # - Underscore-prefixed subdirectories (e.g. `src/layer1_wasm/_shared/`)
-#   hold scaffolding shared across reproductions. They are bundled flat
-#   under `repro/_shared/`, since each reproduction now lives at
-#   `repro/<project>/<issue_path>/` and references shared modules via
-#   `../../_shared/…`.
-# - Legacy `/poc/<slug>/` URLs (Phase 0 noun) get HTML meta-refresh
-#   redirect pages pointing at the new `/repro/<project>/<issue_path>/`
-#   location, so external links from before the migration continue to
-#   work.
-
+#   hold scaffolding shared across reproductions. They are bundled under
+#   each `repro/<project>/` directory so recipes can reference shared
+#   modules via `../_shared/…`.
 on:
   push:
     branches: [main]
@@ -274,23 +268,19 @@ jobs:
         # to the reproduction for review; they get copied too, which is
         # fine — the pages are static.
         #
-        # Three flavours of subdirectory:
+        # Two flavours of subdirectory:
         # 1. Reproduction pages — must contain `index.html`. Skipped if not.
-        #    Also gets an HTML meta-refresh redirect page at
-        #    `<pages-base>/poc/<slug>/` to keep legacy URLs working.
         # 2. Underscore-prefixed scaffolding (`_shared/`, `_assets/`) —
         #    duplicated under each `<project>/` so recipes can keep their
         #    `../_shared/…` references intact under the new
         #    `<project>/<issue_path>/` URL shape (one directory level
         #    above the recipe). The cost is a few KB × N projects of
         #    duplication; the win is leaving every recipe's source
-        #    untouched. No `/poc/_shared/` legacy redirect — that was
-        #    never a public URL.
+        #    untouched.
         working-directory: ${{ github.workspace }}
         run: |
           set -euo pipefail
           dest="docs/doc_build/repro"
-          legacy_dest="docs/doc_build/poc"
           if [ ! -d src/layer1_wasm ]; then
             echo "No src/layer1_wasm/ directory; skipping bundling."
             exit 0
@@ -315,15 +305,15 @@ jobs:
             done
           done
           # Bundle each individual recipe.
-          for poc in src/layer1_wasm/*/; do
-            slug="$(basename "$poc")"
+          for recipe in src/layer1_wasm/*/; do
+            slug="$(basename "$recipe")"
             case "$slug" in
               _*)
                 continue
                 ;;
             esac
-            if [ ! -f "${poc}index.html" ]; then
-              echo "Skipping ${poc} (no index.html)"
+            if [ ! -f "${recipe}index.html" ]; then
+              echo "Skipping ${recipe} (no index.html)"
               continue
             fi
             page_url="$(jq -r --arg s "$slug" \
@@ -337,35 +327,12 @@ jobs:
             rel="${rel%/}"
             echo "Bundling reproduction: ${slug} → ${dest}/${rel}/"
             mkdir -p "$dest/$rel"
-            # `cp -R "$poc/."` copies the recipe directory's CONTENTS
+            # `cp -R "$recipe/."` copies the recipe directory's CONTENTS
             # (not the directory itself), so the recipe lands at $rel/
             # rather than $rel/$slug/.
-            cp -R "${poc}." "$dest/$rel/"
-            # Legacy `/poc/<slug>/` redirect — HTML meta-refresh is
-            # the simplest mechanism that works on GitHub Pages
-            # (which has no native server-side 301 support). Points
-            # at the new `<project>/<issue_path>/` location.
-            mkdir -p "$legacy_dest/$slug"
-            cat > "$legacy_dest/$slug/index.html" <<HTML
-          <!doctype html>
-          <html lang="en">
-            <head>
-              <meta charset="utf-8" />
-              <title>Vivarium · moved to /repro/${rel}/</title>
-              <meta http-equiv="refresh" content="0; url=../../repro/${rel}/" />
-              <link rel="canonical" href="../../repro/${rel}/" />
-              <meta name="robots" content="noindex" />
-            </head>
-            <body>
-              <p>This reproduction has moved to
-                <a href="../../repro/${rel}/">/repro/${rel}/</a>.
-                Updating in a moment…</p>
-            </body>
-          </html>
-          HTML
+            cp -R "${recipe}." "$dest/$rel/"
           done
           ls -la "$dest" || true
-          ls -la "$legacy_dest" || true
 
       - name: Bundle Layer 2 reproductions alongside docs
         # Layer 2 catalogue convention (per ADR-0010 / private memo):
@@ -445,31 +412,6 @@ jobs:
             echo "Bundling Layer 2 reproduction: ${slug} → ${dest}/${rel}/"
             mkdir -p "$dest/$rel"
             cp -R "${entry}." "$dest/$rel/"
-            # Legacy slug-only URL `/repro/<slug>/` redirect. Before the
-            # hierarchical-URL move, Layer 2 pages were published at
-            # `<pages-base>/repro/<slug>/`; existing links in the wild
-            # need a meta-refresh to the new
-            # `<project>/<issue_path>/` location.
-            if [ "$rel" != "$slug" ]; then
-              mkdir -p "$dest/$slug"
-              cat > "$dest/$slug/index.html" <<HTML
-          <!doctype html>
-          <html lang="en">
-            <head>
-              <meta charset="utf-8" />
-              <title>Vivarium · moved to /repro/${rel}/</title>
-              <meta http-equiv="refresh" content="0; url=../${rel}/" />
-              <link rel="canonical" href="../${rel}/" />
-              <meta name="robots" content="noindex" />
-            </head>
-            <body>
-              <p>This reproduction has moved to
-                <a href="../${rel}/">/repro/${rel}/</a>.
-                Updating in a moment…</p>
-            </body>
-          </html>
-          HTML
-            fi
           done
           ls -la "$dest" || true
 

--- a/docs/docs/en/spec/contract-v1.md
+++ b/docs/docs/en/spec/contract-v1.md
@@ -297,7 +297,7 @@ enforcement single-sourced.
 The optional revision-2 evidence surface deliberately has **no**
 conformance clause: gating an optional surface on CI would create
 the wrong incentive (page authors padding empty evidence elements
-just to satisfy the gate). When the gallery's first non-PoC page emits evidence,
+just to satisfy the gate). When another gallery page emits evidence,
 a follow-up Issue can decide whether to enforce shape (e.g. "if
 `#evidence` exists, it must contain at least one
 `[data-evidence]` child") at that point.

--- a/docs/playwright.config.ts
+++ b/docs/playwright.config.ts
@@ -10,9 +10,6 @@
 //   exposes the loading-UX surface (vh-progress fades, vh-output
 //   reveals on completion). This guards the regression where chrome.js
 //   fails to inject silently.
-// - The **legacy flat URL** (/repro/<slug>/) either redirects to the
-//   hierarchical form or still serves a working page — never the
-//   silent-break shape (parent HTML 200 + asset 404/503).
 //
 // One static HTTP server is auto-started: rspress's preview server on
 // port 8770 (well clear of Layer 1=8767, Layer 2=8768). Tests address

--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -31,48 +31,12 @@ const REPRO_MIME: Record<string, string> = {
 };
 
 // Resolve a /repro/<sub> URL path to an absolute file under one of
-// src/layer{1,2,3}_*. Supports trailing-slash to index.html and
-// extension-based MIME type. Returns null if no match.
-//
-// URL to disk-slug mapping for the canonical <project>/<issue_path>/...
-// URL shape (PR #159 — flat slug `<project>-<issue>` URLs were
-// deprecated then; the resolver enforces the migration so any
-// remaining flat URL surfaces as a 404 instead of silently serving):
-//
-//   1. Underscore-prefixed first segment (e.g. _shared/sw.js,
-//      _layer2-shared/...) is looked up as-is, since shared scaffolding
-//      lives flat under each src/layer{N}_*/ and never had project /
-//      issue segmentation.
-//
-//   2. Single-segment lookups: covers project-landing assets and
-//      shared single-segment files (legacy `/repro/foo.js` etc.).
-//      Legacy flat slug directory URLs like `/repro/regex-779/` are
-//      explicitly excluded — they match the flat-slug regex and fall
-//      through to rspress, which 404s. Without this guard the disk
-//      lookup happens to find `regex-779/index.html` and serves the
-//      deprecated URL, defeating the migration.
-//
-//   3. Multi-segment lookups: first segment is the project, second
-//      segment is the issue_path. The recipe directory on disk is one of:
-//        a. <project>-<issue_path> (the prefix-style slug, the common
-//           case, e.g. cpython-137205, bash-local-shadows-exit).
-//        b. <issue_path> (the override-style slug for recipes whose
-//           on-disk name does not embed the project, e.g.
-//           PROJECT_OVERRIDES['lost-update'] = 'pthread', served at
-//           /repro/pthread/lost-update/ from the disk dir lost-update/).
-//      Both candidates are tried; the first that exists wins. Any
-//      remaining segments are joined back onto the resolved disk slug as
-//      the asset path under that recipe directory (e.g. repro.wasm,
-//      verdict.json).
+// src/layer{1,2,3}_*. Canonical recipe URLs use
+// /repro/<project>/<issue_path>/..., while underscore-prefixed shared
+// scaffolding remains flat under /repro/_*/...
 //
 // Exported so the docs/scripts/__tests__/resolveReproFile.test.ts unit
 // suite can verify each branch without spinning up the dev middleware.
-
-// Legacy flat slug shape: `<project>-<issue>` (one or more lowercase
-// dash-separated word segments followed by a trailing decimal issue
-// number). Used to suppress flat-URL directory lookups in the
-// single-segment branch so the deprecated form 404s cleanly.
-const LEGACY_FLAT_SLUG_RE = /^[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*-\d+$/;
 
 export function resolveReproFile(rawSubpath: string): string | null {
   const subpath = rawSubpath || '';
@@ -95,18 +59,7 @@ export function resolveReproFile(rawSubpath: string): string | null {
     // Shared scaffolding — keep flat lookup.
     candidates.push(joinDisk(segments, trailingFile));
   } else if (segments.length === 1) {
-    const single = segments[0]!;
-    if (trailingFile === 'index.html' && LEGACY_FLAT_SLUG_RE.test(single)) {
-      // Legacy flat slug directory URL (e.g. `/repro/regex-779/`).
-      // Deprecated by PR #159 — fall through, rspress 404s.
-    } else {
-      // Project landing (`/repro/<project>/`) or legacy asset
-      // (`/repro/foo.js`) — try as-is. Project landings have no
-      // disk match and fall through to rspress for the rspress
-      // page; asset URLs that exist on disk under one of the layer
-      // roots get served.
-      candidates.push(joinDisk(segments, trailingFile));
-    }
+    // Project landing (`/repro/<project>/`) — fall through to rspress.
   } else {
     // Multi-segment — try the prefix-style slug first, then the
     // override-style slug.
@@ -245,9 +198,10 @@ export default defineConfig({
     ],
   },
 
-  // Dev-only middleware that intercepts `/vivarium/repro/<slug>/...` URLs
-  // and serves the corresponding file from `src/layer{1,2,3}_*/<slug>/`
-  // BEFORE rspress's SPA history fallback claims the URL.
+  // Dev-only middleware that intercepts
+  // `/vivarium/repro/<project>/<issue_path>/...` URLs and serves the
+  // corresponding file from `src/layer{1,2,3}_*/<recipe>/` BEFORE
+  // rspress's SPA history fallback claims the URL.
   //
   // Production deploy doesn't need this — the GH Actions build copies
   // these directories into doc_build/repro/ as plain static assets, so
@@ -274,16 +228,13 @@ export default defineConfig({
             // No file on disk. Three cases:
             //
             // 1. Directory-shaped URL (empty subpath or ends with '/') —
-            //    `/vivarium/repro/`, `/vivarium/repro/some-slug/`. These
-            //    should fall through to rspress's SPA so the gallery
-            //    page (docs/docs/{en,ja}/repro/index.mdx) can render.
-            //    Only the individual recipe slugs that DO have an
-            //    index.html in src/ get intercepted above.
+            //    `/vivarium/repro/`, project landing pages, or unknown
+            //    recipe routes. These should fall through to rspress's
+            //    SPA so docs routes can render or 404 there.
             //
             // 2. Extension-less URL — `/vivarium/repro/compare`,
-            //    `/vivarium/repro/some-slug`. These are rspress SPA
-            //    routes (e.g. R.3's compare.mdx page) or directory URLs
-            //    that need a redirect. Fall through so rspress can
+            //    `/vivarium/repro/<project>`, etc. These are rspress
+            //    SPA routes or clean URLs; fall through so rspress can
             //    handle them.
             //
             // 3. Asset-shaped URL (has an extension) — `repro.wasm`,

--- a/docs/scripts/__tests__/resolveReproFile.test.ts
+++ b/docs/scripts/__tests__/resolveReproFile.test.ts
@@ -7,16 +7,10 @@
 //   copy the same files into `doc_build/repro/`. So an E2E suite that
 //   runs against `bunx rspress preview` (production-shape) cannot
 //   exercise the middleware at all.
-// - Path resolution has three branches (underscore-prefixed shared,
-//   single-segment, multi-segment hierarchical) plus a trailing-slash
+// - Path resolution has two branches (underscore-prefixed shared and
+//   multi-segment hierarchical) plus a trailing-slash
 //   → index.html projection. An assertion matrix is the cheapest way
 //   to keep all of them honest as the recipe layout evolves.
-// - **Legacy flat URLs are deprecated** (PR #159 migrated to
-//   hierarchical `<project>/<issue>/` form). The unit suite locks in
-//   that flat URLs return `null` so the dev middleware sends 404 and
-//   the deprecation is visible — without these cases, a future
-//   refactor could re-add a flat fallback and silently re-introduce
-//   the dead URL shape.
 //
 // The test imports `resolveReproFile` directly. The function is pure
 // (only file-system reads) so it needs no rspress runtime, no port
@@ -79,31 +73,6 @@ describe('resolveReproFile — hierarchical (canonical) URLs', () => {
   });
 });
 
-describe('resolveReproFile — legacy flat URLs (deprecated, must 404)', () => {
-  // Flat slug URLs like `/repro/regex-779/` (and their assets) were
-  // deprecated by PR #159 in favour of the hierarchical
-  // `/repro/<project>/<issue>/` shape. The middleware must return null
-  // for the legacy form so the rspress fallback / asset 404 surfaces
-  // the deprecation cleanly. These cases lock that contract in.
-
-  test('legacy flat URL (/regex-779/) → null (deprecated, 404)', () => {
-    expect(resolveReproFile('regex-779/')).toBe(null);
-  });
-
-  test('legacy flat asset (/regex-779/repro.js) → null (deprecated, 404)', () => {
-    expect(resolveReproFile('regex-779/repro.js')).toBe(null);
-  });
-
-  test('legacy flat highlighted html (/regex-779/repro.highlighted.html) → null (deprecated)', () => {
-    expect(resolveReproFile('regex-779/repro.highlighted.html')).toBe(null);
-  });
-
-  test('legacy flat URL with non-numeric tail (/numpy-28287/repro.wasm) → null (deprecated)', () => {
-    // Same contract for every numeric-suffix flat slug.
-    expect(resolveReproFile('numpy-28287/repro.wasm')).toBe(null);
-  });
-});
-
 describe('resolveReproFile — bare and not-found URLs', () => {
   test('bare /repro/ → null (caller falls through to rspress for the gallery page)', () => {
     expect(resolveReproFile('')).toBe(null);
@@ -140,11 +109,8 @@ describe('resolveReproFile — shared scaffolding (underscore prefix)', () => {
   });
 });
 
-describe('resolveReproFile — single-segment legacy assets', () => {
+describe('resolveReproFile — single-segment project routes', () => {
   test("single-segment with extension that doesn't exist → null (caller returns 404)", () => {
-    // Pre-#159 there were also single-segment URLs like
-    // `/repro/something.js` for shared assets. Those that don't
-    // exist on disk fall through cleanly.
     expect(resolveReproFile('nope.js')).toBe(null);
   });
 

--- a/mise.toml
+++ b/mise.toml
@@ -248,7 +248,7 @@ for dockerfile in src/layer2_docker/*/Dockerfile; do
   echo "==> capture verdict.json for ${slug}"
   bash scripts/capture_layer2_verdict.sh "$tag" "${slug_dir}/verdict.json"
 done
-echo "Done. Refresh http://localhost:3000/vivarium/repro/<slug>/ to see captured verdicts."
+echo "Done. Refresh http://localhost:3000/vivarium/repro/<project>/<issue_path>/ to see captured verdicts."
 '''
 
 # ── Branch-fix publish (Path B, PAT-push) ────────────────────────────────

--- a/packages/mcp-server/src/tools/verify_branch_fix.ts
+++ b/packages/mcp-server/src/tools/verify_branch_fix.ts
@@ -92,10 +92,10 @@ function pathBCompareUrl(inputs: PathBUrlInputs): string {
 }
 
 function deriveCompareBaseFromPageUrl(pageUrl: string): string {
-  // page_url is e.g. https://aletheia-works.github.io/vivarium/repro/<slug>/.
+  // page_url is e.g.
+  // https://aletheia-works.github.io/vivarium/repro/<project>/<issue_path>/.
   // The compare page sits at /repro/compare under both /en and /ja chrome.
-  // Default to no-locale (legacy /repro/compare) — R.3 mounts the same
-  // component in both locales.
+  // R.3 mounts the same component in both locales.
   try {
     const u = new URL(pageUrl);
     return `${u.origin}/vivarium/repro/compare`;

--- a/src/README.md
+++ b/src/README.md
@@ -1,7 +1,6 @@
 # `src/` — Vivarium source tree
 
-> Scaffolding only. Phase 0 has not committed to any specific implementation
-> yet; this directory exists so layer boundaries are visible from day one.
+> Reproduction recipes live here, grouped by the layer they exercise.
 
 ---
 
@@ -18,8 +17,9 @@ reproduction problems have fundamentally different requirements:
 
 Picking one layer as "the answer" would force square pegs into round
 holes. The three-layer split exists so each problem class can be solved
-on its own terms — see [`AGENTS.md § 5`](../AGENTS.md) and the eventual
-[`docs/docs/ARCHITECTURE.md`](../docs/docs/) for the longer-form argument.
+on its own terms — see [`AGENTS.md § 5`](../AGENTS.md) and
+[`docs/docs/en/architecture.mdx`](../docs/docs/en/architecture.mdx) for the
+longer-form argument.
 
 ## Layout
 
@@ -31,19 +31,11 @@ src/
 ```
 
 Each subdirectory has its own `README.md` describing the kinds of
-problems routed to that layer. None contain production code yet —
-bringing a layer online starts with a feature Issue, not with
-speculative scaffolding.
+problems routed to that layer and the conventions for recipes in that
+catalogue.
 
 ## What does **not** live here
 
 - **Infrastructure-as-Code** — lives in [`infra/`](../infra/).
 - **Docs site** — lives in [`docs/`](../docs/) (markdown content under `docs/docs/`).
 - **Tooling and build configuration** — project root.
-
-## Current phase
-
-Phase 0 (Bootstrap) will populate `layer1_wasm/` first, starting with a
-hand-picked Pyodide + pandas reproduction PoC
-([Issue #13](https://github.com/aletheia-works/vivarium/issues/13)).
-Layers 2 and 3 are expected but unscheduled.

--- a/src/layer1_wasm/README.md
+++ b/src/layer1_wasm/README.md
@@ -28,34 +28,29 @@
 
 | Language | Runtime                         | Status   |
 |----------|---------------------------------|----------|
-| Python   | [Pyodide](https://pyodide.org)  | Phase 0 first target |
-| SQLite   | [sqlite-wasm](https://sqlite.org/wasm/) | Paired with Pyodide |
-| Rust     | `wasm32-wasi` / `wasm32-unknown-unknown` | Deferred |
-| Ruby     | [Ruby.wasm](https://github.com/ruby/ruby.wasm) | Deferred |
-| PHP      | [php-wasm](https://github.com/WordPress/wordpress-playground) | Deferred |
+| Python   | [Pyodide](https://pyodide.org)  | Active |
+| SQLite   | Pyodide `sqlite3`               | Active |
+| Rust     | `wasm32-wasip1`                 | Active |
+| Ruby     | [Ruby.wasm](https://github.com/ruby/ruby.wasm) | Active |
+| PHP      | [php-wasm](https://github.com/WordPress/wordpress-playground) | Active |
 
 Concrete runtime choices land in [`docs/docs/`](../../docs/docs/) as ADRs, not
 here.
 
-## Phase 0 scope
+## Catalogue
 
-First vertical is **Pyodide + a hand-picked pandas bug**
-([Issue #13](https://github.com/aletheia-works/vivarium/issues/13)).
+Layer 1 recipes are immediate subdirectories such as
+[`pandas-56679/`](./pandas-56679/), [`regex-779/`](./regex-779/), and
+[`ruby-21709/`](./ruby-21709/). They are static browser pages published
+under `/vivarium/repro/<project>/<issue_path>/` by the `deploy-docs`
+workflow.
 
-### What is here
+## Conventions
 
-- [`pandas-56679/`](./pandas-56679/) — the Phase 0 PoC.
-  Reproduces [`pandas-dev/pandas#56679`](https://github.com/pandas-dev/pandas/issues/56679)
-  end-to-end in Pyodide. Static HTML; deployed under
-  `/vivarium/poc/pandas-56679/` by the `deploy-docs` workflow.
-
-### Conventions for new PoCs
-
-Each new Layer 1 PoC is its own immediate subdirectory of this folder
+Each new Layer 1 recipe is its own immediate subdirectory of this folder
 (e.g. `numpy-12345/`, `pandas-56679/`). The directory is required to
-contain an `index.html`; the deploy workflow publishes any directory
-matching this shape under `/vivarium/poc/<slug>/`. Companion files
-(`repro.mjs`, `style.css`, `README.md`, fixtures) live alongside.
+contain an `index.html`; companion files (`repro.ts`, `README.md`,
+fixtures, generated-highlight inputs) live alongside.
 
 ## Verdict surface
 

--- a/src/layer1_wasm/_assets/chrome.js
+++ b/src/layer1_wasm/_assets/chrome.js
@@ -199,9 +199,9 @@ function registerServiceWorker() {
   if (!('serviceWorker' in navigator)) return;
   if (location.protocol === 'file:') return;
 
-  // Path is relative to /repro/<slug>/. The SW lives at
-  // /vivarium/repro/_assets/sw.js (per-layer copy under each layer's
-  // _assets/ tree). Scope is the whole /repro/ tree so any reproduction
+  // Path is relative to /repro/<project>/<issue_path>/. The SW lives at
+  // /vivarium/repro/<project>/_assets/sw.js (per-project copy under each
+  // layer's _assets/ tree). Scope is the whole /repro/ tree so any reproduction
   // page benefits from the cached Pyodide; this requires the
   // `Service-Worker-Allowed` header which the rspress dev middleware
   // sets for any file ending in `sw.js`, regardless of SW location.

--- a/src/layer1_wasm/_assets/sw.js
+++ b/src/layer1_wasm/_assets/sw.js
@@ -1,9 +1,9 @@
 // Vivarium reproduction-page service worker.
 //
 // Caches Pyodide / Ruby.wasm / php-wasm runtime files so repeat visits
-// to any /repro/<slug>/ page are near-instant (no CDN fetch). First
-// visits go to the network; the response is stored in CacheStorage so
-// the next visit (any tab, any reproduction) hits cache.
+// to any /repro/<project>/<issue_path>/ page are near-instant (no CDN
+// fetch). First visits go to the network; the response is stored in
+// CacheStorage so the next visit (any tab, any reproduction) hits cache.
 //
 // Scope is /vivarium/repro/ — every reproduction page is in this tree.
 // Pages outside (the rspress docs site itself) are not affected.

--- a/src/layer1_wasm/_shared/README.md
+++ b/src/layer1_wasm/_shared/README.md
@@ -3,7 +3,7 @@
 Shared modules used by every reproduction page in `src/layer1_wasm/`.
 The leading underscore is the convention for "this directory is not a
 reproduction" — `deploy-docs.yml` recognises it and bundles the contents
-under `<pages-base>/poc/_shared/` without requiring an `index.html`.
+under each Layer 1 project directory without requiring an `index.html`.
 
 ## Source language
 
@@ -81,7 +81,7 @@ python -m http.server -d _shared 8766
 
 ## Smoke test expectations
 
-Open `<pages-base>/poc/_shared/_test/` in a browser. Expected:
+Open `<pages-base>/repro/<project>/_shared/_test/` in a browser. Expected:
 
 - The verdict band shows `bug reproduced — _shared helpers wired
   up.` and `data-verdict="reproduced"`.
@@ -102,5 +102,5 @@ when the deploy step copies the tree. It then iterates immediate
 subdirectories of `src/layer1_wasm/`; the default rule (must contain
 `index.html`) is relaxed for underscore-prefixed directories so that
 shared scaffolding ships without pretending to be a reproduction. The
-modules end up at `<pages-base>/poc/_shared/`, reachable from each
-reproduction at the relative path `../_shared/…`.
+modules end up at `<pages-base>/repro/<project>/_shared/`, reachable
+from each reproduction at the relative path `../_shared/…`.

--- a/src/layer1_wasm/astroid-2993/README.md
+++ b/src/layer1_wasm/astroid-2993/README.md
@@ -39,11 +39,10 @@ but valid type comments.
   assignment and function pathological type comments must not crash
   after the fix, while a deeply nested but valid type comment must
   still parse.
-- Reported against astroid 4.1.x. Latest release at authoring time
-  is 4.1.2 (2026-03-22) and the bug still reproduces there; pinning
-  in PEP 723 / `repro.ts` to that exact version locks the verdict
-  to a known-bad build, so the page flips to `unreproduced` only
-  when a new astroid release lands an actual fix.
+- Reported against astroid 4.1.x. Pinning PEP 723 / `repro.ts` to
+  `astroid==4.1.2` locks the verdict to a known-bad build, so the page
+  flips to `unreproduced` only when the pin is intentionally updated to
+  a fixed release.
 - Demonstrates Vivarium handles bugs in upstream projects whose
   packages are not pre-bundled in Pyodide — the page installs
   astroid from PyPI via `micropip` after the runtime bootstraps.
@@ -78,7 +77,7 @@ read each variant's outcome from the JSON inside its own `<pre>`
 (`crashed: true|false`, `skipped_pathological`,
 `valid_control_parsed`, and per-case details).
 
-The `result` field of `__VIVARIUM_RESULT__` keeps the legacy
+The `result` field of `__VIVARIUM_RESULT__` keeps the existing
 `nested_braces` / `exception_type` / `crashed` fields and additively
 gains `skipped_pathological`, `valid_control_parsed`, `cases`,
 `result.baseline`, and `result.fix_candidate`, with each variant's

--- a/src/layer1_wasm/pandas-56679/README.md
+++ b/src/layer1_wasm/pandas-56679/README.md
@@ -1,9 +1,8 @@
 # Reproduction — pandas-dev/pandas#56679
 
-> **Status**: Phase 1 reproduction page. Originally Vivarium's Phase 0
-> hand-coded PoC; retrofitted onto the [`_shared/`](../_shared/) helpers
-> and TypeScript toolchain so it consumes the canonical `vivarium-contract: v1`
-> surface like every other Phase 1 page.
+> **Status**: Layer 1 reproduction page. Uses the shared
+> [`_shared/`](../_shared/) helpers and TypeScript toolchain, and emits
+> the canonical `vivarium-contract: v1` surface.
 
 ## The bug
 
@@ -13,8 +12,6 @@
 constructors should produce a consistent dtype for an empty input.
 
 ## Why this bug
-
-Originally selected as Phase 0's "easiest to debug at a glance" PoC:
 
 - Three-line reproduction, zero non-pandas dependencies.
 - Verdict is a `dtype` comparison — a single boolean — so the page emits
@@ -113,11 +110,6 @@ Published to GitHub Pages at
 build` in `src/layer1_wasm/` first so the compiled `repro.js` exists
 when the bundling step copies the directory into the Pages artefact.
 
-Legacy URL `https://aletheia-works.github.io/vivarium/poc/pandas-56679/`
-is preserved by an HTML meta-refresh redirect generated at deploy
-time, so external links from before the URL migration continue to
-work.
-
 ## Verification status
 
 ### Machine-verified (Claude Preview MCP, Chromium-based engine)
@@ -136,12 +128,10 @@ work.
 
 ### Needs a human check
 
-Carried over from the Phase 0 PoC, still applicable post-retrofit:
-
 1. **Cross-browser** — confirmation in current Firefox and Safari, in
    addition to the Chromium engine that Preview MCP drives. Pyodide
    advertises support, but Safari has historically differed on
-   `SharedArrayBuffer` / COOP-COEP defaults; this PoC does not use
+   `SharedArrayBuffer` / COOP-COEP defaults; this recipe does not use
    threading so it should be unaffected, but only a real run on each
    engine can prove it.
 2. **First-visit load on typical broadband** — local measurement is not

--- a/src/layer1_wasm/php-12167/repro.ts
+++ b/src/layer1_wasm/php-12167/repro.ts
@@ -15,13 +15,12 @@
 //   - "unreproduced" — the bug does NOT reproduce (the runtime ships a fix,
 //     or the runtime errored before producing a result).
 //
-// Phase 7 B3 (ADR-0030) — this recipe is the PoC for R.2 Path A
-// (Layer 1 source-substitution branch-fix). After the baseline run
-// captures the original verdict, we opt into the shared Path A panel
-// so visitors can paste an alternative reproduction script (typically a
-// userland fix proposed by an AI agent) and re-run it through the same
-// php-wasm runtime. The panel produces a Contract v1 verdict bundle
-// the visitor drops on /repro/compare for side-by-side review.
+// This recipe exercises R.2 Path A (Layer 1 source-substitution
+// branch-fix). After the baseline run captures the original verdict, we
+// opt into the shared Path A panel so visitors can paste an alternative
+// reproduction script and re-run it through the same php-wasm runtime.
+// The panel produces a Contract v1 verdict bundle the visitor drops on
+// /repro/compare for side-by-side review.
 
 import { enablePathA, type PathACapturedRun } from '../_shared/path_a.js';
 import { loadVivariumPhp, type PhpRunner } from '../_shared/php_loader.js';

--- a/src/layer1_wasm/tests/path_a.spec.ts
+++ b/src/layer1_wasm/tests/path_a.spec.ts
@@ -1,6 +1,6 @@
 // Phase 7 B3 — R.2 Path A regression suite.
 //
-// Asserts the Path A panel on the php-12167 PoC recipe:
+// Asserts the Path A panel on the php-12167 recipe:
 //  - Mounts after the baseline run completes.
 //  - Accepts a userland fix via the textarea + Run button and re-runs
 //    the substituted source through the same php-wasm runtime.

--- a/src/layer2_docker/_assets/chrome.js
+++ b/src/layer2_docker/_assets/chrome.js
@@ -184,9 +184,9 @@ function registerServiceWorker() {
   if (!('serviceWorker' in navigator)) return;
   if (location.protocol === 'file:') return;
 
-  // Path is relative to /repro/<slug>/. The SW lives at
-  // /vivarium/repro/_assets/sw.js (per-layer copy under each layer's
-  // _assets/ tree). Scope is the whole /repro/ tree so any reproduction
+  // Path is relative to /repro/<project>/<issue_path>/. The SW lives at
+  // /vivarium/repro/<project>/_assets/sw.js (per-project copy under each
+  // layer's _assets/ tree). Scope is the whole /repro/ tree so any reproduction
   // page benefits from the cached Pyodide; this requires the
   // `Service-Worker-Allowed` header which the rspress dev middleware
   // sets for any file ending in `sw.js`, regardless of SW location.

--- a/src/layer2_docker/_assets/sw.js
+++ b/src/layer2_docker/_assets/sw.js
@@ -1,9 +1,9 @@
 // Vivarium reproduction-page service worker.
 //
 // Caches Pyodide / Ruby.wasm / php-wasm runtime files so repeat visits
-// to any /repro/<slug>/ page are near-instant (no CDN fetch). First
-// visits go to the network; the response is stored in CacheStorage so
-// the next visit (any tab, any reproduction) hits cache.
+// to any /repro/<project>/<issue_path>/ page are near-instant (no CDN
+// fetch). First visits go to the network; the response is stored in
+// CacheStorage so the next visit (any tab, any reproduction) hits cache.
 //
 // Scope is /vivarium/repro/ — every reproduction page is in this tree.
 // Pages outside (the rspress docs site itself) are not affected.


### PR DESCRIPTION
## Summary

- Remove legacy reproduction URL compatibility for `/poc/<slug>/` and slug-only `/repro/<slug>/` paths.
- Simplify the Rspress dev resolver and tests around the canonical `/repro/<project>/<issue_path>/` shape.
- Clean stale Phase 0 / PoC wording from nearby source docs and comments.

Closes: n/a

## Review focus

- [x] Confirm `deploy-docs.yml` no longer emits compatibility redirect pages.
- [x] Confirm canonical reproduction routes and shared asset routing remain intact.
- [x] Confirm the removed historical comments were not carrying current operational guidance.

## Process notes

- AI-authored? Yes; please ensure the `ai: generated` label is present.
- Scope-creep check: the diff is limited to legacy URL compatibility removal and stale-comment cleanup.
- Validation: targeted `rg` checks, `resolveReproFile` smoke test via Node, and local `rspress build`.
