### PR TITLE
feat(wasm): add fix-candidate verification to hypothesis-4651

### DIFF
--- a/scripts/build-layer1-wheels.sh
+++ b/scripts/build-layer1-wheels.sh
@@ -46,6 +46,13 @@ for src_json in "${sources[@]}"; do
   pkg=$(jq -r '.package' "$src_json")
   url=$(jq -r '.source.url' "$src_json")
   ref=$(jq -r '.source.ref' "$src_json")
+  # `source.subdirectory` is optional; monorepos like
+  # `HypothesisWorks/hypothesis` keep the installable Python package
+  # under a subdirectory (`hypothesis-python/`) rather than at the
+  # repo root, and pip needs PEP 508 `#subdirectory=<dir>` appended
+  # to the VCS spec to find pyproject.toml there. Empty string =
+  # repo root (the common case; astroid-2993 etc.).
+  subdirectory=$(jq -r '.source.subdirectory // ""' "$src_json")
   upstream_pr=$(jq -r '.upstream_pr // ""' "$src_json")
   purpose=$(jq -r '.purpose // ""' "$src_json")
 
@@ -54,7 +61,12 @@ for src_json in "${sources[@]}"; do
     continue
   fi
 
-  echo "[wheels:build] $slug: building $pkg @ git+$url@$ref"
+  pip_spec="${pkg} @ git+${url}@${ref}"
+  if [ -n "$subdirectory" ]; then
+    pip_spec="${pip_spec}#subdirectory=${subdirectory}"
+  fi
+
+  echo "[wheels:build] $slug: building $pip_spec"
 
   # Wipe any stale artefacts so the manifest never points at a wheel
   # filename that no longer exists.
@@ -69,7 +81,7 @@ for src_json in "${sources[@]}"; do
   uv run --no-project --with pip --python 3.13 -- \
     python -m pip wheel --no-deps \
     --wheel-dir "$wheels_dir" \
