### PR TITLE
feat(wasm): add layer 1 reproduction for HypothesisWorks/hypothesis#4651

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -9,7 +9,7 @@
     },
     {
       "name": "vivarium-layer1",
-      "runtimeExecutable": "C:\\Users\\Jam\\AppData\\Local\\mise\\installs\\uv\\0.11.12\\uv.exe",
+      "runtimeExecutable": "C:\\Users\\Jam\\AppData\\Local\\mise\\installs\\uv\\0.11.14\\uv.exe",
       "runtimeArgs": ["run", "--no-project", "--python", "3.13", "python", "-m", "http.server", "8767", "--directory", "src/layer1_wasm"],
       "port": 8767
     }

--- a/docs/site/_data/projects.json
+++ b/docs/site/_data/projects.json
@@ -98,6 +98,13 @@
       "description": "Layer 2 Docker reproductions targeting open upstream regressions in the Node.js runtime. Each recipe pins a stable `node:<major>-slim` base so the verdict flips from `reproduced` to `unreproduced` once the upstream fix lands in a later patch release.",
       "homepage": "https://nodejs.org/",
       "github": "https://github.com/nodejs/node"
+    },
+    "hypothesis": {
+      "display_name": "Hypothesis",
+      "tagline": "Property-based testing for Python.",
+      "description": "Reproductions install hypothesis from PyPI via micropip into the Pyodide build that ships in the browser; pages also publish a CLI repro.py that runs against a host CPython pinned via mise.",
+      "homepage": "https://hypothesis.readthedocs.io/",
+      "github": "https://github.com/HypothesisWorks/hypothesis"
     }
   }
 }

--- a/docs/site/_data/recipe-facets.json
+++ b/docs/site/_data/recipe-facets.json
@@ -89,6 +89,17 @@
       "symptom": "intl-month-dropped",
       "severity": "regression",
       "tags": ["intl", "datetimeformat", "iso8601-calendar", "icu"]
+    },
+    "hypothesis-4651": {
+      "language": "python",
+      "symptom": "strategy-violates-declared-bound",
+      "severity": "bug",
+      "tags": [
+        "property-based-testing",
+        "decimal",
+        "strategies",
+        "strategy-invariant"
+      ]
     }
   }
 }

