### PR TITLE
fix(repro): inject favicons via chrome.js on reproduction pages

### DIFF
--- a/src/layer1_wasm/_assets/chrome.js
+++ b/src/layer1_wasm/_assets/chrome.js
@@ -6,6 +6,27 @@
 // Plain JS (no TypeScript build) so Layer 2 — which has no tsc step —
 // can also import it without a compile dance.
 
+// ── Favicon injection ───────────────────────────────────────────────────
+// Mirrors the rspress docs site config (docs/rspress.config.ts head[]).
+// Repro pages don't go through rspress, so we attach the same icons here
+// once per page load. Absolute /vivarium/ paths because SITE_BASE is
+// fixed at /vivarium/ (docs/scripts/site-paths.ts) and repro URLs nest
+// two levels deep (/vivarium/repro/<project>/<issue>/), so absolute
+// paths sidestep brittle relative-path arithmetic.
+(function injectFavicons() {
+  const icons = [
+    { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/vivarium/favicon-32x32.png' },
+    { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/vivarium/favicon-16x16.png' },
+    { rel: 'icon', type: 'image/png', sizes: '192x192', href: '/vivarium/icon-192.png' },
+    { rel: 'apple-touch-icon', sizes: '180x180', href: '/vivarium/apple-touch-icon.png' },
+  ];
+  for (const spec of icons) {
+    const link = document.createElement('link');
+    for (const [k, v] of Object.entries(spec)) link.setAttribute(k, v);
+    document.head.appendChild(link);
+  }
+})();
+
 const THEME_KEY = 'rspress-theme-appearance';
 
 // ── Theme helpers ────────────────────────────────────────────────────────

--- a/src/layer1_wasm/_assets/chrome.js
+++ b/src/layer1_wasm/_assets/chrome.js
@@ -21,6 +21,9 @@
     { rel: 'apple-touch-icon', sizes: '180x180', href: '/vivarium/apple-touch-icon.png' },
   ];
   for (const spec of icons) {
+    // Skip if an equivalent link already exists (e.g. a future template
+    // adds a static <link> for the same rel+sizes pair).
+    if (document.head.querySelector(`link[rel="${spec.rel}"][sizes="${spec.sizes}"]`)) continue;
     const link = document.createElement('link');
     for (const [k, v] of Object.entries(spec)) link.setAttribute(k, v);
     document.head.appendChild(link);

--- a/src/layer2_docker/_assets/chrome.js
+++ b/src/layer2_docker/_assets/chrome.js
@@ -6,6 +6,27 @@
 // Plain JS (no TypeScript build) so Layer 2 — which has no tsc step —
 // can also import it without a compile dance.
 
+// ── Favicon injection ───────────────────────────────────────────────────
+// Mirrors the rspress docs site config (docs/rspress.config.ts head[]).
+// Repro pages don't go through rspress, so we attach the same icons here
+// once per page load. Absolute /vivarium/ paths because SITE_BASE is
+// fixed at /vivarium/ (docs/scripts/site-paths.ts) and repro URLs nest
+// two levels deep (/vivarium/repro/<project>/<issue>/), so absolute
+// paths sidestep brittle relative-path arithmetic.
+(function injectFavicons() {
+  const icons = [
+    { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/vivarium/favicon-32x32.png' },
+    { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/vivarium/favicon-16x16.png' },
+    { rel: 'icon', type: 'image/png', sizes: '192x192', href: '/vivarium/icon-192.png' },
+    { rel: 'apple-touch-icon', sizes: '180x180', href: '/vivarium/apple-touch-icon.png' },
+  ];
+  for (const spec of icons) {
+    const link = document.createElement('link');
+    for (const [k, v] of Object.entries(spec)) link.setAttribute(k, v);
+    document.head.appendChild(link);
+  }
+})();
+
 const THEME_KEY = 'rspress-theme-appearance';
 
 // ── Theme helpers ────────────────────────────────────────────────────────

--- a/src/layer2_docker/_assets/chrome.js
+++ b/src/layer2_docker/_assets/chrome.js
@@ -21,6 +21,9 @@
     { rel: 'apple-touch-icon', sizes: '180x180', href: '/vivarium/apple-touch-icon.png' },
   ];
   for (const spec of icons) {
+    // Skip if an equivalent link already exists (e.g. a future template
+    // adds a static <link> for the same rel+sizes pair).
+    if (document.head.querySelector(`link[rel="${spec.rel}"][sizes="${spec.sizes}"]`)) continue;
     const link = document.createElement('link');
     for (const [k, v] of Object.entries(spec)) link.setAttribute(k, v);
     document.head.appendChild(link);


### PR DESCRIPTION
## Summary

- Reproduction pages (`/vivarium/repro/<project>/<issue>/`) had no `<link rel=\"icon\">` markup, so browser tabs fell back to the default icon while the rspress docs site at the same origin already renders the Vivarium favicon.
- Inject the same four icons from rspress.config.ts via the shared `_assets/chrome.js` (Layer 1 + Layer 2), so every existing recipe and any future one gets favicons automatically — no per-page template change required.
- Defensive guard added per Sourcery review: skip injection when a `<link rel=\"icon\" sizes=\"…\">` with the same rel+sizes pair already exists in `<head>`, so a future static template won't end up with duplicates.

## Review focus

- [ ] Absolute `/vivarium/...` paths are the right call vs. relative — repro URLs nest two levels deep (`/vivarium/repro/<project>/<issue>/`) and `SITE_BASE` is fixed at `/vivarium/` in [docs/scripts/site-paths.ts](docs/scripts/site-paths.ts), so relative-path arithmetic would be brittle.
- [ ] Same four icons (32x32 / 16x16 / 192x192 / apple-touch 180x180) match what [docs/rspress.config.ts](docs/rspress.config.ts) declares — no drift.
- [ ] The dedupe guard (`link[rel=\"...\"][sizes=\"...\"]`) won't false-positive against existing chrome.js-injected links because the IIFE runs once per page load.

## Process notes

- AI-authored, `ai: generated` label will be applied.
- Scope: limited to favicon injection in the two `_assets/chrome.js` files. No template-level HTML edits, no docs changes.