-    "${pkg} @ git+${url}@${ref}"
+    "$pip_spec"
 
   whl=$(ls "$wheels_dir"/*.whl | head -1)
   if [ -z "$whl" ]; then
@@ -89,7 +101,9 @@ for src_json in "${sources[@]}"; do
     --arg purpose "$purpose" \
     --arg url "$url" \
     --arg ref "$ref" \
+    --arg subdirectory "$subdirectory" \
     --arg commit "$commit" \
+    --arg pip_spec "$pip_spec" \
     --arg upstream_pr "$upstream_pr" \
     --arg fetched_at "$fetched_at" \
     --argjson schema_version 1 \
@@ -99,13 +113,13 @@ for src_json in "${sources[@]}"; do
       filename: $filename,
       version: $version,
       purpose: $purpose,
-      source: {
+      source: ({
         type: "git",
         url: $url,
         ref: $ref,
         commit: $commit,
-        spec: ($pkg + " @ git+" + $url + "@" + $ref)
-      },
+        spec: $pip_spec
+      } + (if $subdirectory == "" then {} else {subdirectory: $subdirectory} end)),
       upstream_pr: $upstream_pr,
       fetched_at: $fetched_at
     }' >"$wheels_dir/manifest.json"

--- a/src/layer1_wasm/hypothesis-4651/README.md
+++ b/src/layer1_wasm/hypothesis-4651/README.md
@@ -81,10 +81,13 @@ remains open as of 2026-05-16.
 
 | File         | Role                                                              |
 | ------------ | ----------------------------------------------------------------- |
-| `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
-| `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. Renders baseline + fix-candidate output panes side-by-side. |
+| `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. Drives the two-variant run. |
 | `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
 | `repro.py`   | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. PEP 723 inline metadata pins `hypothesis==6.152.7`. |
+| `fix-candidate.json` | **Tracked.** Single source of truth for the fix branch the page renders alongside the baseline (fork repo URL, branch ref, and `subdirectory: hypothesis-python` because the installable package lives there in this monorepo). Read by `scripts/build-layer1-wheels.sh`. |
+| `verify_fix.py` | **Maintainer convenience.** PEP 723 native orchestrator that runs the reproduction against **both** the baseline pin and the fix-candidate spec in side-by-side `uv run --no-project --with <spec>` venvs, so a reviewer can see the before/after verdict in one command. Exits 0 iff baseline reproduces AND fix-candidate does not. Deleted once the fix is merged upstream and released on PyPI. |
+| `wheels/`    | Generated; gitignored. `mise run repro:build:wheels` (`scripts/build-layer1-wheels.sh`) builds `hypothesis-<version>-py3-none-any.whl` from `fix-candidate.json` plus a `manifest.json` (filename + version + resolved commit + spec). `repro.ts` fetches the manifest at page load to install the fix candidate in the same Pyodide tab. |
 
 ## Verdict contract — `vivarium-contract: v1`
 
@@ -125,6 +128,57 @@ mise install
 mise exec uv -- uv run src/layer1_wasm/hypothesis-4651/repro.py
 # verdict=reproduced — st.decimals(places=…) produced a Decimal outside the declared bounds
 ```
+
+## Fix-candidate verification
+
+A fork+branch carrying a proposed fix is rendered **side-by-side**
+with the baseline on the same page, so a reviewer can see the
+before/after verdict in one page load.
+
+- **Fix branch:**
+  <https://github.com/JamBalaya56562/hypothesis/tree/fix-decimals-places-bounds>
+  (monorepo — the installable Python package lives under
+  `hypothesis-python/`, declared via `source.subdirectory` in
+  `fix-candidate.json`).
+- **What the page shows:**
+  - top right pane (`#output`) — baseline run against PyPI
+    `hypothesis==6.152.7`. Expected `bound_violated: true`.
+  - bottom right pane (`#output-fix`) — fix-candidate run against
+    the wheel built from the branch. Expected `bound_violated: false`.
+  - top-level `#verdict` pill mirrors the baseline so the existing
+    single-verdict Contract v1 surface keeps its prior meaning.
+
+### Local in-browser
+
+```bash
+mise run repro:build:wheels                      # build wheel into src/layer1_wasm/hypothesis-4651/wheels/
+cd src/layer1_wasm
+bun install --frozen-lockfile
+bun run build
+python -m http.server -d . 8767
+# open http://localhost:8767/hypothesis-4651/
+```
+
+### Local native (two-variant)
+
+```bash
+mise exec uv -- uv run src/layer1_wasm/hypothesis-4651/verify_fix.py
+# stdout: JSON envelope with both verdicts side-by-side
+# exit 0 + "verdict=fix-candidate-confirmed" if baseline=reproduced AND fix-candidate=unreproduced
+```
+
+### When the fix lands upstream
+
+Once an upstream-merged hypothesis release lands on PyPI:
+
+1. Bump the `hypothesis==<version>` pin in `repro.py` and `repro.ts`.
+2. Delete `fix-candidate.json`, `verify_fix.py`, and the `wheels/`
+   directory.
+3. Restore `index.html` to a single-output pane (`<pre id="output">`)
+   and drop the `outputFixEl` branch from `repro.ts`.
+
+The page becomes a plain "fixed upstream — verdict flips to
+`unreproduced`" recipe again.
 
 ## Authorship
 

--- a/src/layer1_wasm/hypothesis-4651/fix-candidate.json
+++ b/src/layer1_wasm/hypothesis-4651/fix-candidate.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "package": "hypothesis",
+  "purpose": "fix-candidate verification for HypothesisWorks/hypothesis#4651",
+  "source": {
+    "type": "git",
+    "url": "https://github.com/JamBalaya56562/hypothesis",
+    "ref": "fix-decimals-places-bounds",
+    "subdirectory": "hypothesis-python"
+  },
+  "upstream_pr": ""
+}

--- a/src/layer1_wasm/hypothesis-4651/index.html
+++ b/src/layer1_wasm/hypothesis-4651/index.html
@@ -52,6 +52,14 @@
           digit. The full discussion lives in the GitHub issue
           thread linked below.
         </p>
+        <p>
+          A fix-candidate branch
+          (<code>JamBalaya56562/hypothesis@fix-decimals-places-bounds</code>)
+          is built into a pure-Python wheel under <code>./wheels/</code>
+          and installed into the same Pyodide tab after the baseline
+          run completes, so visitors can compare the before/after
+          verdict in one page load.
+        </p>
       </div>
       <hr class="vh-drawer__divider" />
       <div class="vh-drawer__meta-grid">
@@ -80,6 +88,10 @@
             <a class="vh-chip" href="https://github.com/HypothesisWorks/hypothesis/issues/4651" target="_blank" rel="noreferrer">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
               Upstream issue
+            </a>
+            <a class="vh-chip" href="https://github.com/JamBalaya56562/hypothesis/tree/fix-decimals-places-bounds" target="_blank" rel="noreferrer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><line x1="6" y1="9" x2="6" y2="21"/></svg>
+              Fix candidate branch
             </a>
           </div>
         </div>
@@ -168,9 +180,22 @@
 <span class="line"><span style="color:#E1E4E8">result</span></span></code></pre>
         </section>
 
-        <section class="vh-main__col vh-main__col--output">
-          <h2>Output</h2>
-          <pre id="output">(running)</pre>
+        <section class="vh-main__col vh-main__col--output vh-output-multi">
+          <header class="vh-variant-head" data-variant="baseline">
+            <h2 class="vh-variant-head__title">Baseline output</h2>
+          </header>
+          <div class="vh-variant-stage" data-variant="baseline">
+            <!-- chrome.js inserts <div class="vh-progress"> before #output;
+                 the stage stacks both children in one grid cell so the
+                 overlay covers the pre during loading without taking
+                 extra column height. -->
+            <pre id="output" class="vh-variant-output">(pending)</pre>
+          </div>
+
+          <header class="vh-variant-head vh-variant-head--secondary" data-variant="fix-candidate">
+            <h2 class="vh-variant-head__title">Fix-candidate output</h2>
+          </header>
+          <pre id="output-fix" class="vh-variant-output">(waiting for baseline)</pre>
         </section>
       </div>
 

--- a/src/layer1_wasm/hypothesis-4651/repro.ts
+++ b/src/layer1_wasm/hypothesis-4651/repro.ts
@@ -11,9 +11,14 @@
 // loses almost all the coefficient's significant digits, so the
 // final quantised Decimal can land far outside the declared range.
 //
-// Verdict semantics (per ADR-0008 / contract v1):
-//   - "reproduced" — a Hypothesis search or a manual `strategy.example()`
-//     sweep produced at least one `Decimal` outside `[MIN, MAX]`.
+// Verdict semantics (per ADR-0008 / contract v1) — applied to each
+// variant card individually; the top-level `#verdict` pill mirrors
+// the **baseline** variant so the existing Contract v1 single-verdict
+// surface (`__VIVARIUM_VERDICT__`, `data-verdict`) keeps its prior
+// meaning and downstream consumers do not need to branch.
+//   - "reproduced" — a Hypothesis search or a manual
+//     `strategy.example()` sweep produced at least one `Decimal`
+//     outside `[MIN, MAX]`.
 //   - "unreproduced" — both signal paths returned empty (the strategy
 //     respected its declared bounds on every sample), or the runtime
 //     errored before producing a result.
@@ -21,7 +26,10 @@
 // hypothesis is **not** in Pyodide's bundled package set, so we install
 // it via `micropip` after the Pyodide bootstrap. hypothesis is pure
 // Python and pulls in `attrs` + `sortedcontainers` as transitive
-// dependencies — all single pure-Python wheels from PyPI.
+// dependencies — all single pure-Python wheels from PyPI. The
+// fix-candidate this page renders side-by-side is a pure-Python wheel
+// under `./wheels/` built from the fork+branch
+// `JamBalaya56562/hypothesis@fix-decimals-places-bounds`.
 
 import { loadVivariumPyodide } from '../_shared/loader.js';
 import type { PathACapturedRun } from '../_shared/path_a.js';
@@ -127,13 +135,31 @@ interface PyodideRuntime {
   }>;
 }
 
-const outputEl = document.getElementById('output');
+interface WheelManifest {
+  schema_version: number;
+  package: string;
+  filename: string;
+  version: string;
+  source: {
+    type: string;
+    url: string;
+    ref: string;
+    commit?: string;
+    spec?: string;
+    subdirectory?: string;
+  };
+  upstream_pr?: string;
+  fetched_at?: string;
+}
+
+const outputBaselineEl = document.getElementById('output');
+const outputFixEl = document.getElementById('output-fix');
 const metaEl = document.getElementById('meta');
 const reproCodeEl = document.getElementById('repro-code');
 
-if (!outputEl || !metaEl || !reproCodeEl) {
+if (!outputBaselineEl || !outputFixEl || !metaEl || !reproCodeEl) {
   throw new Error(
-    'hypothesis-4651: missing required DOM elements (#output, #meta, #repro-code).',
+    'hypothesis-4651: missing required DOM elements (#output, #output-fix, #meta, #repro-code).',
   );
 }
 
@@ -165,14 +191,33 @@ function evaluate(result: ReproOutput): {
   };
 }
 
+// Pyodide maps Python `None` to JS `undefined`, and `JSON.stringify`
+// strips `undefined`-valued keys. Normalising here keeps both panels
+// comparable at a glance (matches the astroid-2993 pattern).
+function normalize(result: ReproOutput): ReproOutput {
+  return {
+    hypothesis_version: result.hypothesis_version,
+    python_version: result.python_version,
+    min_value: result.min_value,
+    max_value: result.max_value,
+    places: result.places,
+    hypothesis_falsifying: result.hypothesis_falsifying ?? null,
+    hypothesis_crash: result.hypothesis_crash ?? null,
+    manual_violations: result.manual_violations ?? [],
+    manual_crash: result.manual_crash ?? null,
+    bound_violated: result.bound_violated,
+  };
+}
+
 async function captureRun(
   runtime: PyodideRuntime,
   source: string,
 ): Promise<PathACapturedRun> {
   try {
     const proxy = await runtime.runPythonAsync(source);
-    const result = proxy.toJs({ dict_converter: Object.fromEntries });
+    const raw = proxy.toJs({ dict_converter: Object.fromEntries });
     proxy.destroy?.();
+    const result = normalize(raw);
     const ev = evaluate(result);
     return {
       exitCode: 0,
@@ -191,70 +236,207 @@ async function captureRun(
   }
 }
 
+// Drop the in-memory hypothesis module tree so the next `import
+// hypothesis` resolves the freshly-installed wheel rather than the
+// previously-loaded version. Pyodide caches imports in `sys.modules`;
+// `del` is the only reliable way to force a re-resolution after
+// `micropip.uninstall`.
+async function reinstallHypothesis(
+  runtime: PyodideRuntime,
+  installSpec: string,
+): Promise<void> {
+  await runtime.runPythonAsync(`
+import micropip, sys
+try:
+    await micropip.uninstall("hypothesis")
+except Exception:
+    pass
+for _name in [n for n in list(sys.modules) if n == "hypothesis" or n.startswith("hypothesis.")]:
+    del sys.modules[_name]
+await micropip.install(${JSON.stringify(installSpec)})
+`);
+}
+
 const startedAt = new Date();
+
+let baselineCapture: PathACapturedRun | null = null;
+let baselineParsed: ReproOutput | null = null;
+let fixCapture: PathACapturedRun | null = null;
+let fixParsed: ReproOutput | null = null;
+let manifest: WheelManifest | null = null;
 
 try {
   const { pyodide, version } = await loadVivariumPyodide({
     packages: ['micropip'],
     pendingText: 'Loading Pyodide runtime and micropip…',
   });
-
-  setVerdict('pending', 'Installing hypothesis from PyPI…');
   const runtime = pyodide as PyodideRuntime;
+
+  // Baseline variant: PyPI hypothesis==6.152.7.
+  setVerdict('pending', 'Installing hypothesis==6.152.7 from PyPI…');
   await runtime.runPythonAsync(`
 import micropip
 await micropip.install("hypothesis==6.152.7")
 `);
 
-  setVerdict('pending', 'Running reproduction script…');
-  const baseline = await captureRun(runtime, REPRO_CODE);
-
-  let baselineResult: ReproOutput | null = null;
+  setVerdict('pending', 'Running reproduction script (baseline)…');
+  baselineCapture = await captureRun(runtime, REPRO_CODE);
   try {
-    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
+    baselineParsed = JSON.parse(baselineCapture.stdout) as ReproOutput;
   } catch {
-    outputEl.textContent = baseline.stdout;
-    setVerdict(baseline.verdict, baseline.message);
-    throw new Error(baseline.message);
+    baselineParsed = null;
   }
+  outputBaselineEl.textContent = baselineCapture.stdout;
+
+  // Build the Contract v1 envelope as a closure that reflects whatever
+  // variant data is currently captured. Called once after baseline (so
+  // `__VIVARIUM_RESULT__` is populated by the time the top-level
+  // `#verdict` pill flips to "reproduced" — Playwright reads the
+  // envelope at that moment and would otherwise see `undefined`), and
+  // again after the fix-candidate run completes so the envelope picks
+  // up the second variant.
+  const buildEnvelope = (): VivariumResultV1 | null => {
+    if (!baselineParsed || !baselineCapture) return null;
+    const finishedAt = new Date();
+    return {
+      contract: 'v1',
+      bug: {
+        project: 'hypothesis',
+        issue: 4651,
+        upstream_url:
+          'https://github.com/HypothesisWorks/hypothesis/issues/4651',
+      },
+      runtime: {
+        name: 'pyodide',
+        version,
+        extras: {
+          python: baselineParsed.python_version,
+          hypothesis: baselineParsed.hypothesis_version,
+          ...(fixParsed
+            ? { hypothesis_fix_candidate: fixParsed.hypothesis_version }
+            : {}),
+        },
+      },
+      result: {
+        min_value: baselineParsed.min_value,
+        max_value: baselineParsed.max_value,
+        places: baselineParsed.places,
+        hypothesis_falsifying: baselineParsed.hypothesis_falsifying,
+        manual_violation_count: baselineParsed.manual_violations.length,
+        bound_violated: baselineParsed.bound_violated,
+        baseline: {
+          spec: 'hypothesis==6.152.7',
+          verdict: baselineCapture.verdict,
+          hypothesis_version: baselineParsed.hypothesis_version,
+          hypothesis_falsifying: baselineParsed.hypothesis_falsifying,
+          manual_violation_count: baselineParsed.manual_violations.length,
+          bound_violated: baselineParsed.bound_violated,
+        },
+        fix_candidate:
+          fixParsed && fixCapture && manifest
+            ? {
+                spec:
+                  manifest.source.spec ??
+                  `hypothesis @ git+${manifest.source.url}@${manifest.source.ref}` +
+                    (manifest.source.subdirectory
+                      ? `#subdirectory=${manifest.source.subdirectory}`
+                      : ''),
+                verdict: fixCapture.verdict,
+                hypothesis_version: fixParsed.hypothesis_version,
+                hypothesis_falsifying: fixParsed.hypothesis_falsifying,
+                manual_violation_count: fixParsed.manual_violations.length,
+                bound_violated: fixParsed.bound_violated,
+                upstream_pr: manifest.upstream_pr || null,
+              }
+            : null,
+      },
+      timing: {
+        started_at: startedAt.toISOString(),
+        finished_at: finishedAt.toISOString(),
+        duration_ms: finishedAt.getTime() - startedAt.getTime(),
+      },
+    };
+  };
+
+  // Publish the baseline-only envelope BEFORE flipping the verdict
+  // pill — Playwright's regression suite reads `__VIVARIUM_RESULT__`
+  // the moment `data-verdict` leaves `pending`.
+  const initialEnvelope = buildEnvelope();
+  if (initialEnvelope) setResult(initialEnvelope);
+
+  // Top-level verdict pill mirrors baseline — preserves the
+  // single-verdict Contract v1 surface for downstream consumers.
+  setVerdict(baselineCapture.verdict, baselineCapture.message);
 
   metaEl.textContent =
-    `hypothesis ${baselineResult.hypothesis_version} on Python ${baselineResult.python_version} ` +
-    `via Pyodide v${version}.`;
-  outputEl.textContent = baseline.stdout;
-  setVerdict(baseline.verdict, baseline.message);
+    `Baseline hypothesis ${baselineParsed?.hypothesis_version ?? '?'} on Python ` +
+    `${baselineParsed?.python_version ?? '?'} via Pyodide v${version}.`;
 
-  const finishedAt = new Date();
-  const envelope: VivariumResultV1 = {
-    contract: 'v1',
-    bug: {
-      project: 'hypothesis',
-      issue: 4651,
-      upstream_url: 'https://github.com/HypothesisWorks/hypothesis/issues/4651',
-    },
-    runtime: {
-      name: 'pyodide',
-      version,
-      extras: {
-        python: baselineResult.python_version,
-        hypothesis: baselineResult.hypothesis_version,
-      },
-    },
-    result: {
-      min_value: baselineResult.min_value,
-      max_value: baselineResult.max_value,
-      places: baselineResult.places,
-      hypothesis_falsifying: baselineResult.hypothesis_falsifying,
-      manual_violation_count: baselineResult.manual_violations.length,
-      bound_violated: baselineResult.bound_violated,
-    },
-    timing: {
-      started_at: startedAt.toISOString(),
-      finished_at: finishedAt.toISOString(),
-      duration_ms: finishedAt.getTime() - startedAt.getTime(),
-    },
-  };
-  setResult(envelope);
+  // Fix-candidate variant: committed wheel.
+  outputFixEl.textContent = 'Fetching wheel manifest…';
+  let manifestRes: Response | null = null;
+  try {
+    manifestRes = await fetch('./wheels/manifest.json', { cache: 'no-store' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    outputFixEl.textContent = `Could not fetch wheel manifest: ${message}`;
+  }
+
+  if (manifestRes && manifestRes.ok) {
+    manifest = (await manifestRes.json()) as WheelManifest;
+    const wheelUrl = new URL(
+      `./wheels/${manifest.filename}`,
+      window.location.href,
+    ).toString();
+    outputFixEl.textContent =
+      `Installing ${manifest.filename} (${manifest.version})…\n` +
+      `from ${manifest.source.url}@${manifest.source.ref}` +
+      (manifest.source.subdirectory
+        ? ` (subdir: ${manifest.source.subdirectory})`
+        : '');
+    try {
+      await reinstallHypothesis(runtime, wheelUrl);
+      fixCapture = await captureRun(runtime, REPRO_CODE);
+      try {
+        fixParsed = JSON.parse(fixCapture.stdout) as ReproOutput;
+      } catch {
+        fixParsed = null;
+      }
+      outputFixEl.textContent = fixCapture.stdout;
+    } catch (err) {
+      const errAny = err as { stack?: string; message?: string } | null;
+      const message =
+        (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
+      outputFixEl.textContent = `Fix-candidate install/run failed: ${message}`;
+    }
+  } else if (manifestRes && !manifestRes.ok) {
+    outputFixEl.textContent = `Wheel manifest unavailable (HTTP ${manifestRes.status}).`;
+  }
+
+  // Restore baseline hypothesis so the visitor-facing runner (Edit +
+  // Run) operates against the buggy build — the runner's documented
+  // mental model is "test your script change against the same broken
+  // interpreter the recipe loaded". Without this, runner.runFix would
+  // execute against the fix-candidate hypothesis, which is
+  // semantically surprising for visitors paste-editing the script.
+  try {
+    await reinstallHypothesis(runtime, 'hypothesis==6.152.7');
+  } catch {
+    console.warn(
+      'hypothesis-4651: failed to restore baseline for the runner; runner.runFix will run against the fix-candidate.',
+    );
+  }
+
+  // ---- Contract v1 envelope (final) ---------------------------------
+  // Re-publish the envelope now that the fix-candidate variant has
+  // also captured (or definitively failed). `result` keeps the
+  // historical baseline-only fields so consumers reading
+  // `__VIVARIUM_RESULT__.result.bound_violated` continue to work,
+  // and the additive `baseline` / `fix_candidate` sub-objects
+  // describe each variant separately. Additive change — no
+  // `contract` version bump.
+  const finalEnvelope = buildEnvelope();
+  if (finalEnvelope) setResult(finalEnvelope);
 
   enableRunner({
     slug: 'hypothesis-4651',
@@ -264,7 +446,7 @@ await micropip.install("hypothesis==6.152.7")
 } catch (err: unknown) {
   console.error(err);
   const errAny = err as { stack?: string; message?: string } | null;
-  outputEl.textContent =
+  outputBaselineEl.textContent =
     (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
   if (globalThis.__VIVARIUM_VERDICT__ !== 'unreproduced') {
     setVerdict(

--- a/src/layer1_wasm/hypothesis-4651/verify_fix.py
+++ b/src/layer1_wasm/hypothesis-4651/verify_fix.py
@@ -1,0 +1,225 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = []
+# ///
+"""Vivarium Layer 1 — hypothesis#4651 fix-candidate verification (native).
+
+Sibling of `repro.py`. Where `repro.py` runs the reproduction against
+**one** hypothesis build (the canonical bug-still-present pin), this
+orchestrator runs it against **two** builds in side-by-side ephemeral
+venvs:
+
+1. ``baseline`` — ``hypothesis==6.152.7`` from PyPI (the build under
+   which the bug was confirmed; should still ``reproduced``).
+2. ``fix-candidate`` — the fork+branch carrying the proposed fix
+   (currently
+   ``JamBalaya56562/hypothesis@fix-decimals-places-bounds`` with the
+   installable package under ``hypothesis-python/``); should flip to
+   ``unreproduced`` by keeping every ``st.decimals(places=…)`` sample
+   inside the declared bounds.
+
+The output is a single JSON envelope on stdout listing both verdicts,
+so a maintainer can see the **before / after** of the candidate fix
+in one invocation. The exit code is ``0`` iff every variant matches
+its expected verdict (baseline reproduces AND fix-candidate does not);
+anything else is treated as a regression.
+
+This script does **not** ship a Vivarium Contract v1 surface — it is a
+maintainer convenience tool. The canonical Contract v1 verdict for
+this recipe is the live one published by ``index.html`` (and mirrored
+by ``repro.py`` for native runs against a single build). Once an
+upstream-merged release lands on PyPI, bump the pin in ``repro.py`` /
+``repro.ts`` and delete this script.
+
+Run:
+
+    mise install                                                          # one-time
+    mise exec uv -- uv run src/layer1_wasm/hypothesis-4651/verify_fix.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from datetime import datetime, timezone
+
+VARIANTS: list[dict[str, str]] = [
+    {
+        "name": "baseline",
+        "label": "PyPI hypothesis==6.152.7 (pre-fix)",
+        "spec": "hypothesis==6.152.7",
+        "expected": "reproduced",
+    },
+    {
+        "name": "fix-candidate",
+        "label": "JamBalaya56562/hypothesis@fix-decimals-places-bounds",
+        "spec": (
+            "hypothesis @ git+https://github.com/JamBalaya56562/hypothesis"
+            "@fix-decimals-places-bounds"
+            "#subdirectory=hypothesis-python"
+        ),
+        "expected": "unreproduced",
+    },
+]
+
+# Per-variant probe; runs in a uv-managed ephemeral venv that has the
+# variant's hypothesis spec installed. Mirrors repro.py's bound-check
+# logic so the per-variant verdicts are directly comparable.
+PROBE = textwrap.dedent(
+    """
+    import json, sys
+    from decimal import Decimal
+    import hypothesis
+    from hypothesis import HealthCheck, given, settings
+    from hypothesis import strategies as st
+
+    MIN_ = Decimal("0." + "0" * 63 + "1")
+    MAX_ = Decimal("9" * 64 + "." + "9" * 64)
+    PLACES = 2
+
+    result = {
+        "hypothesis_version": hypothesis.__version__,
+        "python_version": sys.version.split()[0],
+        "min_value": str(MIN_),
+        "max_value": str(MAX_),
+        "places": PLACES,
+        "hypothesis_falsifying": None,
+        "hypothesis_crash": None,
+        "manual_violations": [],
+        "manual_crash": None,
+        "bound_violated": False,
+    }
+
+    state = {"falsifying": None}
+
+    @given(st.decimals(min_value=MIN_, max_value=MAX_, places=PLACES))
+    @settings(
+        max_examples=300,
+        deadline=None,
+        derandomize=True,
+        database=None,
+        suppress_health_check=list(HealthCheck),
+    )
+    def prop(d):
+        if not (MIN_ <= d <= MAX_):
+            if state["falsifying"] is None:
+                state["falsifying"] = str(d)[:200]
+            raise AssertionError(str(d)[:120])
+
+    try:
+        prop()
+    except AssertionError:
+        pass
+    except Exception as e:
+        result["hypothesis_crash"] = f"{type(e).__name__}: {str(e)[:200]}"
+
+    result["hypothesis_falsifying"] = state["falsifying"]
+
+    strat = st.decimals(min_value=MIN_, max_value=MAX_, places=PLACES)
+    try:
+        for _ in range(500):
+            try:
+                v = strat.example()
+            except Exception:
+                continue
+            if not (MIN_ <= v <= MAX_):
+                result["manual_violations"].append(str(v)[:200])
+                if len(result["manual_violations"]) >= 3:
+                    break
+    except Exception as e:
+        result["manual_crash"] = f"{type(e).__name__}: {str(e)[:200]}"
+
+    result["bound_violated"] = bool(result["hypothesis_falsifying"]) or bool(
+        result["manual_violations"]
+    )
+
+    print(json.dumps(result))
+    """
+).strip()
+
+
+def run_variant(variant: dict[str, str]) -> dict[str, object]:
+    print(f"\n--- {variant['name']} :: {variant['label']} ---", file=sys.stderr)
+    proc = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--no-project",
+            "--with",
+            variant["spec"],
+            "python",
+            "-c",
+            PROBE,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    record: dict[str, object] = {
+        "name": variant["name"],
+        "label": variant["label"],
+        "spec": variant["spec"],
+        "expected": variant["expected"],
+    }
+    stdout = proc.stdout.strip()
+    if proc.returncode != 0 and not stdout:
+        record["error"] = (
+            f"uv run exited {proc.returncode}; "
+            f"stderr tail: {proc.stderr[-400:]!r}"
+        )
+        record["verdict"] = "unreproduced"
+        return record
+    try:
+        result = json.loads(stdout.splitlines()[-1])
+    except (ValueError, IndexError):
+        record["error"] = f"probe stdout was not JSON; stdout tail: {stdout[-400:]!r}"
+        record["verdict"] = "unreproduced"
+        return record
+    record.update(result)
+    record["verdict"] = "reproduced" if result["bound_violated"] else "unreproduced"
+    return record
+
+
+def main() -> int:
+    started_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    variants = [run_variant(v) for v in VARIANTS]
+    finished_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    envelope = {
+        "tool": "vivarium-hypothesis-4651-fix-verification",
+        "schema_version": "internal-1",
+        "bug": {
+            "project": "hypothesis",
+            "issue": 4651,
+            "upstream_url": "https://github.com/HypothesisWorks/hypothesis/issues/4651",
+        },
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "variants": variants,
+    }
+    print(json.dumps(envelope, indent=2))
+
+    mismatches = [v for v in variants if v["verdict"] != v["expected"]]
+    if mismatches:
+        print(
+            "\nverdict=mismatch — variants did not match expected verdicts: "
+            + ", ".join(
+                f"{v['name']} expected={v['expected']} got={v['verdict']}"
+                for v in mismatches
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "\nverdict=fix-candidate-confirmed — baseline still reproduces and "
+        "the fix candidate keeps st.decimals(places=…) inside the declared bounds.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION

Render JamBalaya56562/hypothesis@fix-decimals-places-bounds (proposed
fix for HypothesisWorks/hypothesis#4651) side-by-side with the
PyPI baseline (hypothesis==6.152.7) on the same recipe page, so a
reviewer can see the before/after verdict in one page load — same
pattern astroid-2993 already uses.

New files:
- src/layer1_wasm/hypothesis-4651/fix-candidate.json — single source
  of truth for the fix branch (fork URL + ref +
  source.subdirectory: "hypothesis-python" because the installable
  Python package lives in that monorepo subdir). Read by
  scripts/build-layer1-wheels.sh.
- src/layer1_wasm/hypothesis-4651/verify_fix.py — PEP 723 native
  orchestrator that runs both variants in side-by-side ephemeral
  uv venvs; exit 0 iff baseline reproduces AND fix-candidate does
  not.

Modified:
- scripts/build-layer1-wheels.sh — read optional
  source.subdirectory and append PEP 508 #subdirectory=<dir> to
  the VCS spec, so monorepos (Hypothesis, future Django/pytest,
  etc.) build correctly. Empty string keeps the repo-root behaviour
  used by astroid-2993.
- src/layer1_wasm/hypothesis-4651/index.html — replace the single
  output pane with a vh-output-multi 2-variant block
  (baseline + fix-candidate), add a "Fix candidate branch" header
  chip, extend drawer copy.
- src/layer1_wasm/hypothesis-4651/repro.ts — drive the 2-variant
  run: PyPI baseline install + capture, reinstallHypothesis()
  helper (micropip uninstall + sys.modules purge + install wheel),
  fix-candidate capture, then restore baseline for the Runner.
  Contract v1 envelope grows additive result.baseline /
  result.fix_candidate sub-objects; existing flat fields are kept
  for backward compatibility.
- src/layer1_wasm/hypothesis-4651/README.md — Files table now lists
  the fix-candidate machinery; add a "Fix-candidate verification"
  section with in-browser + native two-variant workflows and the
  cleanup steps for when the fix lands upstream.

Verified end-to-end (2026-05-16):
- mise run repro:build:wheels builds
  hypothesis-6.152.7-py3-none-any.whl at commit 34a3f9e0.
- verify_fix.py returns exit 0 + verdict=fix-candidate-confirmed
  (baseline bound_violated:true with falsifying example 10^64,
  fix-candidate bound_violated:false, manual_violations 0).
- Browser render under Pyodide 0.29.3 matches: baseline pane shows
  reproduced, fix-candidate pane shows unreproduced.
