### PR TITLE
docs: data-drive recipe-slug references and pin hero exemplars

### DIFF
--- a/.claude/rules/recipe-authoring.md
+++ b/.claude/rules/recipe-authoring.md
@@ -58,6 +58,22 @@ docs/site/_data/recipe-facets.json   ← add a row keyed by <slug>
 docs/site/_data/projects.json        ← add a row keyed by <project> (only if new)
 ```
 
+Before **deleting** a recipe, also check the landing-page hero for a
+pinned reference:
+
+```bash
+grep -F "<slug>" docs/site/_components/VivariumHero.tsx
+```
+
+If the slug appears, it is intentionally pinned to the hero and is
+paired with hand-written copy (`title` / `lede` / `verdictText` /
+`pulling` / `ready` / `okLine`) that the recipe metadata cannot
+supply. Pick a same-layer replacement and rewrite the matching
+`STRINGS` block in **both** `en` and `ja` before the deletion lands.
+Visitor-facing MDX references go through the data-driven
+[`LiveExamples`](../../docs/site/_components/LiveExamples.tsx)
+component and self-heal — only the hero needs manual handover.
+
 Then regenerate every derived artefact in one shot:
 
 ```bash

--- a/docs/site/_components/LiveExamples.tsx
+++ b/docs/site/_components/LiveExamples.tsx
@@ -1,0 +1,189 @@
+// Data-driven recipe references for visitor-facing docs.
+//
+// Reads `docs/site/public/api/recipes.json` at build time (same import
+// pattern as RecipeGallery) and resolves slug references against the
+// current catalogue, so deleting a recipe under `src/layer*_*/` no
+// longer requires a parallel docs sweep. See ADR-0035-equivalent
+// rationale in PR #235 (generator → MDX-consumer pattern).
+//
+// The hero (`VivariumHero.tsx`) is the deliberate exception — its
+// three slugs are paired with hand-written copy that can't be derived
+// here, and are pinned with a header comment + checklist entry.
+
+import recipesIndex from '../public/api/recipes.json';
+
+interface RecipeEntry {
+  slug: string;
+  layer: 1 | 2 | 3;
+  project: string;
+  issue: number;
+  title: string;
+  page_url: string;
+  source_url: string;
+  verdict_url?: string;
+  language: string;
+  symptom?: string;
+  severity?: string;
+  tags: string[];
+}
+
+interface RecipesIndex {
+  index: 'v1';
+  contract: 'v1';
+  recipes: RecipeEntry[];
+}
+
+const INDEX = recipesIndex as RecipesIndex;
+
+type Lang = 'en' | 'ja';
+
+// Mirror RecipeGallery's localizeRecipeUrl: when the docs are served
+// from a non-production origin (rspress dev, a fork's Pages deploy),
+// rewrite the recipe's baked-in absolute URL to the current origin so
+// in-page links stay clickable.
+function localizeRecipeUrl(url: string): string {
+  if (typeof window === 'undefined') return url;
+  try {
+    const u = new URL(url);
+    return window.location.origin + u.pathname + u.search + u.hash;
+  } catch {
+    return url;
+  }
+}
+
+interface SelectFilters {
+  layer: 1 | 2 | 3;
+  language?: string;
+  project?: string;
+  kind?: 'numeric' | 'descriptive';
+}
+
+function selectRecipes(filters: SelectFilters): RecipeEntry[] {
+  return INDEX.recipes
+    .filter((r) => r.layer === filters.layer)
+    .filter((r) => !filters.language || r.language === filters.language)
+    .filter((r) => !filters.project || r.project === filters.project)
+    .filter((r) => {
+      if (filters.kind === 'numeric') return r.issue > 0;
+      if (filters.kind === 'descriptive') return r.issue === 0;
+      return true;
+    })
+    .slice()
+    .sort((a, b) => {
+      if (b.issue !== a.issue) return b.issue - a.issue;
+      return a.slug.localeCompare(b.slug);
+    });
+}
+
+const SEPARATORS: Record<Lang, { and: string; comma: string }> = {
+  en: { and: ' and ', comma: ', ' },
+  ja: { and: 'や', comma: '、' },
+};
+
+const EMPTY_FALLBACK: Record<Lang, React.ReactNode> = {
+  en: (
+    <em>
+      (no live example yet — see <a href="/vivarium/repro/">the gallery</a>)
+    </em>
+  ),
+  ja: (
+    <em>
+      (該当する live サンプルなし —{' '}
+      <a href="/vivarium/ja/repro/">ギャラリーを参照</a>)
+    </em>
+  ),
+};
+
+interface LiveExamplesProps {
+  layer: 1 | 2 | 3;
+  language?: string;
+  project?: string;
+  kind?: 'numeric' | 'descriptive';
+  limit?: number;
+  format?: 'list' | 'inline-prose';
+  lang?: Lang;
+  fallback?: React.ReactNode;
+}
+
+export function LiveExamples({
+  layer,
+  language,
+  project,
+  kind,
+  limit,
+  format = 'list',
+  lang = 'en',
+  fallback,
+}: LiveExamplesProps) {
+  const matches = selectRecipes({ layer, language, project, kind });
+  const picked = typeof limit === 'number' ? matches.slice(0, limit) : matches;
+
+  if (picked.length === 0) {
+    const f = fallback ?? EMPTY_FALLBACK[lang];
+    if (format === 'inline-prose') return <>{f}</>;
+    return (
+      <ul>
+        <li>{f}</li>
+      </ul>
+    );
+  }
+
+  if (format === 'inline-prose') {
+    const sep = SEPARATORS[lang];
+    return (
+      <>
+        {picked.map((r, i) => (
+          <span key={r.slug}>
+            {i > 0 ? (i === picked.length - 1 ? sep.and : sep.comma) : null}
+            <a href={localizeRecipeUrl(r.page_url)}>
+              {r.project}#{r.issue}
+            </a>
+          </span>
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <ul>
+      {picked.map((r) => (
+        <li key={r.slug}>
+          <a href={localizeRecipeUrl(r.page_url)}>{r.title}</a>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+interface ExampleSlugProps {
+  layer: 1 | 2 | 3;
+  language?: string;
+  project?: string;
+  kind?: 'numeric' | 'descriptive';
+  linked?: boolean;
+  fallback?: string;
+}
+
+export function ExampleSlug({
+  layer,
+  language,
+  project,
+  kind,
+  linked = false,
+  fallback,
+}: ExampleSlugProps) {
+  const matches = selectRecipes({ layer, language, project, kind });
+  const picked = matches[0];
+
+  if (!picked) {
+    const text = fallback ?? `<${language ?? 'project'}-<issue>>`;
+    return <>{text}</>;
+  }
+
+  if (linked) {
+    return <a href={localizeRecipeUrl(picked.page_url)}>{picked.slug}</a>;
+  }
+  return <>{picked.slug}</>;
+}
+
+export default LiveExamples;

--- a/docs/site/_components/VivariumHero.tsx
+++ b/docs/site/_components/VivariumHero.tsx
@@ -2,6 +2,15 @@ import { ArrowRight, Lock } from 'lucide-react';
 import { useState } from 'react';
 import './vivarium-hero.css';
 
+// PINNED SLUGS — intentionally NOT derived from recipes.json.
+// The three slugs below (cpython-137205, postgres-lost-update, ruby-21709)
+// are paired with hand-written hero copy (lede / verdictText / pulling /
+// ready / okLine) that the recipe metadata cannot supply. If one of these
+// recipes must be deleted (e.g. upstream merges or rejects the fix), FIRST
+// pick a same-layer replacement and rewrite the matching STRINGS entry in
+// BOTH en and ja before the deletion lands. See
+// .claude/rules/recipe-authoring.md "Data files to update".
+
 type Lang = 'en' | 'ja';
 
 const STRINGS = {

--- a/docs/site/en/architecture.mdx
+++ b/docs/site/en/architecture.mdx
@@ -12,6 +12,7 @@ import {
   NextCta,
   BottomNote,
 } from '../_components/PageChrome';
+import { LiveExamples } from '../_components/LiveExamples';
 
 <Page>
   <PageHero
@@ -89,7 +90,7 @@ import {
     eyebrow="// 01 · LAYER 1"
     heading="WebAssembly, in the page."
     intro={
-      <p>Reproductions run directly inside your browser tab. No account, no install — open the page and it starts. Phases 0–2 built up Python / Ruby / PHP / Rust recipes like <a href="/vivarium/repro/cpython/137205/">cpython#137205</a> and <a href="/vivarium/repro/pandas/56679/">pandas#56679</a>; this layer is the most "browser-only" surface Vivarium ships.</p>
+      <p>Reproductions run directly inside your browser tab. No account, no install — open the page and it starts. Phases 0–2 built up Python / Ruby / PHP / Rust recipes, e.g. <LiveExamples layer={1} kind="numeric" limit={2} format="inline-prose" lang="en" />; this layer is the most "browser-only" surface Vivarium ships.</p>
     }
     cellLabels={{
       fits: 'Bugs this layer fits',
@@ -122,11 +123,11 @@ import {
     }
     runtimes={
       <ul>
-        <li><strong>Python</strong>: <a href="https://pyodide.org">Pyodide</a> — e.g. <a href="/vivarium/repro/numpy/28287/">numpy#28287</a>, <a href="/vivarium/repro/pandas/56679/">pandas#56679</a>.</li>
-        <li><strong>SQLite</strong>: <a href="https://sqlite.org/wasm/">sqlite-wasm</a> (via Pyodide) — e.g. <a href="/vivarium/repro/cpython/137205/">cpython#137205</a>.</li>
-        <li><strong>Rust</strong>: <code>wasm32-wasip1</code> — e.g. <a href="/vivarium/repro/regex/779/">regex#779</a>.</li>
-        <li><strong>Ruby</strong>: <a href="https://github.com/ruby/ruby.wasm">Ruby.wasm</a> — e.g. <a href="/vivarium/repro/ruby/21709/">ruby#21709</a>.</li>
-        <li><strong>PHP</strong>: <a href="https://github.com/WordPress/wordpress-playground">php-wasm</a> — e.g. <a href="/vivarium/repro/php/12167/">php#12167</a>.</li>
+        <li><strong>Python</strong>: <a href="https://pyodide.org">Pyodide</a> — live: <LiveExamples layer={1} language="python" kind="numeric" limit={2} format="inline-prose" lang="en" /></li>
+        <li><strong>Rust</strong>: <code>wasm32-wasip1</code> — live: <LiveExamples layer={1} language="rust" kind="numeric" limit={1} format="inline-prose" lang="en" /></li>
+        <li><strong>Ruby</strong>: <a href="https://github.com/ruby/ruby.wasm">Ruby.wasm</a> — live: <LiveExamples layer={1} language="ruby" kind="numeric" limit={1} format="inline-prose" lang="en" /></li>
+        <li><strong>PHP</strong>: <a href="https://github.com/WordPress/wordpress-playground">php-wasm</a> — live: <LiveExamples layer={1} language="php" kind="numeric" limit={1} format="inline-prose" lang="en" /></li>
+        <li><strong>SQLite</strong>: <a href="https://sqlite.org/wasm/">sqlite-wasm</a> (via Pyodide) — recipes that hit the sqlite WASM build via Pyodide live under the Python listing above.</li>
       </ul>
     }
   />
@@ -163,14 +164,7 @@ import {
         <li><strong>Concurrency itself.</strong> Layer 2 runs on real threads, but reproducing heisenbugs reliably is Layer 3 territory.</li>
       </ul>
     }
-    runtimes={
-      <ul>
-        <li><a href="/vivarium/repro/postgres/lost-update/">postgres-lost-update</a> — lost updates straddling a transaction boundary.</li>
-        <li><a href="/vivarium/repro/flock/is-advisory/">flock-is-advisory</a> — file locks are advisory, not mandatory.</li>
-        <li><a href="/vivarium/repro/find/xargs-whitespace/">find-xargs-whitespace</a> — whitespace handling across the pipeline boundary.</li>
-        <li><a href="/vivarium/repro/bash/local-shadows-exit/">bash-local-shadows-exit</a> — <code>local</code> shadows the parent shell's <code>$?</code>.</li>
-      </ul>
-    }
+    runtimes={<LiveExamples layer={2} lang="en" />}
   />
 
   <LayerSection

--- a/docs/site/en/guide/compare-branch-fix.mdx
+++ b/docs/site/en/guide/compare-branch-fix.mdx
@@ -12,6 +12,7 @@ import {
   NextCta,
   BottomNote,
 } from '../../_components/PageChrome';
+import { ExampleSlug } from '../../_components/LiveExamples';
 
 <Page>
   <PageHero
@@ -57,7 +58,7 @@ import {
       items={[
         {
           lead: 'I know the recipe.',
-          body: <>Browse <a href="/vivarium/repro/">the gallery</a> and click through to the recipe page. Note the slug (e.g. <code>php-12167</code>).</>,
+          body: <>Browse <a href="/vivarium/repro/">the gallery</a> and click through to the recipe page. Note the slug (e.g. <code><ExampleSlug layer={1} language="php" fallback="<php-slug>" /></code>).</>,
         },
         {
           lead: 'I have an error message — find the recipe for me.',
@@ -71,7 +72,7 @@ import {
     eyebrow="// 2 · PATH A — LAYER 1"
     heading="Paste a fix on the recipe page; capture the verdict."
   >
-    <p>Layer 1 recipes that opt into Path A render a <strong>"Try a fix"</strong> panel underneath the baseline output. Today this is shipped on <a href="/vivarium/repro/php/12167/"><code>php-12167</code></a>; others follow as the shape proves out.</p>
+    <p>Layer 1 recipes that opt into Path A render a <strong>"Try a fix"</strong> panel underneath the baseline output. Today this is shipped on the PHP exemplar (<code><ExampleSlug layer={1} language="php" linked fallback="<php-slug>" /></code>); others follow as the shape proves out.</p>
     <NumberedList
       items={[
         {

--- a/docs/site/en/guide/fork-your-own.mdx
+++ b/docs/site/en/guide/fork-your-own.mdx
@@ -12,6 +12,7 @@ import {
   NextCta,
   BottomNote,
 } from '../../_components/PageChrome';
+import { ExampleSlug } from '../../_components/LiveExamples';
 
 <Page>
   <PageHero
@@ -124,7 +125,7 @@ cd vivarium`}</code></pre>
       <li><code>src/layer1_wasm/&lt;slug&gt;/repro.ts</code> — runs the reproduction in Pyodide / Ruby.wasm / php-wasm / Rust and sets the verdict.</li>
       <li><code>src/layer1_wasm/&lt;slug&gt;/README.md</code> — what the recipe is.</li>
     </ul>
-    <p>The fastest path is to copy an existing recipe like{' '} <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/pandas-56679"><code>pandas-56679</code></a>{' '} or{' '} <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/regex-779"><code>regex-779</code></a>, change the slug (<code>&lt;project&gt;-&lt;issue&gt;</code> is the convention), and rewrite the reproduction script.</p>
+    <p>The fastest path is to copy an existing recipe like{' '} <code><ExampleSlug layer={1} language="python" /></code>{' '} or{' '} <code><ExampleSlug layer={1} language="rust" fallback="<rust-slug>" /></code>, change the slug (<code>&lt;project&gt;-&lt;issue&gt;</code> is the convention), and rewrite the reproduction script.</p>
     <Callout>
       The contract a recipe satisfies is{' '}
       <a href="/vivarium/spec/contract-v1">Contract v1</a>. Emit{' '}

--- a/docs/site/en/guide/getting-started.mdx
+++ b/docs/site/en/guide/getting-started.mdx
@@ -12,6 +12,7 @@ import {
   NextCta,
   BottomNote,
 } from '../../_components/PageChrome';
+import { ExampleSlug } from '../../_components/LiveExamples';
 
 <Page>
   <PageHero
@@ -59,7 +60,7 @@ import {
     eyebrow="// 2 · RUN A RECIPE"
     heading="One click. The browser does the rest."
   >
-    <p>Walk through it once with <code>pandas-56679</code> as the running example. Hitting "Open" on the card pops a new tab at the recipe's page, <a href="/vivarium/repro/pandas/56679/" target="_blank" rel="noreferrer"><code>/repro/pandas/56679/</code></a>.</p>
+    <p>Walk through it once with <code><ExampleSlug layer={1} language="python" linked /></code> as the running example. Hitting "Open" on the card pops a new tab at the recipe's page.</p>
     <p>On load the page fetches Pyodide (CPython compiled to WebAssembly) and pandas from the jsDelivr CDN. The verdict badge sits at{' '} <code>pending</code> with "Loading runtime…" while that happens.</p>
     <p>Once loaded, the embedded reproduction script runs and the verdict settles. First load takes a few to a few-tens of seconds depending on connection and cache state; subsequent visits hit the CDN cache and open in milliseconds to a second.</p>
     <Callout>
@@ -74,7 +75,7 @@ import {
     heading="Three values. reproduced / unreproduced / pending."
   >
     <p><code>reproduced</code> means the upstream bug still reproduces. <code>unreproduced</code> means it does not — typically because a newer runtime build resolved the issue, or because the conditions shifted. <code>pending</code> is the in-flight state while the script is running or the runtime is still loading.</p>
-    <p>Open pandas-56679 and the verdict will settle to{' '} <code>reproduced</code> or <code>unreproduced</code> depending on what version of pandas Pyodide currently ships. Underneath the badge you'll see the data the verdict was decided from — the <code>series_dtype</code> vs <code>df_dtype</code> comparison.</p>
+    <p>Open the recipe and the verdict will settle to{' '} <code>reproduced</code> or <code>unreproduced</code> depending on what version of the upstream library the bundled WASM runtime currently ships. Underneath the badge you'll see the data the verdict was decided from — the recipe-specific values whose comparison <em>is</em> the verdict.</p>
     <Callout>
       Why "reproduced / unreproduced" instead of "pass / fail": pass and
       fail flip meaning between teams. Vivarium pins the verb to one
@@ -88,7 +89,7 @@ import {
     heading="Not just the badge — the basis is on the same page."
   >
     <p>Below the verdict badge sits an "Evidence" section bundling the reproduction script's run: stdout, stderr, exit code, duration in milliseconds. Contract v1 revision 2 makes the basis for a verdict readable on-page rather than buried in a separate file.</p>
-    <p>For pandas-56679, that includes the literal <code>series_dtype</code> and <code>df_dtype</code> strings, the boolean for whether they match, and the running pandas / Python versions — all serialised as JSON. That bundle <em>is</em> the evidence.</p>
+    <p>For a typical Python recipe, that includes the literal values whose mismatch <em>is</em> the bug, the boolean for whether they match, and the running library / interpreter versions — all serialised as JSON. That bundle <em>is</em> the evidence.</p>
   </Section>
 
   <Section

--- a/docs/site/en/guide/write-your-first-reproduction.mdx
+++ b/docs/site/en/guide/write-your-first-reproduction.mdx
@@ -12,6 +12,7 @@ import {
   NextCta,
   BottomNote,
 } from '../../_components/PageChrome';
+import { ExampleSlug } from '../../_components/LiveExamples';
 
 <Page>
   <PageHero
@@ -38,7 +39,7 @@ import {
     eyebrow="// 1 · PICK A BUG"
     heading="Slug shape: <project>-<issue>."
   >
-    <p>If the upstream bug has an issue tracker entry, the slug is{' '} <code>&lt;project&gt;-&lt;issue&gt;</code> (e.g.{' '} <code>pandas-56679</code>). Otherwise, a descriptive kebab-case string (e.g. <code>bash-local-shadows-exit</code>) works. The slug is the directory name and also the Manifest v1 <code>slug</code> field.</p>
+    <p>If the upstream bug has an issue tracker entry, the slug is{' '} <code>&lt;project&gt;-&lt;issue&gt;</code> (e.g.{' '} <code><ExampleSlug layer={1} language="python" kind="numeric" /></code>). Otherwise, a descriptive kebab-case string (e.g.{' '} <code><ExampleSlug layer={2} kind="descriptive" fallback="bash-local-shadows-exit" /></code>) works. The slug is the directory name and also the Manifest v1 <code>slug</code> field.</p>
     <p>A Layer 1-friendly bug usually has these properties:</p>
     <ul>
       <li>No external I/O (no network, no filesystem, no subprocess).</li>
@@ -63,7 +64,7 @@ import {
         },
         {
           lead: 'Copy the closest existing recipe.',
-          body: <>Pick one in the same language: Python → <code>src/layer1_wasm/pandas-56679/</code>, Ruby → <code>ruby-21709/</code>, PHP → <code>php-12167/</code>, Rust → <code>regex-779/</code>. Copy the whole directory: <code>cp -r src/layer1_wasm/pandas-56679 src/layer1_wasm/&lt;your-slug&gt;</code>.</>,
+          body: <>Pick one in the same language: Python → <code>src/layer1_wasm/<ExampleSlug layer={1} language="python" />/</code>, Ruby → <code><ExampleSlug layer={1} language="ruby" fallback="<ruby-slug>" />/</code>, PHP → <code><ExampleSlug layer={1} language="php" fallback="<php-slug>" />/</code>, Rust → <code><ExampleSlug layer={1} language="rust" fallback="<rust-slug>" />/</code>. Copy the whole directory: <code>cp -r src/layer1_wasm/<ExampleSlug layer={1} language="python" /> src/layer1_wasm/&lt;your-slug&gt;</code>.</>,
         },
       ]}
     />

--- a/docs/site/ja/architecture.mdx
+++ b/docs/site/ja/architecture.mdx
@@ -12,6 +12,7 @@ import {
   NextCta,
   BottomNote,
 } from '../_components/PageChrome';
+import { LiveExamples } from '../_components/LiveExamples';
 
 <Page>
   <PageHero
@@ -89,7 +90,7 @@ import {
     eyebrow="// 01 · LAYER 1"
     heading="WebAssembly、ページの中で。"
     intro={
-      <p>ユーザーのブラウザタブの中で再現が直接実行される層です。アカウントもインストールも不要、ページを開けばすぐ動きます。Phase 0〜2 で <a href="/vivarium/repro/cpython/137205/">cpython#137205</a> や <a href="/vivarium/repro/pandas/56679/">pandas#56679</a> のように複数の Python / Ruby / PHP / Rust レシピを揃え、現在は最も「ブラウザだけで完結する」surface です。</p>
+      <p>ユーザーのブラウザタブの中で再現が直接実行される層です。アカウントもインストールも不要、ページを開けばすぐ動きます。Phase 0〜2 で複数の Python / Ruby / PHP / Rust レシピを揃え（例: <LiveExamples layer={1} kind="numeric" limit={2} format="inline-prose" lang="ja" />）、現在は最も「ブラウザだけで完結する」surface です。</p>
     }
     cellLabels={{
       fits: '向くバグ',
@@ -122,11 +123,11 @@ import {
     }
     runtimes={
       <ul>
-        <li><strong>Python</strong>: <a href="https://pyodide.org">Pyodide</a> — 例: <a href="/vivarium/repro/numpy/28287/">numpy#28287</a>、<a href="/vivarium/repro/pandas/56679/">pandas#56679</a>。</li>
-        <li><strong>SQLite</strong>: <a href="https://sqlite.org/wasm/">sqlite-wasm</a>（Pyodide 経由）— 例: <a href="/vivarium/repro/cpython/137205/">cpython#137205</a>。</li>
-        <li><strong>Rust</strong>: <code>wasm32-wasip1</code> — 例: <a href="/vivarium/repro/regex/779/">regex#779</a>。</li>
-        <li><strong>Ruby</strong>: <a href="https://github.com/ruby/ruby.wasm">Ruby.wasm</a> — 例: <a href="/vivarium/repro/ruby/21709/">ruby#21709</a>。</li>
-        <li><strong>PHP</strong>: <a href="https://github.com/WordPress/wordpress-playground">php-wasm</a> — 例: <a href="/vivarium/repro/php/12167/">php#12167</a>。</li>
+        <li><strong>Python</strong>: <a href="https://pyodide.org">Pyodide</a> — live: <LiveExamples layer={1} language="python" kind="numeric" limit={2} format="inline-prose" lang="ja" /></li>
+        <li><strong>Rust</strong>: <code>wasm32-wasip1</code> — live: <LiveExamples layer={1} language="rust" kind="numeric" limit={1} format="inline-prose" lang="ja" /></li>
+        <li><strong>Ruby</strong>: <a href="https://github.com/ruby/ruby.wasm">Ruby.wasm</a> — live: <LiveExamples layer={1} language="ruby" kind="numeric" limit={1} format="inline-prose" lang="ja" /></li>
+        <li><strong>PHP</strong>: <a href="https://github.com/WordPress/wordpress-playground">php-wasm</a> — live: <LiveExamples layer={1} language="php" kind="numeric" limit={1} format="inline-prose" lang="ja" /></li>
+        <li><strong>SQLite</strong>: <a href="https://sqlite.org/wasm/">sqlite-wasm</a>（Pyodide 経由）— sqlite WASM ビルドを Pyodide 経由で叩くレシピは上の Python の項にまとまっている。</li>
       </ul>
     }
   />
@@ -163,14 +164,7 @@ import {
         <li><strong>並行性そのものをデバッグするバグ。</strong> Layer 2 は本物のスレッドで動きますが、ハイゼンバグの再現性確保は Layer 3 の領分。</li>
       </ul>
     }
-    runtimes={
-      <ul>
-        <li><a href="/vivarium/repro/postgres/lost-update/">postgres-lost-update</a> — トランザクション境界をまたぐロスト・アップデート。</li>
-        <li><a href="/vivarium/repro/flock/is-advisory/">flock-is-advisory</a> — ファイルロックの advisory な性質。</li>
-        <li><a href="/vivarium/repro/find/xargs-whitespace/">find-xargs-whitespace</a> — パイプライン経由のホワイトスペース取り扱い。</li>
-        <li><a href="/vivarium/repro/bash/local-shadows-exit/">bash-local-shadows-exit</a> — ローカル変数が <code>$?</code> を覆う罠。</li>
-      </ul>
-    }
+    runtimes={<LiveExamples layer={2} lang="ja" />}
   />
 
   <LayerSection

--- a/docs/site/ja/guide/compare-branch-fix.mdx
+++ b/docs/site/ja/guide/compare-branch-fix.mdx
@@ -12,6 +12,7 @@ import {
   NextCta,
   BottomNote,
 } from '../../_components/PageChrome';
+import { ExampleSlug } from '../../_components/LiveExamples';
 
 <Page>
   <PageHero
@@ -57,7 +58,7 @@ import {
       items={[
         {
           lead: 'レシピが既に分かっている。',
-          body: <><a href="/vivarium/ja/repro/">ギャラリー</a>を眺めて該当レシピのページに入る。slug をメモする（例: <code>php-12167</code>）。</>,
+          body: <><a href="/vivarium/ja/repro/">ギャラリー</a>を眺めて該当レシピのページに入る。slug をメモする（例: <code><ExampleSlug layer={1} language="php" fallback="<php-slug>" /></code>）。</>,
         },
         {
           lead: 'エラー文があるのでレシピを探したい。',
@@ -71,7 +72,7 @@ import {
     eyebrow="// 2 · PATH A — LAYER 1"
     heading="レシピページに修正をペースト、verdict をキャプチャ。"
   >
-    <p>Path A に opt-in した Layer 1 レシピは、ベースライン出力の下に{' '} <strong>「Try a fix」</strong> パネルを描画する。現時点では <a href="/vivarium/ja/repro/php/12167/"><code>php-12167</code></a>{' '} に出荷済み、形が proven したら他のレシピも続く。</p>
+    <p>Path A に opt-in した Layer 1 レシピは、ベースライン出力の下に{' '} <strong>「Try a fix」</strong> パネルを描画する。現時点では PHP の例示レシピ（<code><ExampleSlug layer={1} language="php" linked fallback="<php-slug>" /></code>）に出荷済み、形が proven したら他のレシピも続く。</p>
     <NumberedList
       items={[
         {

--- a/docs/site/ja/guide/fork-your-own.mdx
+++ b/docs/site/ja/guide/fork-your-own.mdx
@@ -12,6 +12,7 @@ import {
   NextCta,
   BottomNote,
 } from '../../_components/PageChrome';
+import { ExampleSlug } from '../../_components/LiveExamples';
 
 <Page>
   <PageHero
@@ -124,7 +125,7 @@ cd vivarium`}</code></pre>
       <li><code>src/layer1_wasm/&lt;slug&gt;/repro.ts</code> — Pyodide / Ruby.wasm / php-wasm / Rust などで再現スクリプトを実行し、verdict を設定</li>
       <li><code>src/layer1_wasm/&lt;slug&gt;/README.md</code> — レシピの説明</li>
     </ul>
-    <p>既存の <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/pandas-56679"><code>pandas-56679</code></a> や <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/regex-779"><code>regex-779</code></a> を雛形にコピーして、 上流バグの slug（<code>&lt;project&gt;-&lt;issue&gt;</code> 推奨）と 再現スクリプトを書き換えるのが最短です。</p>
+    <p>既存の <code><ExampleSlug layer={1} language="python" /></code> や <code><ExampleSlug layer={1} language="rust" fallback="<rust-slug>" /></code> を雛形にコピーして、 上流バグの slug（<code>&lt;project&gt;-&lt;issue&gt;</code> 推奨）と 再現スクリプトを書き換えるのが最短です。</p>
     <Callout>
       レシピが satisfy するべき仕様は <a href="/vivarium/ja/spec/contract-v1">Contract v1</a>
       に書かれています。<code>&lt;meta name="vivarium-contract" content="v1"&gt;</code> と

--- a/docs/site/ja/guide/getting-started.mdx
+++ b/docs/site/ja/guide/getting-started.mdx
@@ -12,6 +12,7 @@ import {
   NextCta,
   BottomNote,
 } from '../../_components/PageChrome';
+import { ExampleSlug } from '../../_components/LiveExamples';
 
 <Page>
   <PageHero
@@ -59,11 +60,11 @@ import {
     eyebrow="// 2 · レシピを動かす"
     heading="クリック 1 回。後はブラウザがやる。"
   >
-    <p>初回は何が起きているのか分かりやすいように、<code>pandas-56679</code> を例に進める。 カードの「Open」ボタンを押すと別タブで{' '} <a href="/vivarium/repro/pandas/56679/" target="_blank" rel="noreferrer"> /repro/pandas/56679/ </a>{' '} が開く。</p>
-    <p>ページが読み込まれると、まず Pyodide（CPython の WebAssembly ビルド）と pandas を jsDelivr CDN からダウンロードする。verdict バッジは <code>pending</code> 状態で 「ランタイムを読み込み中」と表示される。</p>
+    <p>初回は何が起きているのか分かりやすいように、<code><ExampleSlug layer={1} language="python" linked /></code> を例に進める。 カードの「Open」ボタンを押すと別タブで該当レシピのページが開く。</p>
+    <p>ページが読み込まれると、まず Pyodide（CPython の WebAssembly ビルド）と対象ライブラリを jsDelivr CDN からダウンロードする。verdict バッジは <code>pending</code> 状態で 「ランタイムを読み込み中」と表示される。</p>
     <p>ロード完了後、ページに埋め込まれた再現スクリプトが実行され、verdict が確定する。 初回ロードは数秒〜十数秒（接続速度とブラウザのキャッシュ状態による）、 2 回目以降は CDN キャッシュが効いてミリ秒〜秒で開く。</p>
     <Callout>
-      Layer 1 はブラウザ完結。ローカルに Python も pandas も入れる必要はない。
+      Layer 1 はブラウザ完結。ローカルに Python も対象ライブラリも入れる必要はない。
       Vivarium が宣言する 3 層アーキテクチャは{' '}
       <a href="/vivarium/ja/architecture">アーキテクチャ</a> 参照。
     </Callout>
@@ -74,7 +75,7 @@ import {
     heading="reproduced / unreproduced / pending の 3 値だけ。"
   >
     <p><code>reproduced</code> はアップストリームバグが現在も再現することを示す。 <code>unreproduced</code> は再現しなかったこと——つまりランタイムの新しいビルドが 問題を解消した、あるいは再現条件が変わった——を示す。<code>pending</code> は まだ実行中、もしくは初期化中の中間状態。</p>
-    <p>pandas-56679 を開いて少し待つと、現状（pandas が Pyodide で出荷している版で再現するかどうか） に応じて値が <code>reproduced</code> か <code>unreproduced</code> に落ち着く。 verdict バッジの下に、その判定の根拠となった出力——<code>series_dtype</code> と <code>df_dtype</code> の比較結果——も表示される。</p>
+    <p>レシピを開いて少し待つと、現状（Pyodide が出荷しているライブラリ版で再現するかどうか） に応じて値が <code>reproduced</code> か <code>unreproduced</code> に落ち着く。 verdict バッジの下に、その判定の根拠となった出力——レシピ固有の比較値——も表示される。</p>
     <Callout>
       「pass / fail」ではなく「reproduced / unreproduced」を使う理由: テスト用語の{' '}
       pass / fail はチームによって意味が逆転する。Vivarium の動詞は
@@ -88,7 +89,7 @@ import {
     heading="バッジだけではなく、その根拠も同じページに。"
   >
     <p>verdict バッジの下に「Evidence」セクションがあり、再現スクリプトの実行結果が まとまっている: stdout、stderr、終了コード、所要時間（ms）。Contract v1 リビジョン 2 により、verdict が出る根拠がページから直接読める。</p>
-    <p>たとえば pandas-56679 では、<code>series_dtype</code> と <code>df_dtype</code> の 文字列値、両者が一致しないかどうかの真偽値、pandas と Python のバージョンが JSON で出力される。これがそのまま<strong>evidence</strong> として記録される。</p>
+    <p>典型的な Python レシピでは、両者が一致するかどうかの真偽値、不一致を引き起こす実際の値、ライブラリ／インタプリタのバージョンが JSON で出力される。これがそのまま<strong>evidence</strong> として記録される。</p>
   </Section>
 
   <Section

--- a/docs/site/ja/guide/write-your-first-reproduction.mdx
+++ b/docs/site/ja/guide/write-your-first-reproduction.mdx
@@ -12,6 +12,7 @@ import {
   NextCta,
   BottomNote,
 } from '../../_components/PageChrome';
+import { ExampleSlug } from '../../_components/LiveExamples';
 
 <Page>
   <PageHero
@@ -38,7 +39,7 @@ import {
     eyebrow="// 1 · 再現したいバグを決める"
     heading="スラッグは <project>-<issue> 形式。"
   >
-    <p>上流 Issue がある場合は <code>&lt;project&gt;-&lt;issue&gt;</code> （例: <code>pandas-56679</code>）が標準。 ない場合は説明的なケバブケース（例: <code>bash-local-shadows-exit</code>）。 これがディレクトリ名でもあり、Manifest v1 の <code>slug</code> でもあります。</p>
+    <p>上流 Issue がある場合は <code>&lt;project&gt;-&lt;issue&gt;</code> （例: <code><ExampleSlug layer={1} language="python" kind="numeric" /></code>）が標準。 ない場合は説明的なケバブケース（例: <code><ExampleSlug layer={2} kind="descriptive" fallback="bash-local-shadows-exit" /></code>）。 これがディレクトリ名でもあり、Manifest v1 の <code>slug</code> でもあります。</p>
     <p>バグを選ぶときは、Layer 1 で完結するか確認するのがコツです:</p>
     <ul>
       <li>外部 I/O（ネットワーク、ファイル、サブプロセス）を踏まない。</li>
@@ -63,7 +64,7 @@ import {
         },
         {
           lead: '一番近い既存レシピをコピーする。',
-          body: <>言語が同じレシピを丸ごとコピーするのが楽です。Python なら <code>src/layer1_wasm/pandas-56679/</code>、Ruby なら <code>ruby-21709/</code>、PHP なら <code>php-12167/</code>、Rust なら <code>regex-779/</code>。<code>cp -r src/layer1_wasm/pandas-56679 src/layer1_wasm/&lt;あなたの slug&gt;</code> でディレクトリごと複製。</>,
+          body: <>言語が同じレシピを丸ごとコピーするのが楽です。Python なら <code>src/layer1_wasm/<ExampleSlug layer={1} language="python" />/</code>、Ruby なら <code><ExampleSlug layer={1} language="ruby" fallback="<ruby-slug>" />/</code>、PHP なら <code><ExampleSlug layer={1} language="php" fallback="<php-slug>" />/</code>、Rust なら <code><ExampleSlug layer={1} language="rust" fallback="<rust-slug>" />/</code>。<code>cp -r src/layer1_wasm/<ExampleSlug layer={1} language="python" /> src/layer1_wasm/&lt;あなたの slug&gt;</code> でディレクトリごと複製。</>,
         },
       ]}
     />


### PR DESCRIPTION

Recipe directories under src/layer{1,2,3}_*/<slug>/ churn whenever
upstream merges or rejects the fix (recent: astroid-2993 PR #246,
hypothesis-4651 PR #248). Six MDX files embedded concrete slugs
across both locales, forcing a parallel docs sweep on every deletion
- and the build doesn't link-check those references, so missed
updates left dead links.

Extend PR #235's generator -> MDX-consumer pattern to slugs:

- New _components/LiveExamples.tsx (LiveExamples + ExampleSlug)
  reads public/api/recipes.json at build time and resolves slug
  references against the current catalogue. Deterministic sort by
  (issue desc, slug asc); explicit fallback when zero matches.
- architecture.mdx (en + ja) intro paragraph + Layer 1 runtime list
  + Layer 2 runtime list now data-driven.
- Guide files (getting-started, write-your-first-reproduction,
  compare-branch-fix, fork-your-own; en + ja) use <ExampleSlug>
  for inline references; pandas-56679-specific verdict-field copy
  in getting-started genericised.

VivariumHero.tsx stays pinned (cpython-137205, postgres-lost-update,
ruby-21709 are paired with hand-written copy that recipes.json
can't supply). Header comment + new bullet in
.claude/rules/recipe-authoring.md "Data files to update" force the
next engineer who deletes one of those slugs to confront the hero
rewrite first.

Verification:
- mise run recipes:index, docs:check, markdown:check all green.
- rspress build green.
- Deletion rehearsal: temporarily moved src/layer1_wasm/pandas-56679
  out of the tree, regenerated, rebuilt. Confirmed architecture.html
  flipped pandas#56679 -> numpy#28287 with no broken links or build
  error. Recipe restored before commit.