--- a/docs/site/public/api/projects.json
+++ b/docs/site/public/api/projects.json
@@ -67,6 +67,19 @@
       "github": "https://github.com/util-linux/util-linux"
     },
     {
+      "project": "hypothesis",
+      "display_name": "Hypothesis",
+      "recipe_count": 1,
+      "layers": [
+        1
+      ],
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/hypothesis/",
+      "tagline": "Property-based testing for Python.",
+      "description": "Reproductions install hypothesis from PyPI via micropip into the Pyodide build that ships in the browser; pages also publish a CLI repro.py that runs against a host CPython pinned via mise.",
+      "homepage": "https://hypothesis.readthedocs.io/",
+      "github": "https://github.com/HypothesisWorks/hypothesis"
+    },
+    {
       "project": "mpmath",
       "display_name": "mpmath",
       "recipe_count": 1,

--- a/docs/site/public/api/recipes.json
+++ b/docs/site/public/api/recipes.json
@@ -39,6 +39,24 @@
       "severity": "spec-violation"
     },
     {
+      "slug": "hypothesis-4651",
+      "layer": 1,
+      "project": "hypothesis",
+      "issue": 4651,
+      "title": "HypothesisWorks/hypothesis#4651",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/hypothesis/4651/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/hypothesis-4651",
+      "language": "python",
+      "tags": [
+        "property-based-testing",
+        "decimal",
+        "strategies",
+        "strategy-invariant"
+      ],
+      "symptom": "strategy-violates-declared-bound",
+      "severity": "bug"
+    },
+    {
       "slug": "mpmath-983",
       "layer": 1,
       "project": "mpmath",

--- a/src/layer1_wasm/hypothesis-4651/README.md
+++ b/src/layer1_wasm/hypothesis-4651/README.md
@@ -1,0 +1,144 @@
+# Reproduction — HypothesisWorks/hypothesis#4651
+
+> Layer 1 reproduction page — installs a third-party Python package
+> via `micropip`. Conforms to `vivarium-contract: v1`. The recipe was
+> drafted by an AI agent (Claude Code, Opus 4.7); see the
+> [Authorship](#authorship) note below.
+
+## The bug
+
+[HypothesisWorks/hypothesis#4651](https://github.com/HypothesisWorks/hypothesis/issues/4651)
+— `st.decimals(min_value, max_value, places=N)` returns
+`Decimal` values that exceed the declared `[min_value, max_value]`
+range when both bounds have many significant digits.
+
+```python
+import decimal
+from hypothesis import given, settings
+from hypothesis.strategies import decimals
+
+min_ = decimal.Decimal(f"0.{'0' * 63}1")
+max_ = decimal.Decimal(f"{'9' * 64}.{'9' * 64}")
+
+@given(decimals(min_value=min_, max_value=max_, places=2))
+@settings(max_examples=10000)
+def f(d):
+    assert min_ <= d <= max_
+
+f()
+# Falsifying example: f(d=int_to_decimal(10**78))   ← far above max_
+```
+
+The suspected fix area is the internal `ctx(val)` helper in
+[`hypothesis/strategies/_internal/core.py:1811`](https://github.com/HypothesisWorks/hypothesis/blob/master/hypothesis-python/src/hypothesis/strategies/_internal/core.py#L1811):
+
+```python
+def ctx(val):
+    """Return a context in which this value is lossless."""
+    precision = ceil(math.log10(abs(val) or 1)) + places + 1
+    return Context(prec=max([precision, 1]))
+```
+
+For `min_value = Decimal("0." + "0" * 63 + "1")`, `math.log10(abs(val))`
+is roughly `-64`, so `ceil(...) + places + 1` is negative — and the
+`max([precision, 1])` floor clamps the working precision to 1.
+`ctx(min_value).divide(min_value, factor)` then loses essentially
+every coefficient digit, and the strategy ends up sampling integers
+whose `* 10^-places` re-projection lands far outside the declared
+range. The closed PRs ([#4668](https://github.com/HypothesisWorks/hypothesis/pull/4668),
+[#4688](https://github.com/HypothesisWorks/hypothesis/pull/4688))
+both propose deriving precision from the `Decimal` coefficient's
+digit count rather than `math.log10(magnitude)`, but were rejected
+without merge for unrelated authorship reasons. The bug itself
+remains open as of 2026-05-16.
+
+## Why this bug
+
+- Pure Python — hypothesis pulls in `attrs` and `sortedcontainers`,
+  also pure Python. No native extensions, no I/O, no thread
+  scheduler. Pyodide installs all three wheels from PyPI via
+  `micropip` in seconds.
+- Reproduction is two independent signal paths (a bounded
+  `@given` search and a manual `strategy.example()` sweep). The
+  verdict reduces to a boolean: at least one sample violated the
+  declared bounds → bug. Either path alone suffices, so a recipe
+  emits a mechanically-distinguishable
+  `reproduced` / `unreproduced` even if the WASM runtime breaks
+  one of the two signals.
+- Reported against hypothesis 6.116.0; the latest release at
+  authoring time is 6.152.7 (2026-05-16) and the bug still
+  reproduces there. Pinning in PEP 723 / `repro.ts` to that exact
+  version locks the verdict to a known-bad build, so the page
+  flips to `unreproduced` only when a new hypothesis release lands
+  an actual fix.
+- Demonstrates Vivarium handles **property-based-testing
+  strategy-invariant** bugs — strategies that violate the bounds
+  they themselves declare. This category is distinct from
+  `mpmath-983` (numerical stability) and `astroid-2993`
+  (parser memory error), so it broadens the Layer 1 catalogue.
+
+## Files
+
+| File         | Role                                                              |
+| ------------ | ----------------------------------------------------------------- |
+| `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
+| `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
+| `repro.py`   | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. PEP 723 inline metadata pins `hypothesis==6.152.7`. |
+
+## Verdict contract — `vivarium-contract: v1`
+
+The page conforms to the contract canonicalised in
+[`../_shared/verdict.ts`](../_shared/verdict.ts). The `result`
+field of the envelope reports `min_value`, `max_value`, `places`,
+the `hypothesis_falsifying` example string (or `null`),
+`manual_violation_count`, and the boolean `bound_violated`.
+
+A `reproduced` verdict means **the bug reproduced** — either the
+bounded `@given` search caught an `AssertionError` from a
+bound-violating sample, or the manual sweep observed at least one
+`strategy.example()` value outside `[min_value, max_value]`. An
+`unreproduced` verdict means both paths returned empty (the
+strategy respected its declared bounds across every sample, or the
+runtime errored before producing a result).
+
+## Running locally — in-browser
+
+```bash
+cd src/layer1_wasm
+bun install
+bun run build
+python -m http.server -d . 8767
+# open http://localhost:8767/hypothesis-4651/
+```
+
+The page first preloads `micropip`, then installs
+`hypothesis==6.152.7` (plus its `attrs` + `sortedcontainers`
+transitive dependencies) from PyPI on the visitor's machine before
+running the reproduction. First-visit cold load is slower than
+recipes that exercise only Pyodide-bundled packages.
+
+## Native verification — same reproduction under a real CPython
+
+```bash
+mise install
+mise exec uv -- uv run src/layer1_wasm/hypothesis-4651/repro.py
+# verdict=reproduced — st.decimals(places=…) produced a Decimal outside the declared bounds
+```
+
+## Authorship
+
+This recipe was authored by an AI agent (Claude Code, Opus 4.7)
+acting on instructions from the human maintainer. The vivarium
+project itself is AI-delegated by design; the
+[`ai: generated`](https://github.com/aletheia-works/vivarium/labels/ai%3A%20generated)
+label is applied to every PR an AI agent opens, so reviewers can
+calibrate accordingly. No upstream PR is being opened against
+`HypothesisWorks/hypothesis` from this recipe — the verdict page
+is a stand-alone reproduction artefact.
+
+## Deployment
+
+Published to GitHub Pages at
+`https://aletheia-works.github.io/vivarium/repro/hypothesis/4651/` by
+the `deploy-docs` workflow.

--- a/src/layer1_wasm/hypothesis-4651/index.html
+++ b/src/layer1_wasm/hypothesis-4651/index.html
@@ -1,0 +1,181 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="vivarium-contract" content="v1" />
+    <title>Vivarium · Reproducing HypothesisWorks/hypothesis#4651</title>
+    <!-- vivarium-chrome-injected -->
+    <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.asm.wasm" as="fetch" type="application/wasm" crossorigin />
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/python_stdlib.zip" as="fetch" crossorigin />
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide-lock.json" as="fetch" type="application/json" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <!-- Keep the version below in sync with DEFAULT_PYODIDE_VERSION in
+         ../_shared/loader.ts. -->
+    <link
+      rel="modulepreload"
+      href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.mjs"
+      crossorigin
+    />
+    <link rel="stylesheet" href="../_shared/style.css" />
+    <template id="bug-context">
+      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <div class="vh-drawer__body" id="vh-drawer-body">
+        <p>
+          <code>st.decimals(min_value, max_value, places=N)</code>
+          should only generate <code>Decimal</code> values that fall
+          inside the declared <code>[min_value, max_value]</code>
+          range and align to <code>N</code> decimal places. With
+          high-significant-digit bounds (e.g. a 65-digit
+          <code>min_value</code> and a 129-digit
+          <code>max_value</code>), the strategy returns samples that
+          exceed <code>max_value</code> by many orders of magnitude.
+        </p>
+        <p>
+          The script on this page installs hypothesis into Pyodide
+          via <code>micropip</code>, runs the strategy under both a
+          bounded <code>@given</code> search and a manual
+          <code>strategy.example()</code> sweep, and reports any
+          sample that violates the declared bounds. If either path
+          finds a bound-violating value, the bug reproduces in the
+          runtime currently loaded in your browser tab.
+        </p>
+        <p>
+          The suspected fix area is the internal <code>ctx(val)</code>
+          helper in
+          <code>hypothesis/strategies/_internal/core.py:1811</code>:
+          <code>precision = ceil(math.log10(abs(val) or 1)) + places + 1</code>
+          collapses to 1 for tiny values, and at that precision the
+          quantising divide drops essentially every coefficient
+          digit. The full discussion lives in the GitHub issue
+          thread linked below.
+        </p>
+      </div>
+      <hr class="vh-drawer__divider" />
+      <div class="vh-drawer__meta-grid">
+        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-val">HypothesisWorks/hypothesis</span>
+        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-val">#4651</span>
+        <span class="vh-drawer__meta-key">Layer</span>
+        <span class="vh-drawer__meta-val">L1 · WASM</span>
+        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-val">Pyodide v0.29.3</span>
+      </div>
+    </template>
+  </head>
+  <body>
+    <main class="vh-main">
+      <header class="vh-main__header">
+        <div class="vh-main__header-text">
+          <p class="kicker">L1 · Pyodide · hypothesis</p>
+          <h1>Reproducing <a href="https://github.com/HypothesisWorks/hypothesis/issues/4651">HypothesisWorks/hypothesis#4651</a></h1>
+          <div class="vh-main__header-actions">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+              Bug context
+            </button>
+            <a class="vh-chip" href="https://github.com/HypothesisWorks/hypothesis/issues/4651" target="_blank" rel="noreferrer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              Upstream issue
+            </a>
+          </div>
+        </div>
+        <div class="vh-main__header-aside">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+            Loading Pyodide runtime…
+          </div>
+          <p class="meta" id="meta"></p>
+        </div>
+      </header>
+
+      <div class="vh-main__cols">
+        <section class="vh-main__col vh-main__col--script">
+          <h2>Reproduction script</h2>
+          <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> hypothesis</span></span>
+<span class="line"><span style="color:#F97583">from</span><span style="color:#E1E4E8"> decimal </span><span style="color:#F97583">import</span><span style="color:#E1E4E8"> Decimal</span></span>
+<span class="line"><span style="color:#F97583">from</span><span style="color:#E1E4E8"> hypothesis </span><span style="color:#F97583">import</span><span style="color:#E1E4E8"> given, settings, strategies </span><span style="color:#F97583">as</span><span style="color:#E1E4E8"> st, HealthCheck</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#79B8FF">MIN_</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> Decimal(</span><span style="color:#9ECBFF">"0."</span><span style="color:#F97583"> +</span><span style="color:#9ECBFF"> "0"</span><span style="color:#F97583"> *</span><span style="color:#79B8FF"> 63</span><span style="color:#F97583"> +</span><span style="color:#9ECBFF"> "1"</span><span style="color:#E1E4E8">)</span></span>
+<span class="line"><span style="color:#79B8FF">MAX_</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> Decimal(</span><span style="color:#9ECBFF">"9"</span><span style="color:#F97583"> *</span><span style="color:#79B8FF"> 64</span><span style="color:#F97583"> +</span><span style="color:#9ECBFF"> "."</span><span style="color:#F97583"> +</span><span style="color:#9ECBFF"> "9"</span><span style="color:#F97583"> *</span><span style="color:#79B8FF"> 64</span><span style="color:#E1E4E8">)</span></span>
+<span class="line"><span style="color:#79B8FF">PLACES</span><span style="color:#F97583"> =</span><span style="color:#79B8FF"> 2</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">result </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span style="color:#9ECBFF">    "hypothesis_version"</span><span style="color:#E1E4E8">: hypothesis.</span><span style="color:#79B8FF">__version__</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "python_version"</span><span style="color:#E1E4E8">: sys.version.split()[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
+<span class="line"><span style="color:#9ECBFF">    "min_value"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">str</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">MIN_</span><span style="color:#E1E4E8">),</span></span>
+<span class="line"><span style="color:#9ECBFF">    "max_value"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">str</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">MAX_</span><span style="color:#E1E4E8">),</span></span>
+<span class="line"><span style="color:#9ECBFF">    "places"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">PLACES</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "hypothesis_falsifying"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">None</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "hypothesis_crash"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">None</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "manual_violations"</span><span style="color:#E1E4E8">: [],</span></span>
+<span class="line"><span style="color:#9ECBFF">    "manual_crash"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">None</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "bound_violated"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">False</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#6A737D"># Approach A — bounded Hypothesis search.</span></span>
+<span class="line"><span style="color:#6A737D"># Capturing an AssertionError from inside the property hands us the</span></span>
+<span class="line"><span style="color:#6A737D"># falsifying example without scraping Hypothesis's pytest-style</span></span>
+<span class="line"><span style="color:#6A737D"># reporter. derandomize=True + database=None makes the 300-example</span></span>
+<span class="line"><span style="color:#6A737D"># budget deterministic across browsers.</span></span>
+<span class="line"><span style="color:#E1E4E8">state </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> {</span><span style="color:#9ECBFF">"falsifying"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">None</span><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#B392F0">@given</span><span style="color:#E1E4E8">(st.decimals(</span><span style="color:#FFAB70">min_value</span><span style="color:#F97583">=</span><span style="color:#79B8FF">MIN_</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">max_value</span><span style="color:#F97583">=</span><span style="color:#79B8FF">MAX_</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">places</span><span style="color:#F97583">=</span><span style="color:#79B8FF">PLACES</span><span style="color:#E1E4E8">))</span></span>
+<span class="line"><span style="color:#B392F0">@settings</span><span style="color:#E1E4E8">(</span></span>
+<span class="line"><span style="color:#FFAB70">    max_examples</span><span style="color:#F97583">=</span><span style="color:#79B8FF">300</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#FFAB70">    deadline</span><span style="color:#F97583">=</span><span style="color:#79B8FF">None</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#FFAB70">    derandomize</span><span style="color:#F97583">=</span><span style="color:#79B8FF">True</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#FFAB70">    database</span><span style="color:#F97583">=</span><span style="color:#79B8FF">None</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#FFAB70">    suppress_health_check</span><span style="color:#F97583">=</span><span style="color:#79B8FF">list</span><span style="color:#E1E4E8">(HealthCheck),</span></span>
+<span class="line"><span style="color:#E1E4E8">)</span></span>
+<span class="line"><span style="color:#F97583">def</span><span style="color:#B392F0"> prop</span><span style="color:#E1E4E8">(d):</span></span>
+<span class="line"><span style="color:#F97583">    if</span><span style="color:#F97583"> not</span><span style="color:#E1E4E8"> (</span><span style="color:#79B8FF">MIN_</span><span style="color:#F97583"> &#x3C;=</span><span style="color:#E1E4E8"> d </span><span style="color:#F97583">&#x3C;=</span><span style="color:#79B8FF"> MAX_</span><span style="color:#E1E4E8">):</span></span>
+<span class="line"><span style="color:#F97583">        if</span><span style="color:#E1E4E8"> state[</span><span style="color:#9ECBFF">"falsifying"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">is</span><span style="color:#79B8FF"> None</span><span style="color:#E1E4E8">:</span></span>
+<span class="line"><span style="color:#E1E4E8">            state[</span><span style="color:#9ECBFF">"falsifying"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> str</span><span style="color:#E1E4E8">(d)[:</span><span style="color:#79B8FF">200</span><span style="color:#E1E4E8">]</span></span>
+<span class="line"><span style="color:#F97583">        raise</span><span style="color:#79B8FF"> AssertionError</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">str</span><span style="color:#E1E4E8">(d)[:</span><span style="color:#79B8FF">120</span><span style="color:#E1E4E8">])</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#F97583">try</span><span style="color:#E1E4E8">:</span></span>
+<span class="line"><span style="color:#E1E4E8">    prop()</span></span>
+<span class="line"><span style="color:#F97583">except</span><span style="color:#79B8FF"> AssertionError</span><span style="color:#E1E4E8">:</span></span>
+<span class="line"><span style="color:#F97583">    pass</span></span>
+<span class="line"><span style="color:#F97583">except</span><span style="color:#79B8FF"> Exception</span><span style="color:#F97583"> as</span><span style="color:#E1E4E8"> e:</span></span>
+<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"hypothesis_crash"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#F97583"> f</span><span style="color:#9ECBFF">"</span><span style="color:#79B8FF">{type</span><span style="color:#E1E4E8">(e).</span><span style="color:#79B8FF">__name__}</span><span style="color:#9ECBFF">: </span><span style="color:#79B8FF">{str</span><span style="color:#E1E4E8">(e)[:</span><span style="color:#79B8FF">200</span><span style="color:#E1E4E8">]</span><span style="color:#79B8FF">}</span><span style="color:#9ECBFF">"</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">result[</span><span style="color:#9ECBFF">"hypothesis_falsifying"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> state[</span><span style="color:#9ECBFF">"falsifying"</span><span style="color:#E1E4E8">]</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#6A737D"># Approach B — manual strategy.example() sweep.</span></span>
+<span class="line"><span style="color:#6A737D"># Independent confirmation path: if Hypothesis's machinery itself</span></span>
+<span class="line"><span style="color:#6A737D"># misbehaves on WASM, the raw strategy output still tells us whether</span></span>
+<span class="line"><span style="color:#6A737D"># the bound-violation phenomenon survives.</span></span>
+<span class="line"><span style="color:#E1E4E8">strat </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> st.decimals(</span><span style="color:#FFAB70">min_value</span><span style="color:#F97583">=</span><span style="color:#79B8FF">MIN_</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">max_value</span><span style="color:#F97583">=</span><span style="color:#79B8FF">MAX_</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">places</span><span style="color:#F97583">=</span><span style="color:#79B8FF">PLACES</span><span style="color:#E1E4E8">)</span></span>
+<span class="line"><span style="color:#F97583">try</span><span style="color:#E1E4E8">:</span></span>
+<span class="line"><span style="color:#F97583">    for</span><span style="color:#E1E4E8"> _ </span><span style="color:#F97583">in</span><span style="color:#79B8FF"> range</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">500</span><span style="color:#E1E4E8">):</span></span>
+<span class="line"><span style="color:#F97583">        try</span><span style="color:#E1E4E8">:</span></span>
+<span class="line"><span style="color:#E1E4E8">            v </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> strat.example()</span></span>
+<span class="line"><span style="color:#F97583">        except</span><span style="color:#79B8FF"> Exception</span><span style="color:#E1E4E8">:</span></span>
+<span class="line"><span style="color:#F97583">            continue</span></span>
+<span class="line"><span style="color:#F97583">        if</span><span style="color:#F97583"> not</span><span style="color:#E1E4E8"> (</span><span style="color:#79B8FF">MIN_</span><span style="color:#F97583"> &#x3C;=</span><span style="color:#E1E4E8"> v </span><span style="color:#F97583">&#x3C;=</span><span style="color:#79B8FF"> MAX_</span><span style="color:#E1E4E8">):</span></span>
+<span class="line"><span style="color:#E1E4E8">            result[</span><span style="color:#9ECBFF">"manual_violations"</span><span style="color:#E1E4E8">].append(</span><span style="color:#79B8FF">str</span><span style="color:#E1E4E8">(v)[:</span><span style="color:#79B8FF">200</span><span style="color:#E1E4E8">])</span></span>
+<span class="line"><span style="color:#F97583">            if</span><span style="color:#79B8FF"> len</span><span style="color:#E1E4E8">(result[</span><span style="color:#9ECBFF">"manual_violations"</span><span style="color:#E1E4E8">]) </span><span style="color:#F97583">>=</span><span style="color:#79B8FF"> 3</span><span style="color:#E1E4E8">:</span></span>
+<span class="line"><span style="color:#F97583">                break</span></span>
+<span class="line"><span style="color:#F97583">except</span><span style="color:#79B8FF"> Exception</span><span style="color:#F97583"> as</span><span style="color:#E1E4E8"> e:</span></span>
+<span class="line"><span style="color:#E1E4E8">    result[</span><span style="color:#9ECBFF">"manual_crash"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#F97583"> f</span><span style="color:#9ECBFF">"</span><span style="color:#79B8FF">{type</span><span style="color:#E1E4E8">(e).</span><span style="color:#79B8FF">__name__}</span><span style="color:#9ECBFF">: </span><span style="color:#79B8FF">{str</span><span style="color:#E1E4E8">(e)[:</span><span style="color:#79B8FF">200</span><span style="color:#E1E4E8">]</span><span style="color:#79B8FF">}</span><span style="color:#9ECBFF">"</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">result[</span><span style="color:#9ECBFF">"bound_violated"</span><span style="color:#E1E4E8">] </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> bool</span><span style="color:#E1E4E8">(result[</span><span style="color:#9ECBFF">"hypothesis_falsifying"</span><span style="color:#E1E4E8">]) </span><span style="color:#F97583">or</span><span style="color:#79B8FF"> bool</span><span style="color:#E1E4E8">(result[</span><span style="color:#9ECBFF">"manual_violations"</span><span style="color:#E1E4E8">])</span></span>
+<span class="line"><span style="color:#E1E4E8">result</span></span></code></pre>
+        </section>
+
+        <section class="vh-main__col vh-main__col--output">
+          <h2>Output</h2>
+          <pre id="output">(running)</pre>
+        </section>
+      </div>
+
+    </main>
+
+    <script type="module" src="./repro.js"></script>
+  </body>
+</html>

--- a/src/layer1_wasm/hypothesis-4651/repro.py
+++ b/src/layer1_wasm/hypothesis-4651/repro.py
@@ -1,0 +1,125 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#   "hypothesis==6.152.7",
+# ]
+# ///
+"""Vivarium Layer 1 reproduction — HypothesisWorks/hypothesis#4651, native variant.
+
+Mirrors the script that runs in `repro.ts` (under Pyodide) so a
+contributor can re-verify the bug against a real CPython interpreter
++ a real hypothesis build:
+
+    mise install                                                       # one-time
+    mise exec uv -- uv run src/layer1_wasm/hypothesis-4651/repro.py
+
+PEP 723 inline metadata pins **hypothesis 6.152.7** — the latest
+release at authoring time (2026-05-16). `uv run` reads the metadata
+and creates an ephemeral venv on first invocation; subsequent runs
+hit uv's cache.
+
+The bug: `st.decimals(min_value, max_value, places=N)` returns
+`Decimal` values that exceed the declared bounds when both bounds
+have many significant digits. The internal `ctx(val)` helper
+(`hypothesis/strategies/_internal/core.py:1811`) derives precision
+from `math.log10(abs(val))`, which collapses to 1 for tiny values
+like `Decimal("0." + "0" * 63 + "1")` — and at precision 1 the
+quantising divide loses essentially all the coefficient's digits.
+
+Exits 0 on `pass` (bug REPRODUCED — at least one sample violated
+the declared bounds), 1 on `fail` (the strategy respected its
+bounds across both signal paths, likely fixed upstream).
+"""
+
+import json
+import sys
+from decimal import Decimal
+
+import hypothesis
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+MIN_ = Decimal("0." + "0" * 63 + "1")
+MAX_ = Decimal("9" * 64 + "." + "9" * 64)
+PLACES = 2
+
+
+result = {
+    "hypothesis_version": hypothesis.__version__,
+    "python_version": sys.version.split()[0],
+    "min_value": str(MIN_),
+    "max_value": str(MAX_),
+    "places": PLACES,
+    "hypothesis_falsifying": None,
+    "hypothesis_crash": None,
+    "manual_violations": [],
+    "manual_crash": None,
+    "bound_violated": False,
+}
+
+# Approach A — bounded Hypothesis search. Capturing an AssertionError
+# from inside the property hands us the falsifying example without
+# having to scrape Hypothesis's pytest-style reporter.
+state = {"falsifying": None}
+
+
+@given(st.decimals(min_value=MIN_, max_value=MAX_, places=PLACES))
+@settings(
+    max_examples=300,
+    deadline=None,
+    derandomize=True,
+    database=None,
+    suppress_health_check=list(HealthCheck),
+)
+def prop(d):
+    if not (MIN_ <= d <= MAX_):
+        if state["falsifying"] is None:
+            state["falsifying"] = str(d)[:200]
+        raise AssertionError(str(d)[:120])
+
+
+try:
+    prop()
+except AssertionError:
+    pass
+except Exception as e:
+    result["hypothesis_crash"] = f"{type(e).__name__}: {str(e)[:200]}"
+
+result["hypothesis_falsifying"] = state["falsifying"]
+
+# Approach B — manual strategy.example() sweep. Independent
+# confirmation path: even if Hypothesis's full @given machinery is
+# unreliable for any reason, the raw strategy output still shows
+# whether the bound-violation phenomenon survives.
+strat = st.decimals(min_value=MIN_, max_value=MAX_, places=PLACES)
+try:
+    for _ in range(500):
+        try:
+            v = strat.example()
+        except Exception:
+            continue
+        if not (MIN_ <= v <= MAX_):
+            result["manual_violations"].append(str(v)[:200])
+            if len(result["manual_violations"]) >= 3:
+                break
+except Exception as e:
+    result["manual_crash"] = f"{type(e).__name__}: {str(e)[:200]}"
+
+result["bound_violated"] = bool(result["hypothesis_falsifying"]) or bool(
+    result["manual_violations"]
+)
+
+print(json.dumps(result, indent=2))
+
+if result["bound_violated"]:
+    print(
+        "verdict=reproduced — st.decimals(places=…) produced a Decimal outside the declared bounds",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+else:
+    print(
+        "verdict=unreproduced — st.decimals stayed within bounds across both signal paths (likely fixed upstream)",
+        file=sys.stderr,
+    )
+    sys.exit(1)

--- a/src/layer1_wasm/hypothesis-4651/repro.ts
+++ b/src/layer1_wasm/hypothesis-4651/repro.ts
@@ -1,0 +1,275 @@
+// Vivarium Layer 1 reproduction — HypothesisWorks/hypothesis#4651.
+//
+// `st.decimals(min_value, max_value, places=N)` returns `Decimal`
+// values that exceed `max_value` (or fall below `min_value`) when the
+// bounds have many significant digits. The strategy quantises the
+// sampled value after deciding on a magnitude, but the internal
+// arithmetic context's precision is derived from `math.log10(abs(val))`
+// (`hypothesis/strategies/_internal/core.py:1811`), which collapses to
+// 1 for tiny bounds like `Decimal("0." + "0" * 63 + "1")`. Once
+// precision saturates, `ctx(min_value).divide(min_value, factor)`
+// loses almost all the coefficient's significant digits, so the
+// final quantised Decimal can land far outside the declared range.
+//
+// Verdict semantics (per ADR-0008 / contract v1):
+//   - "reproduced" — a Hypothesis search or a manual `strategy.example()`
+//     sweep produced at least one `Decimal` outside `[MIN, MAX]`.
+//   - "unreproduced" — both signal paths returned empty (the strategy
+//     respected its declared bounds on every sample), or the runtime
+//     errored before producing a result.
+//
+// hypothesis is **not** in Pyodide's bundled package set, so we install
+// it via `micropip` after the Pyodide bootstrap. hypothesis is pure
+// Python and pulls in `attrs` + `sortedcontainers` as transitive
+// dependencies — all single pure-Python wheels from PyPI.
+
+import { loadVivariumPyodide } from '../_shared/loader.js';
+import type { PathACapturedRun } from '../_shared/path_a.js';
+import { enableRunner } from '../_shared/runner.js';
+import {
+  setResult,
+  setVerdict,
+  type VivariumResultV1,
+} from '../_shared/verdict.js';
+
+const REPRO_CODE = `
+import sys
+import hypothesis
+from decimal import Decimal
+from hypothesis import given, settings, strategies as st, HealthCheck
+
+MIN_ = Decimal("0." + "0" * 63 + "1")
+MAX_ = Decimal("9" * 64 + "." + "9" * 64)
+PLACES = 2
+
+result = {
+    "hypothesis_version": hypothesis.__version__,
+    "python_version": sys.version.split()[0],
+    "min_value": str(MIN_),
+    "max_value": str(MAX_),
+    "places": PLACES,
+    "hypothesis_falsifying": None,
+    "hypothesis_crash": None,
+    "manual_violations": [],
+    "manual_crash": None,
+    "bound_violated": False,
+}
+
+# Approach A — bounded Hypothesis search.
+# Capturing an AssertionError from inside the property hands us the
+# falsifying example without scraping Hypothesis's pytest-style
+# reporter. derandomize=True + database=None makes the 300-example
+# budget deterministic across browsers.
+state = {"falsifying": None}
+
+@given(st.decimals(min_value=MIN_, max_value=MAX_, places=PLACES))
+@settings(
+    max_examples=300,
+    deadline=None,
+    derandomize=True,
+    database=None,
+    suppress_health_check=list(HealthCheck),
+)
+def prop(d):
+    if not (MIN_ <= d <= MAX_):
+        if state["falsifying"] is None:
+            state["falsifying"] = str(d)[:200]
+        raise AssertionError(str(d)[:120])
+
+try:
+    prop()
+except AssertionError:
+    pass
+except Exception as e:
+    result["hypothesis_crash"] = f"{type(e).__name__}: {str(e)[:200]}"
+
+result["hypothesis_falsifying"] = state["falsifying"]
+
+# Approach B — manual strategy.example() sweep.
+# Independent confirmation path: if Hypothesis's machinery itself
+# misbehaves on WASM, the raw strategy output still tells us whether
+# the bound-violation phenomenon survives.
+strat = st.decimals(min_value=MIN_, max_value=MAX_, places=PLACES)
+try:
+    for _ in range(500):
+        try:
+            v = strat.example()
+        except Exception:
+            continue
+        if not (MIN_ <= v <= MAX_):
+            result["manual_violations"].append(str(v)[:200])
+            if len(result["manual_violations"]) >= 3:
+                break
+except Exception as e:
+    result["manual_crash"] = f"{type(e).__name__}: {str(e)[:200]}"
+
+result["bound_violated"] = bool(result["hypothesis_falsifying"]) or bool(result["manual_violations"])
+result
+`.trim();
+
+interface ReproOutput {
+  hypothesis_version: string;
+  python_version: string;
+  min_value: string;
+  max_value: string;
+  places: number;
+  hypothesis_falsifying: string | null;
+  hypothesis_crash: string | null;
+  manual_violations: string[];
+  manual_crash: string | null;
+  bound_violated: boolean;
+}
+
+interface PyodideRuntime {
+  runPythonAsync(code: string): Promise<{
+    toJs(opts: { dict_converter: typeof Object.fromEntries }): ReproOutput;
+    destroy?(): void;
+  }>;
+}
+
+const outputEl = document.getElementById('output');
+const metaEl = document.getElementById('meta');
+const reproCodeEl = document.getElementById('repro-code');
+
+if (!outputEl || !metaEl || !reproCodeEl) {
+  throw new Error(
+    'hypothesis-4651: missing required DOM elements (#output, #meta, #repro-code).',
+  );
+}
+
+if (!reproCodeEl.firstChild) {
+  reproCodeEl.textContent = REPRO_CODE;
+  fetch('./repro.highlighted.html')
+    .then((r) => (r.ok ? r.text() : null))
+    .then((html) => {
+      if (html) reproCodeEl.innerHTML = html;
+    })
+    .catch(() => {});
+}
+
+function evaluate(result: ReproOutput): {
+  verdict: 'reproduced' | 'unreproduced';
+  message: string;
+} {
+  if (result.bound_violated) {
+    return {
+      verdict: 'reproduced',
+      message:
+        'bug reproduced — st.decimals(places=…) produced a Decimal outside the declared [min_value, max_value] bounds.',
+    };
+  }
+  return {
+    verdict: 'unreproduced',
+    message:
+      'bug not reproduced — st.decimals stayed within bounds across the hypothesis search and manual sample sweep.',
+  };
+}
+
+async function captureRun(
+  runtime: PyodideRuntime,
+  source: string,
+): Promise<PathACapturedRun> {
+  try {
+    const proxy = await runtime.runPythonAsync(source);
+    const result = proxy.toJs({ dict_converter: Object.fromEntries });
+    proxy.destroy?.();
+    const ev = evaluate(result);
+    return {
+      exitCode: 0,
+      verdict: ev.verdict,
+      message: ev.message,
+      stdout: JSON.stringify(result, null, 2),
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      exitCode: 1,
+      verdict: 'unreproduced',
+      message: `runtime error: ${message}`,
+      stdout: message,
+    };
+  }
+}
+
+const startedAt = new Date();
+
+try {
+  const { pyodide, version } = await loadVivariumPyodide({
+    packages: ['micropip'],
+    pendingText: 'Loading Pyodide runtime and micropip…',
+  });
+
+  setVerdict('pending', 'Installing hypothesis from PyPI…');
+  const runtime = pyodide as PyodideRuntime;
+  await runtime.runPythonAsync(`
+import micropip
+await micropip.install("hypothesis==6.152.7")
+`);
+
+  setVerdict('pending', 'Running reproduction script…');
+  const baseline = await captureRun(runtime, REPRO_CODE);
+
+  let baselineResult: ReproOutput | null = null;
+  try {
+    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
+  } catch {
+    outputEl.textContent = baseline.stdout;
+    setVerdict(baseline.verdict, baseline.message);
+    throw new Error(baseline.message);
+  }
+
+  metaEl.textContent =
+    `hypothesis ${baselineResult.hypothesis_version} on Python ${baselineResult.python_version} ` +
+    `via Pyodide v${version}.`;
+  outputEl.textContent = baseline.stdout;
+  setVerdict(baseline.verdict, baseline.message);
+
+  const finishedAt = new Date();
+  const envelope: VivariumResultV1 = {
+    contract: 'v1',
+    bug: {
+      project: 'hypothesis',
+      issue: 4651,
+      upstream_url: 'https://github.com/HypothesisWorks/hypothesis/issues/4651',
+    },
+    runtime: {
+      name: 'pyodide',
+      version,
+      extras: {
+        python: baselineResult.python_version,
+        hypothesis: baselineResult.hypothesis_version,
+      },
+    },
+    result: {
+      min_value: baselineResult.min_value,
+      max_value: baselineResult.max_value,
+      places: baselineResult.places,
+      hypothesis_falsifying: baselineResult.hypothesis_falsifying,
+      manual_violation_count: baselineResult.manual_violations.length,
+      bound_violated: baselineResult.bound_violated,
+    },
+    timing: {
+      started_at: startedAt.toISOString(),
+      finished_at: finishedAt.toISOString(),
+      duration_ms: finishedAt.getTime() - startedAt.getTime(),
+    },
+  };
+  setResult(envelope);
+
+  enableRunner({
+    slug: 'hypothesis-4651',
+    baselineSource: REPRO_CODE,
+    runFix: (source) => captureRun(runtime, source),
+  });
+} catch (err: unknown) {
+  console.error(err);
+  const errAny = err as { stack?: string; message?: string } | null;
+  outputEl.textContent =
+    (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
+  if (globalThis.__VIVARIUM_VERDICT__ !== 'unreproduced') {
+    setVerdict(
+      'unreproduced',
+      `bug not reproduced — runtime error: ${errAny?.message ?? String(err)}`,
+    );
+  }
+}

--- a/src/layer1_wasm/scripts/highlight-repros.ts
+++ b/src/layer1_wasm/scripts/highlight-repros.ts
@@ -55,6 +55,7 @@ const LAYER1_DIR = dirname(SCRIPT_DIR);
 const LANG_BY_PROJECT: Record<string, BundledLanguage> = {
   astroid: 'python',
   cpython: 'python',
+  hypothesis: 'python',
   mpmath: 'python',
   numpy: 'python',
   pandas: 'python',

--- a/src/layer1_wasm/tests/repro.spec.ts
+++ b/src/layer1_wasm/tests/repro.spec.ts
@@ -125,6 +125,14 @@ const cases: ReproCase[] = [
     expectedBugIssue: 779,
     expectedRuntimeName: "rust-wasi",
   },
+  {
+    name: "hypothesis-4651 reproduction",
+    url: `${LAYER1}/hypothesis-4651/`,
+    expectedVerdict: "reproduced",
+    expectedBugProject: "hypothesis",
+    expectedBugIssue: 4651,
+    expectedRuntimeName: "pyodide",
+  },
   // Layer 2 — Docker catalogue, verdict snapshot fetched from
   // `verdict.json` next to the page. CI generates `verdict.json` in
   // both `repro-regression.yml` (build + run + write) and


### PR DESCRIPTION

`st.decimals(min_value, max_value, places=N)` returns Decimal values
that exceed the declared bounds when both bounds have many
significant digits. The internal ctx() helper derives precision from
math.log10(abs(val)), which collapses to 1 for tiny values, and at
precision 1 the quantising divide drops essentially every coefficient
digit.

The recipe installs hypothesis 6.152.7 via micropip into Pyodide and
runs two independent signal paths: a bounded @given search and a
manual strategy.example() sweep. Either bound violation marks the
bug as reproduced. Native parity via uv reproduces the same falsifying
example (10**64).

Verified locally:
- bun run build (highlight-repros + tsc)
- mise run recipes:index (regenerates recipes.json + projects.json)
- mise exec uv -- uv run repro.py → verdict=reproduced
- browser preview → verdict=reproduced (Pyodide v0.29.3, 22 s)
- mise run ci:lint → all checks passed
- cd docs && bun run build → site build succeeds

Issue #4651 is OPEN; the linked PRs #4668 and #4688 are both
unmerged-closed (maintainer rejected them as undisclosed AI PRs).
This vivarium recipe is a reproduction artefact only; no upstream PR
is being opened.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
