### PR TITLE
fix(mcp): address #250 review — upstream PR base + blocked state + schema gaps

### DIFF
--- a/docs/scripts/generate-recipes-index.ts
+++ b/docs/scripts/generate-recipes-index.ts
@@ -229,17 +229,52 @@ function parseSlug(slug: string): {
 // without a roundtrip.json keep the catalogue field absent); any other
 // failure logs a warning and skips the merge rather than failing the
 // generator — recipes.json must stay generatable from any half-populated
-// tree.
+// tree. Mechanical checks below are the minimal set needed to keep the
+// public catalogue from carrying obviously malformed state; the
+// canonical full-schema validation lives in roundtrip.schema.json and
+// is enforced by the verify_and_report_fix MCP tool / Phase 3
+// validators that consume the file.
 async function loadRoundtripState(
   recipeDir: string,
+  expectedSlug: string,
 ): Promise<RoundtripState | undefined> {
   const path = join(recipeDir, 'roundtrip.json');
   try {
     const raw = await readFile(path, 'utf-8');
     const parsed = JSON.parse(raw) as RoundtripState;
-    if (parsed.schema_version !== 1 || typeof parsed.slug !== 'string') {
+    if (parsed.schema_version !== 1) {
       console.error(
-        `WARNING: ${path} did not look like roundtrip schema_version 1; skipping merge.`,
+        `WARNING: ${path}: schema_version != 1 (got ${parsed.schema_version}); skipping merge.`,
+      );
+      return undefined;
+    }
+    if (typeof parsed.slug !== 'string' || parsed.slug !== expectedSlug) {
+      console.error(
+        `WARNING: ${path}: slug "${parsed.slug}" does not match directory name "${expectedSlug}"; skipping merge.`,
+      );
+      return undefined;
+    }
+    if (
+      typeof parsed.upstream_issue !== 'string' ||
+      parsed.upstream_issue.length === 0
+    ) {
+      console.error(
+        `WARNING: ${path}: upstream_issue missing or empty; skipping merge.`,
+      );
+      return undefined;
+    }
+    if (typeof parsed.status !== 'string' || parsed.status.length === 0) {
+      console.error(
+        `WARNING: ${path}: status missing or empty; skipping merge.`,
+      );
+      return undefined;
+    }
+    if (
+      typeof parsed.updated_at !== 'string' ||
+      parsed.updated_at.length === 0
+    ) {
+      console.error(
+        `WARNING: ${path}: updated_at missing or empty; skipping merge.`,
       );
       return undefined;
     }
@@ -369,7 +404,7 @@ async function buildEntry(
   if (layer === 2 || layer === 3) {
     entry.verdict_url = `${PAGES_BASE}/repro/${project}/${issuePath}/verdict.json`;
   }
-  const roundtrip = await loadRoundtripState(recipeDir);
+  const roundtrip = await loadRoundtripState(recipeDir, slug);
   if (roundtrip) entry.roundtrip = roundtrip;
   return entry;
 }

--- a/docs/scripts/generate-recipes-index.ts
+++ b/docs/scripts/generate-recipes-index.ts
@@ -48,6 +48,33 @@ const REPO_BASE = `https://github.com/${OWNER}/${REPO_NAME}`;
 
 type Layer = 1 | 2 | 3;
 
+// Per-recipe round-trip state. Canonical schema:
+// docs/site/public/spec/roundtrip.schema.json. Surfaced here as
+// `recipe.roundtrip` when the recipe directory carries a
+// `roundtrip.json` (opt-in; recipes without one keep the field absent).
+// ADR-0018 minor-revision policy: this is an additive optional field
+// inside the same `index = "v1"` envelope, no version bump.
+interface RoundtripState {
+  schema_version: 1;
+  slug: string;
+  upstream_issue: string;
+  vivarium_pr?: string | null;
+  fork?: {
+    owner: string;
+    repo: string;
+    branch: string;
+    image_tag?: string;
+  } | null;
+  upstream_pr?: string | null;
+  verdicts?: {
+    unfixed?: { verdict: string; captured_at: string; source: string };
+    fixed?: { verdict: string; captured_at: string; source: string };
+  };
+  status: string;
+  updated_at: string;
+  notes?: string[];
+}
+
 interface RecipeEntry {
   slug: string;
   layer: Layer;
@@ -61,6 +88,7 @@ interface RecipeEntry {
   symptom?: string;
   severity?: string;
   tags: string[];
+  roundtrip?: RoundtripState;
 }
 
 interface RecipesIndex {
@@ -197,6 +225,34 @@ function parseSlug(slug: string): {
   };
 }
 
+// Opt-in round-trip state loader. ENOENT is the common case (recipes
+// without a roundtrip.json keep the catalogue field absent); any other
+// failure logs a warning and skips the merge rather than failing the
+// generator — recipes.json must stay generatable from any half-populated
+// tree.
+async function loadRoundtripState(
+  recipeDir: string,
+): Promise<RoundtripState | undefined> {
+  const path = join(recipeDir, 'roundtrip.json');
+  try {
+    const raw = await readFile(path, 'utf-8');
+    const parsed = JSON.parse(raw) as RoundtripState;
+    if (parsed.schema_version !== 1 || typeof parsed.slug !== 'string') {
+      console.error(
+        `WARNING: ${path} did not look like roundtrip schema_version 1; skipping merge.`,
+      );
+      return undefined;
+    }
+    return parsed;
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return undefined;
+    console.error(
+      `WARNING: could not read ${path} (${err instanceof Error ? err.message : err}); skipping roundtrip merge.`,
+    );
+    return undefined;
+  }
+}
+
 async function readTitle(
   readmePath: string,
   fallback: string,
@@ -313,6 +369,8 @@ async function buildEntry(
   if (layer === 2 || layer === 3) {
     entry.verdict_url = `${PAGES_BASE}/repro/${project}/${issuePath}/verdict.json`;
   }
+  const roundtrip = await loadRoundtripState(recipeDir);
+  if (roundtrip) entry.roundtrip = roundtrip;
   return entry;
 }
 

--- a/docs/scripts/generate-validators.ts
+++ b/docs/scripts/generate-validators.ts
@@ -42,6 +42,11 @@ const TARGETS: Target[] = [
     output: 'verdict-validator.mjs',
     label: 'Verdict v1 (Contract v1)',
   },
+  {
+    schema: 'roundtrip.schema.json',
+    output: 'roundtrip-validator.mjs',
+    label: 'Roundtrip (schema_version 1)',
+  },
 ];
 
 mkdirSync(SITE_GENERATED_VALIDATORS_DIR, { recursive: true });

--- a/docs/site/public/api/recipes.schema.json
+++ b/docs/site/public/api/recipes.schema.json
@@ -97,6 +97,10 @@
             "minLength": 1
           },
           "description": "Optional. Free-form tag list scored by the matcher (e.g. ['sqlite3', 'pragma', 'foreign-keys']). Sourced from the facet overlay. Added 2026-05-03; backwards-compatible."
+        },
+        "roundtrip": {
+          "type": "object",
+          "description": "Optional. Per-recipe round-trip workflow state, sourced from src/layer*/<slug>/roundtrip.json. Canonical inner shape is documented in https://aletheia-works.github.io/vivarium/spec/roundtrip.schema.json (schema_version 1); this catalogue schema intentionally leaves the inner shape unconstrained so the round-trip schema can evolve (verdicts, status enum, fork shape) without forcing a recipes-index revision in lockstep. Added in the 2026-05-17 v1 revision; backwards-compatible, v1 consumers ignore."
         }
       }
     }

--- a/docs/site/public/spec/roundtrip.schema.json
+++ b/docs/site/public/spec/roundtrip.schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia-works.github.io/vivarium/spec/roundtrip.schema.json",
+  "title": "Vivarium round-trip state (schema_version 1)",
+  "description": "Per-recipe round-trip workflow state. Tracked sibling of a recipe's tracked sources (README.md / repro.* / index.html / Dockerfile) under src/layer{1,2,3}_*/<slug>/roundtrip.json. Captures the workflow-level progress of the upstream → reproduction → fix → verification → PR loop that recipes.json (the static catalogue) intentionally does not carry. SSOT boundary: recipes.json holds catalogue facts that solidify at recipe-authoring time (slug existence, layer, page_url); roundtrip.json holds state that keeps moving after the recipe is authored (branch / PR URLs / verdict transitions). The generator at docs/scripts/generate-recipes-index.ts opt-in merges this file into the catalogue entry under a `roundtrip` field; the recipes.json schema literal stays index = 'v1' per the ADR-0018 minor-revision policy. AI agents (the round-trip skill, the verify_and_report_fix MCP tool) write this file; the round-trip workflow's state machine reads `status` to decide the next action.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "slug",
+    "upstream_issue",
+    "status",
+    "updated_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": 1,
+      "description": "Schema version literal. Always 1 for files validating against this schema; breaking changes ship as a sibling schema (roundtrip.v2.schema.json) per ADR-0018."
+    },
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "description": "Kebab-case recipe slug. Matches the parent directory name and the slug in recipes.json."
+    },
+    "upstream_issue": {
+      "type": "string",
+      "format": "uri",
+      "description": "Canonical URL of the upstream issue this round-trip resolves (e.g. https://github.com/mpmath/mpmath/issues/983). The single mandatory cross-repo link."
+    },
+    "vivarium_pr": {
+      "type": ["string", "null"],
+      "format": "uri",
+      "description": "URL of the Vivarium-side PR that lands the recipe + this roundtrip.json. Null while the recipe is still in draft / verifying status."
+    },
+    "fork": {
+      "type": ["object", "null"],
+      "description": "Personal fork of the upstream repo where the candidate fix lives. Null until the round-trip reaches the open_fork_pr stage. AI agents create the fork against the user's account, not the aletheia-works org (see Plan §Phase 4 fork strategy).",
+      "required": ["owner", "repo", "branch"],
+      "additionalProperties": false,
+      "properties": {
+        "owner": {
+          "type": "string",
+          "description": "GitHub login that owns the fork (typically the human contributor's personal account)."
+        },
+        "repo": {
+          "type": "string",
+          "description": "Fork repository name; usually identical to the upstream repo name."
+        },
+        "branch": {
+          "type": "string",
+          "description": "Branch on the fork that holds the candidate fix commits."
+        },
+        "image_tag": {
+          "type": "string",
+          "description": "Optional. For Layer 2/3 round-trips, the branch-fix Docker image tag pushed to GHCR (matches the `branch_image` input of branch-fix-verdict.yml). Absent for Layer 1 round-trips, which substitute fix sources in-browser via Path A."
+        }
+      }
+    },
+    "upstream_pr": {
+      "type": ["string", "null"],
+      "format": "uri",
+      "description": "URL of the upstream PR opened against the upstream repo from the fork branch. Always opened in draft mode by AI agents (see Plan §Phase 4 guardrail 4); a human moves it to ready-for-review. Null until the round-trip reaches the upstream_open stage."
+    },
+    "verdicts": {
+      "type": "object",
+      "description": "Verdict pair that proves the round-trip's claim: `unfixed` shows the bug reproduced against the unmodified upstream, `fixed` shows it stopped reproducing once the candidate fix was applied. A round-trip is only considered verified when both are present and `unfixed.verdict === 'reproduced'` + `fixed.verdict === 'unreproduced'`.",
+      "additionalProperties": false,
+      "properties": {
+        "unfixed": { "$ref": "#/$defs/verdictResult" },
+        "fixed": { "$ref": "#/$defs/verdictResult" }
+      }
+    },
+    "status": {
+      "enum": [
+        "draft",
+        "verifying",
+        "verified",
+        "upstream_open",
+        "merged",
+        "blocked"
+      ],
+      "description": "State-machine position. draft = recipe scaffolded but no verdict yet. verifying = unfixed or fixed verdict capture in progress. verified = both verdicts present and consistent. upstream_open = upstream fork PR opened. merged = upstream PR merged (terminal). blocked = manual intervention required; see `notes` for the reason."
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Wall-clock timestamp of the last write to this file, ISO-8601 with 'Z' suffix. Bumped on every state transition. Used by external tooling (round-trip dashboard, verdict-comment-bot) to detect stale state."
+    },
+    "notes": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional free-form notes appended on each state transition. Conventionally one entry per `status` change. Used to record `blocked` reasons in particular."
+    }
+  },
+  "$defs": {
+    "verdictResult": {
+      "type": "object",
+      "required": ["verdict", "captured_at", "source"],
+      "additionalProperties": false,
+      "properties": {
+        "verdict": {
+          "enum": ["reproduced", "unreproduced"],
+          "description": "Contract v1 verdict polarity. `reproduced` = the bug triggered; `unreproduced` = it did not. Matches verdict.schema.json."
+        },
+        "captured_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Wall-clock timestamp of the verdict capture, ISO-8601 with 'Z' suffix."
+        },
+        "source": {
+          "enum": ["layer1-headless", "layer2-ghcr", "layer3-trace"],
+          "description": "How the verdict was captured. `layer1-headless` = Playwright-driven WASM run targeted by --grep <slug>. `layer2-ghcr` = branch-fix-verdict.yml workflow run consuming a GHCR-pushed image. `layer3-trace` = maintainer-side rr replay against the trace asset pinned in trace.url."
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "schema_version": 1,
+      "slug": "mpmath-983",
+      "upstream_issue": "https://github.com/mpmath/mpmath/issues/983",
+      "vivarium_pr": "https://github.com/aletheia-works/vivarium/pull/200",
+      "fork": {
+        "owner": "JamBalaya56562",
+        "repo": "mpmath",
+        "branch": "fix-issue-983"
+      },
+      "upstream_pr": "https://github.com/mpmath/mpmath/pull/984",
+      "verdicts": {
+        "unfixed": {
+          "verdict": "reproduced",
+          "captured_at": "2026-05-17T03:12:00Z",
+          "source": "layer1-headless"
+        },
+        "fixed": {
+          "verdict": "unreproduced",
+          "captured_at": "2026-05-17T03:18:42Z",
+          "source": "layer1-headless"
+        }
+      },
+      "status": "upstream_open",
+      "updated_at": "2026-05-17T03:20:10Z",
+      "notes": [
+        "scaffolded from upstream issue",
+        "unfixed verdict captured via ci:repro --grep mpmath-983",
+        "fixed verdict captured against fix branch fix-issue-983",
+        "upstream PR opened in draft"
+      ]
+    }
+  ]
+}

--- a/packages/mcp-server/jsr.json
+++ b/packages/mcp-server/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@aletheia-works/vivarium-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aletheia-works/vivarium-mcp",
-  "version": "0.1.1",
-  "description": "MCP server exposing the Vivarium reproduction catalogue (list_recipes, get_recipe, lookup_verdict, match_error, verify_branch_fix, prepare_new_recipe, prepare_fix_candidate) to AI agent clients (Claude Code, Cline, Cursor, Continue, etc.).",
+  "version": "0.1.2",
+  "description": "MCP server exposing the Vivarium reproduction catalogue (list_recipes, get_recipe, lookup_verdict, match_error, verify_branch_fix, verify_and_report_fix, prepare_new_recipe, prepare_fix_candidate) to AI agent clients (Claude Code, Cline, Cursor, Continue, etc.).",
   "license": "Apache-2.0",
   "homepage": "https://github.com/aletheia-works/vivarium/tree/main/packages/mcp-server",
   "bugs": {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -35,6 +35,11 @@ import {
   type PrepareNewRecipeArgs,
 } from './tools/prepare_new_recipe.js';
 import {
+  VERIFY_AND_REPORT_FIX_TOOL,
+  verifyAndReportFix,
+  type VerifyAndReportFixArgs,
+} from './tools/verify_and_report_fix.js';
+import {
   VERIFY_BRANCH_FIX_TOOL,
   verifyBranchFix,
   type VerifyBranchFixArgs,
@@ -48,7 +53,7 @@ const SERVER_NAME = 'vivarium-mcp';
 // description / surface refinements) — the project is still pre-1.0
 // and `prepare_fix_candidate` is meaningful but fully opt-in, so a minor
 // bump would overstate the impact.
-const SERVER_VERSION = '0.1.1';
+const SERVER_VERSION = '0.1.2';
 
 export function createServer(): Server {
   const server = new Server(
@@ -63,6 +68,7 @@ export function createServer(): Server {
       LOOKUP_VERDICT_TOOL,
       MATCH_ERROR_TOOL,
       VERIFY_BRANCH_FIX_TOOL,
+      VERIFY_AND_REPORT_FIX_TOOL,
       PREPARE_NEW_RECIPE_TOOL,
       PREPARE_FIX_CANDIDATE_TOOL,
     ],
@@ -90,6 +96,11 @@ export function createServer(): Server {
         case 'verify_branch_fix':
           payload = await verifyBranchFix(
             args as unknown as VerifyBranchFixArgs,
+          );
+          break;
+        case 'verify_and_report_fix':
+          payload = await verifyAndReportFix(
+            args as unknown as VerifyAndReportFixArgs,
           );
           break;
         case 'prepare_new_recipe':

--- a/packages/mcp-server/src/tools/verify_and_report_fix.ts
+++ b/packages/mcp-server/src/tools/verify_and_report_fix.ts
@@ -60,12 +60,15 @@ const LAYER_DIRNAME: Record<Layer, string> = {
 
 // Pure state-machine transition. Exported so unit tests and any future
 // MCP client can reuse the same logic without re-implementing the
-// transitions.
+// transitions. `status: blocked` short-circuits to manual_intervention
+// regardless of verdict / PR fields so a paused round-trip cannot drift
+// further on automation.
 export function computeNextAction(
   state: Partial<RoundtripState> | undefined,
 ): RoundtripNextAction {
   if (!state) return 'verify_unfixed';
 
+  if (state.status === 'blocked') return 'manual_intervention';
   if (state.status === 'merged') return 'complete';
   if (state.upstream_pr) return 'complete';
 
@@ -82,6 +85,26 @@ export function computeNextAction(
   return 'verify_unfixed';
 }
 
+// Parse `https://github.com/<owner>/<repo>/issues/<n>` (or `/pull/<n>`)
+// to extract the upstream repo coordinates. The fork repo is the
+// contributor's mirror; upstream PRs always target the original owner,
+// not the fork. Returns undefined for non-github / malformed URLs.
+export function parseUpstreamIssue(
+  url: string | undefined,
+): { owner: string; repo: string } | undefined {
+  if (!url) return undefined;
+  try {
+    const u = new URL(url);
+    if (u.hostname !== 'github.com') return undefined;
+    const parts = u.pathname.split('/').filter(Boolean);
+    if (parts.length < 4) return undefined;
+    if (parts[2] !== 'issues' && parts[2] !== 'pull') return undefined;
+    return { owner: parts[0]!, repo: parts[1]! };
+  } catch {
+    return undefined;
+  }
+}
+
 interface BuildCommandsArgs {
   next: RoundtripNextAction;
   slug: string;
@@ -91,11 +114,21 @@ interface BuildCommandsArgs {
   ghCommand?: string;
   branchImage?: string;
   fork?: RoundtripState['fork'];
+  upstreamIssue?: string;
 }
 
 function buildCommands(args: BuildCommandsArgs): string[] {
-  const { next, slug, layer, pathAB, compareUrl, ghCommand, branchImage, fork } =
-    args;
+  const {
+    next,
+    slug,
+    layer,
+    pathAB,
+    compareUrl,
+    ghCommand,
+    branchImage,
+    fork,
+    upstreamIssue,
+  } = args;
   switch (next) {
     case 'verify_unfixed':
       if (pathAB === 'A') {
@@ -125,19 +158,36 @@ function buildCommands(args: BuildCommandsArgs): string[] {
         ghCommand ??
           `gh workflow run branch-fix-verdict.yml --repo aletheia-works/vivarium -f slug=${slug} -f branch_image=<your-image-ref>`,
       ];
-    case 'open_fork_pr':
+    case 'open_fork_pr': {
+      if (!fork) {
+        return [
+          `# Populate roundtrip.json#/fork (owner / repo / branch) before opening the upstream PR.`,
+        ];
+      }
+      const upstream = parseUpstreamIssue(upstreamIssue);
+      if (!upstream) {
+        return [
+          `# Cannot derive upstream repo from roundtrip.json#/upstream_issue ('${upstreamIssue ?? 'missing'}').`,
+          `# Expected form: https://github.com/<owner>/<repo>/issues/<n>.`,
+        ];
+      }
       return [
-        `# Open the upstream fork PR in draft mode (AI agents must keep it --draft per round-trip guardrail 4).`,
-        fork
-          ? `gh pr create --repo ${fork.owner}/${fork.repo} --head ${fork.owner}:${fork.branch} --draft --label 'ai: generated' --title '<title>' --body '<body>'`
-          : `# Populate roundtrip.json#/fork (owner / repo / branch) before opening the upstream PR.`,
+        `# Open the upstream PR in draft mode (AI agents must keep it --draft per round-trip guardrail 4).`,
+        `# Base repo = upstream (${upstream.owner}/${upstream.repo}); head = contributor fork (${fork.owner}:${fork.branch}).`,
+        `gh pr create --repo ${upstream.owner}/${upstream.repo} --head ${fork.owner}:${fork.branch} --draft --label 'ai: generated' --title '<title>' --body '<body>'`,
       ];
+    }
     case 'open_vivarium_pr':
       return [
         `# Submit the Vivarium-side PR carrying the recipe and roundtrip.json update.`,
         `sl addremove`,
         `sl commit -m 'feat(layer${layer}): ${slug} — round-trip verdicts captured'`,
         `sl pr submit`,
+      ];
+    case 'manual_intervention':
+      return [
+        `# status=blocked: round-trip paused for manual review.`,
+        `# Inspect roundtrip.json#/notes for the reason and resolve before resuming automation.`,
       ];
     case 'complete':
       return [];
@@ -179,6 +229,7 @@ export async function verifyAndReportFix(
     ghCommand: verifyResult.gh_command,
     branchImage: args.branch_image,
     fork: args.current_state?.fork ?? undefined,
+    upstreamIssue: args.current_state?.upstream_issue,
   });
 
   const notes = [...verifyResult.notes];

--- a/packages/mcp-server/src/tools/verify_and_report_fix.ts
+++ b/packages/mcp-server/src/tools/verify_and_report_fix.ts
@@ -1,0 +1,239 @@
+// Layer-abstracted round-trip verification helper. Computes the
+// state-machine next_action from a recipe's current round-trip state
+// (passed in via `current_state`, typically the contents of
+// src/layer{1,2,3}_*/<slug>/roundtrip.json) and returns the commands
+// the round-trip skill should run next. Bridges Path A (Layer 1,
+// browser-driven Playwright runs) and Path B (Layer 2/3,
+// branch-fix-verdict.yml workflow dispatch) under a single return
+// shape so callers do not branch on layer.
+//
+// Phase 1 (this commit): SCAFFOLDING ONLY. The tool returns the
+// canonical roundtrip.json path, the state-machine next_action, and
+// the verify_branch_fix-derived deep-link commands. It does NOT execute
+// verdict capture or mutate roundtrip.json. Phase 3 will replace the
+// command-string return with actual execution for Layer 1
+// (Playwright-driven targeted runs) while keeping the same return
+// shape for Layer 2/3 (GitHub Actions workflow_dispatch wrapping).
+
+import { getCatalogue } from '../catalogue.js';
+import type {
+  Layer,
+  RoundtripNextAction,
+  RoundtripState,
+} from '../types.js';
+import { verifyBranchFix } from './verify_branch_fix.js';
+
+export interface VerifyAndReportFixArgs {
+  slug: string;
+  fix_url?: string;
+  fix_source?: string;
+  branch_image?: string;
+  current_state?: Partial<RoundtripState>;
+}
+
+export interface VerifyAndReportFixOk {
+  ok: true;
+  slug: string;
+  layer: Layer;
+  path: 'A' | 'B';
+  verdicts: NonNullable<RoundtripState['verdicts']>;
+  roundtrip_path: string;
+  next_action: RoundtripNextAction;
+  commands: string[];
+  notes: string[];
+}
+
+export interface VerifyAndReportFixError {
+  ok: false;
+  error: string;
+}
+
+export type VerifyAndReportFixResult =
+  | VerifyAndReportFixOk
+  | VerifyAndReportFixError;
+
+const LAYER_DIRNAME: Record<Layer, string> = {
+  1: 'layer1_wasm',
+  2: 'layer2_docker',
+  3: 'layer3_thirdway',
+};
+
+// Pure state-machine transition. Exported so unit tests and any future
+// MCP client can reuse the same logic without re-implementing the
+// transitions.
+export function computeNextAction(
+  state: Partial<RoundtripState> | undefined,
+): RoundtripNextAction {
+  if (!state) return 'verify_unfixed';
+
+  if (state.status === 'merged') return 'complete';
+  if (state.upstream_pr) return 'complete';
+
+  const unfixed = state.verdicts?.unfixed;
+  const fixed = state.verdicts?.fixed;
+  const verified =
+    unfixed?.verdict === 'reproduced' && fixed?.verdict === 'unreproduced';
+
+  if (verified) {
+    if (!state.vivarium_pr) return 'open_vivarium_pr';
+    return 'open_fork_pr';
+  }
+  if (unfixed?.verdict === 'reproduced') return 'verify_fixed';
+  return 'verify_unfixed';
+}
+
+interface BuildCommandsArgs {
+  next: RoundtripNextAction;
+  slug: string;
+  layer: Layer;
+  pathAB: 'A' | 'B';
+  compareUrl: string;
+  ghCommand?: string;
+  branchImage?: string;
+  fork?: RoundtripState['fork'];
+}
+
+function buildCommands(args: BuildCommandsArgs): string[] {
+  const { next, slug, layer, pathAB, compareUrl, ghCommand, branchImage, fork } =
+    args;
+  switch (next) {
+    case 'verify_unfixed':
+      if (pathAB === 'A') {
+        return [
+          `# Capture the unfixed verdict against the upstream-as-shipped runtime.`,
+          `bun x playwright test --grep ${slug}`,
+          `# Or inspect the verdict visually at ${compareUrl}.`,
+        ];
+      }
+      return [
+        `# Capture the unfixed verdict by running the recipe's Docker image as-published.`,
+        `mise run recipes:verify ${slug}`,
+      ];
+    case 'verify_fixed':
+      if (pathAB === 'A') {
+        return [
+          `# Capture the fixed verdict against the candidate fix source.`,
+          `PLAYWRIGHT_FIX_URL='<fix-url>' bun x playwright test --grep ${slug}`,
+          `# Or open ${compareUrl} in a browser; the fix is pre-loaded via ?fix_url= / ?fix=<base64>.`,
+        ];
+      }
+      return [
+        `# Build and push the branch-fix Docker image, then dispatch the verdict workflow.`,
+        branchImage
+          ? `# Using branch_image=${branchImage}`
+          : `# Substitute <your-image-ref> with the GHCR tag of your branch-fix image.`,
+        ghCommand ??
+          `gh workflow run branch-fix-verdict.yml --repo aletheia-works/vivarium -f slug=${slug} -f branch_image=<your-image-ref>`,
+      ];
+    case 'open_fork_pr':
+      return [
+        `# Open the upstream fork PR in draft mode (AI agents must keep it --draft per round-trip guardrail 4).`,
+        fork
+          ? `gh pr create --repo ${fork.owner}/${fork.repo} --head ${fork.owner}:${fork.branch} --draft --label 'ai: generated' --title '<title>' --body '<body>'`
+          : `# Populate roundtrip.json#/fork (owner / repo / branch) before opening the upstream PR.`,
+      ];
+    case 'open_vivarium_pr':
+      return [
+        `# Submit the Vivarium-side PR carrying the recipe and roundtrip.json update.`,
+        `sl addremove`,
+        `sl commit -m 'feat(layer${layer}): ${slug} — round-trip verdicts captured'`,
+        `sl pr submit`,
+      ];
+    case 'complete':
+      return [];
+  }
+}
+
+export async function verifyAndReportFix(
+  args: VerifyAndReportFixArgs,
+): Promise<VerifyAndReportFixResult> {
+  const slug = args.slug?.trim();
+  if (!slug) {
+    return { ok: false, error: 'missing required argument: slug' };
+  }
+
+  const { recipes } = await getCatalogue();
+  const recipe = recipes.find((r) => r.slug === slug);
+  if (!recipe) {
+    return { ok: false, error: `recipe not found: ${slug}` };
+  }
+
+  const verifyResult = await verifyBranchFix({
+    slug,
+    fix_url: args.fix_url,
+    fix_source: args.fix_source,
+  });
+  if (!verifyResult.ok) {
+    return { ok: false, error: verifyResult.error };
+  }
+
+  const next = computeNextAction(args.current_state);
+  const verdicts = args.current_state?.verdicts ?? {};
+  const roundtripPath = `src/${LAYER_DIRNAME[recipe.layer]}/${slug}/roundtrip.json`;
+  const commands = buildCommands({
+    next,
+    slug,
+    layer: recipe.layer,
+    pathAB: verifyResult.path,
+    compareUrl: verifyResult.compare_url,
+    ghCommand: verifyResult.gh_command,
+    branchImage: args.branch_image,
+    fork: args.current_state?.fork ?? undefined,
+  });
+
+  const notes = [...verifyResult.notes];
+  notes.push(
+    'phase 1 skeleton — verify_and_report_fix returns commands but does not yet execute verdict capture; phase 3 will replace the command return for layer 1 with playwright-driven runs.',
+  );
+
+  return {
+    ok: true,
+    slug: recipe.slug,
+    layer: recipe.layer,
+    path: verifyResult.path,
+    verdicts,
+    roundtrip_path: roundtripPath,
+    next_action: next,
+    commands,
+    notes,
+  };
+}
+
+export const VERIFY_AND_REPORT_FIX_TOOL = {
+  name: 'verify_and_report_fix',
+  description:
+    "Layer-abstracted round-trip verification helper. Computes the state-machine next_action from a recipe's current round-trip state (passed via `current_state`, typically the contents of `src/layer{1,2,3}_*/<slug>/roundtrip.json` against the roundtrip.schema.json shape) and returns the commands the round-trip skill should run next. Bridges Path A (Layer 1, browser-driven Playwright targeted runs) and Path B (Layer 2/3, branch-fix-verdict.yml workflow dispatch) under a single return shape so callers do not branch on layer. The `next_action` enum (`verify_unfixed` → `verify_fixed` → `open_vivarium_pr` → `open_fork_pr` → `complete`) drives the round-trip state machine end-to-end. SCAFFOLDING HELPER as of v0.1.x: the returned `commands[]` are executed by the caller, not by the MCP server. Use `verify_branch_fix` directly when you only need a Path A/B deep-link and not the state-machine layer.",
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      slug: {
+        type: 'string' as const,
+        pattern: '^[a-z0-9]+(-[a-z0-9]+)*$',
+        description:
+          "Kebab-case recipe slug (e.g. 'php-12167', 'bash-local-shadows-exit'). Same convention as Manifest v1's `slug`.",
+      },
+      fix_url: {
+        type: 'string' as const,
+        description:
+          'Public URL of the candidate fix source. Layer 1 only — forwarded to verify_branch_fix to build the Path A `?fix_url=` deep-link. Mutually exclusive with fix_source.',
+      },
+      fix_source: {
+        type: 'string' as const,
+        description:
+          'Inline candidate fix source. Layer 1 only — forwarded to verify_branch_fix to build the Path A `?fix=<base64>` deep-link. Mutually exclusive with fix_url. Max 4096 bytes.',
+      },
+      branch_image: {
+        type: 'string' as const,
+        description:
+          "Layer 2/3 only. GHCR tag of the contributor's branch-fix Docker image (e.g. 'ghcr.io/<user>/vivarium-<slug>:fix-issue-<n>'). Surfaced as a comment in the returned commands when present; substituted into the gh workflow run command in Phase 3.",
+      },
+      current_state: {
+        type: 'object' as const,
+        description:
+          "Current round-trip state for the slug, matching the roundtrip.schema.json shape. Pass the parsed contents of the recipe's roundtrip.json. Omit (or pass {}) for a fresh round-trip — the tool will return `next_action='verify_unfixed'`.",
+        additionalProperties: true,
+      },
+    },
+    required: ['slug'],
+  },
+} as const;

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -1,8 +1,10 @@
-// Surface-only type façade for the recipes index (v1) and the
-// Layer 2/3 verdict snapshot (Contract v1). Canonical JSON Schemas
+// Surface-only type façade for the recipes index (v1), the
+// Layer 2/3 verdict snapshot (Contract v1), and the per-recipe
+// round-trip state (schema_version 1). Canonical JSON Schemas
 // live at:
 //   https://aletheia-works.github.io/vivarium/api/recipes.schema.json
 //   https://aletheia-works.github.io/vivarium/spec/verdict.schema.json
+//   https://aletheia-works.github.io/vivarium/spec/roundtrip.schema.json
 
 export type Layer = 1 | 2 | 3;
 
@@ -21,6 +23,10 @@ export interface RecipeEntry {
   symptom?: string;
   severity?: string;
   tags?: string[];
+  // Round-trip state (optional, opt-in per recipe). Sourced from
+  // src/layer*/<slug>/roundtrip.json by generate-recipes-index.ts.
+  // Older bundled snapshots without this field stay readable.
+  roundtrip?: RoundtripState;
 }
 
 export interface RecipesIndex {
@@ -43,3 +49,57 @@ export interface VerdictSnapshot {
   // it to `evidence.stderr` at the lift boundary.
   stderr_tail: string;
 }
+
+// Per-recipe round-trip state (schema_version 1). Canonical schema:
+// docs/site/public/spec/roundtrip.schema.json. SSOT for the
+// upstream → reproduction → fix → verification → PR loop.
+
+export type RoundtripStatus =
+  | 'draft'
+  | 'verifying'
+  | 'verified'
+  | 'upstream_open'
+  | 'merged'
+  | 'blocked';
+
+export type VerdictSource = 'layer1-headless' | 'layer2-ghcr' | 'layer3-trace';
+
+export interface RoundtripVerdict {
+  verdict: Verdict;
+  captured_at: string;
+  source: VerdictSource;
+}
+
+export interface RoundtripFork {
+  owner: string;
+  repo: string;
+  branch: string;
+  image_tag?: string;
+}
+
+export interface RoundtripState {
+  schema_version: 1;
+  slug: string;
+  upstream_issue: string;
+  vivarium_pr?: string | null;
+  fork?: RoundtripFork | null;
+  upstream_pr?: string | null;
+  verdicts?: {
+    unfixed?: RoundtripVerdict;
+    fixed?: RoundtripVerdict;
+  };
+  status: RoundtripStatus;
+  updated_at: string;
+  notes?: string[];
+}
+
+// Next-action keys consumed by the round-trip skill's state machine.
+// Computed by `verify_and_report_fix` from the current RoundtripState
+// so the skill (and any future MCP client) can decide the next call
+// without re-implementing the state transitions.
+export type RoundtripNextAction =
+  | 'verify_unfixed'
+  | 'verify_fixed'
+  | 'open_fork_pr'
+  | 'open_vivarium_pr'
+  | 'complete';

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -96,10 +96,13 @@ export interface RoundtripState {
 // Next-action keys consumed by the round-trip skill's state machine.
 // Computed by `verify_and_report_fix` from the current RoundtripState
 // so the skill (and any future MCP client) can decide the next call
-// without re-implementing the state transitions.
+// without re-implementing the state transitions. `manual_intervention`
+// is the terminal action for `status: blocked` — callers must surface
+// the roundtrip.json#/notes reason and pause automation.
 export type RoundtripNextAction =
   | 'verify_unfixed'
   | 'verify_fixed'
   | 'open_fork_pr'
   | 'open_vivarium_pr'
+  | 'manual_intervention'
   | 'complete';

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -13,6 +13,7 @@ import { prepareFixCandidate } from '../src/tools/prepare_fix_candidate.ts';
 import { prepareNewRecipe } from '../src/tools/prepare_new_recipe.ts';
 import {
   computeNextAction,
+  parseUpstreamIssue,
   verifyAndReportFix,
 } from '../src/tools/verify_and_report_fix.ts';
 import { verifyBranchFix } from '../src/tools/verify_branch_fix.ts';
@@ -491,6 +492,66 @@ describe('computeNextAction (state machine)', () => {
   it('returns complete once status=merged regardless of other fields', () => {
     assert.equal(computeNextAction({ status: 'merged' }), 'complete');
   });
+
+  it('returns manual_intervention when status=blocked, even if verdicts look verified', () => {
+    // status: blocked is a tombstone — automation must stop until a
+    // human resolves it, regardless of how progressed other fields look.
+    assert.equal(
+      computeNextAction({
+        status: 'blocked',
+        vivarium_pr: 'https://github.com/aletheia-works/vivarium/pull/200',
+        verdicts: {
+          unfixed: {
+            verdict: 'reproduced',
+            captured_at: '2026-05-17T00:00:00Z',
+            source: 'layer1-headless',
+          },
+          fixed: {
+            verdict: 'unreproduced',
+            captured_at: '2026-05-17T00:10:00Z',
+            source: 'layer1-headless',
+          },
+        },
+      }),
+      'manual_intervention',
+    );
+  });
+});
+
+describe('parseUpstreamIssue', () => {
+  it('extracts owner/repo from a canonical github.com issue URL', () => {
+    assert.deepEqual(
+      parseUpstreamIssue('https://github.com/pandas-dev/pandas/issues/56679'),
+      { owner: 'pandas-dev', repo: 'pandas' },
+    );
+  });
+
+  it('also accepts the /pull/<n> form', () => {
+    assert.deepEqual(
+      parseUpstreamIssue('https://github.com/mpmath/mpmath/pull/984'),
+      { owner: 'mpmath', repo: 'mpmath' },
+    );
+  });
+
+  it('returns undefined for non-github hosts', () => {
+    assert.equal(
+      parseUpstreamIssue('https://gitlab.com/foo/bar/-/issues/1'),
+      undefined,
+    );
+  });
+
+  it('returns undefined for malformed URLs', () => {
+    assert.equal(parseUpstreamIssue('not a url'), undefined);
+    assert.equal(parseUpstreamIssue(''), undefined);
+    assert.equal(parseUpstreamIssue(undefined), undefined);
+  });
+
+  it('returns undefined for github URLs missing the issues/pull segment', () => {
+    assert.equal(
+      parseUpstreamIssue('https://github.com/pandas-dev/pandas'),
+      undefined,
+    );
+  });
 });
 
 describe('verify_and_report_fix', () => {
@@ -580,7 +641,52 @@ describe('verify_and_report_fix', () => {
     }
   });
 
-  it('verified + vivarium_pr + fork → next_action=open_fork_pr + draft gh pr create', async () => {
+  it('verified + vivarium_pr + fork → open_fork_pr targets upstream repo, not fork', async () => {
+    const r = await verifyAndReportFix({
+      slug: 'pandas-56679',
+      current_state: {
+        status: 'verified',
+        upstream_issue: 'https://github.com/pandas-dev/pandas/issues/56679',
+        vivarium_pr: 'https://github.com/aletheia-works/vivarium/pull/200',
+        fork: {
+          owner: 'JamBalaya56562',
+          repo: 'pandas',
+          branch: 'fix-issue-56679',
+        },
+        verdicts: {
+          unfixed: {
+            verdict: 'reproduced',
+            captured_at: '2026-05-17T00:00:00Z',
+            source: 'layer1-headless',
+          },
+          fixed: {
+            verdict: 'unreproduced',
+            captured_at: '2026-05-17T00:10:00Z',
+            source: 'layer1-headless',
+          },
+        },
+      },
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.next_action, 'open_fork_pr');
+      const ghCmd = r.commands.find((c) => c.startsWith('gh pr create'));
+      assert.ok(ghCmd, 'open_fork_pr commands should contain a gh pr create line');
+      // The PR's base repo MUST be the upstream owner/repo derived from
+      // upstream_issue, not the contributor's fork. --head still points
+      // at the fork's branch.
+      assert.match(ghCmd!, /--repo pandas-dev\/pandas/);
+      assert.match(ghCmd!, /--head JamBalaya56562:fix-issue-56679/);
+      assert.ok(
+        !/--repo JamBalaya56562\/pandas/.test(ghCmd!),
+        '--repo must NOT be the fork repo',
+      );
+      assert.match(ghCmd!, /--draft/);
+      assert.match(ghCmd!, /--label 'ai: generated'/);
+    }
+  });
+
+  it('open_fork_pr without upstream_issue surfaces a warning comment instead of executing', async () => {
     const r = await verifyAndReportFix({
       slug: 'pandas-56679',
       current_state: {
@@ -608,12 +714,36 @@ describe('verify_and_report_fix', () => {
     assert.equal(r.ok, true);
     if (r.ok) {
       assert.equal(r.next_action, 'open_fork_pr');
-      const ghCmd = r.commands.find((c) => c.startsWith('gh pr create'));
-      assert.ok(ghCmd, 'open_fork_pr commands should contain a gh pr create line');
-      assert.match(ghCmd!, /--repo JamBalaya56562\/pandas/);
-      assert.match(ghCmd!, /--head JamBalaya56562:fix-issue-56679/);
-      assert.match(ghCmd!, /--draft/);
-      assert.match(ghCmd!, /--label 'ai: generated'/);
+      assert.ok(
+        !r.commands.some((c) => c.startsWith('gh pr create')),
+        'should NOT emit gh pr create when upstream cannot be derived',
+      );
+      assert.ok(
+        r.commands.some((c) => /Cannot derive upstream repo/.test(c)),
+        'should explain why the command was suppressed',
+      );
+    }
+  });
+
+  it('blocked state → next_action=manual_intervention with stop-the-line commands', async () => {
+    const r = await verifyAndReportFix({
+      slug: 'pandas-56679',
+      current_state: {
+        status: 'blocked',
+        notes: ['upstream maintainer rejected the fix approach'],
+      },
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.next_action, 'manual_intervention');
+      assert.ok(
+        r.commands.some((c) => /status=blocked/.test(c)),
+        'commands should annotate that the round-trip is paused',
+      );
+      assert.ok(
+        !r.commands.some((c) => c.startsWith('gh ') || c.startsWith('sl ')),
+        'manual_intervention must NOT emit executable commands',
+      );
     }
   });
 

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -11,6 +11,10 @@ import { lookupVerdict } from '../src/tools/lookup_verdict.ts';
 import { matchError } from '../src/tools/match_error.ts';
 import { prepareFixCandidate } from '../src/tools/prepare_fix_candidate.ts';
 import { prepareNewRecipe } from '../src/tools/prepare_new_recipe.ts';
+import {
+  computeNextAction,
+  verifyAndReportFix,
+} from '../src/tools/verify_and_report_fix.ts';
 import { verifyBranchFix } from '../src/tools/verify_branch_fix.ts';
 
 const FIXTURE_INDEX = {
@@ -402,6 +406,229 @@ describe('verify_branch_fix', () => {
       assert.equal(r.path, 'B');
       assert.equal(r.layer, 3);
       assert.match(r.gh_command!, /-f slug=lost-update/);
+    }
+  });
+});
+
+describe('computeNextAction (state machine)', () => {
+  it('returns verify_unfixed when state is undefined (fresh round-trip)', () => {
+    assert.equal(computeNextAction(undefined), 'verify_unfixed');
+  });
+
+  it('returns verify_unfixed when only status=draft is present', () => {
+    assert.equal(computeNextAction({ status: 'draft' }), 'verify_unfixed');
+  });
+
+  it('returns verify_fixed once unfixed=reproduced is captured', () => {
+    assert.equal(
+      computeNextAction({
+        status: 'verifying',
+        verdicts: {
+          unfixed: {
+            verdict: 'reproduced',
+            captured_at: '2026-05-17T00:00:00Z',
+            source: 'layer1-headless',
+          },
+        },
+      }),
+      'verify_fixed',
+    );
+  });
+
+  it('returns open_vivarium_pr when both verdicts proper polarity and no vivarium_pr', () => {
+    assert.equal(
+      computeNextAction({
+        status: 'verified',
+        verdicts: {
+          unfixed: {
+            verdict: 'reproduced',
+            captured_at: '2026-05-17T00:00:00Z',
+            source: 'layer1-headless',
+          },
+          fixed: {
+            verdict: 'unreproduced',
+            captured_at: '2026-05-17T00:10:00Z',
+            source: 'layer1-headless',
+          },
+        },
+      }),
+      'open_vivarium_pr',
+    );
+  });
+
+  it('returns open_fork_pr once vivarium_pr is recorded', () => {
+    assert.equal(
+      computeNextAction({
+        status: 'verified',
+        vivarium_pr: 'https://github.com/aletheia-works/vivarium/pull/200',
+        verdicts: {
+          unfixed: {
+            verdict: 'reproduced',
+            captured_at: '2026-05-17T00:00:00Z',
+            source: 'layer1-headless',
+          },
+          fixed: {
+            verdict: 'unreproduced',
+            captured_at: '2026-05-17T00:10:00Z',
+            source: 'layer1-headless',
+          },
+        },
+      }),
+      'open_fork_pr',
+    );
+  });
+
+  it('returns complete once upstream_pr is opened', () => {
+    assert.equal(
+      computeNextAction({
+        status: 'upstream_open',
+        upstream_pr: 'https://github.com/mpmath/mpmath/pull/984',
+      }),
+      'complete',
+    );
+  });
+
+  it('returns complete once status=merged regardless of other fields', () => {
+    assert.equal(computeNextAction({ status: 'merged' }), 'complete');
+  });
+});
+
+describe('verify_and_report_fix', () => {
+  it('returns ok:false on missing slug', async () => {
+    const r = await verifyAndReportFix({ slug: '' });
+    assert.equal(r.ok, false);
+  });
+
+  it('returns ok:false on unknown slug', async () => {
+    const r = await verifyAndReportFix({ slug: 'nonexistent-recipe' });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /not found/);
+  });
+
+  it('Layer 1 + no state → next_action=verify_unfixed, path A, layer1_wasm roundtrip_path', async () => {
+    const r = await verifyAndReportFix({ slug: 'pandas-56679' });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.layer, 1);
+      assert.equal(r.path, 'A');
+      assert.equal(r.next_action, 'verify_unfixed');
+      assert.equal(
+        r.roundtrip_path,
+        'src/layer1_wasm/pandas-56679/roundtrip.json',
+      );
+      assert.ok(
+        r.commands.some((c) => c.includes('bun x playwright test')),
+        'layer 1 verify_unfixed commands should include playwright invocation',
+      );
+    }
+  });
+
+  it('Layer 2 + no state → next_action=verify_unfixed, path B, mise recipes:verify', async () => {
+    const r = await verifyAndReportFix({ slug: 'bash-local-shadows-exit' });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.layer, 2);
+      assert.equal(r.path, 'B');
+      assert.equal(r.next_action, 'verify_unfixed');
+      assert.equal(
+        r.roundtrip_path,
+        'src/layer2_docker/bash-local-shadows-exit/roundtrip.json',
+      );
+      assert.ok(
+        r.commands.some((c) =>
+          c.includes('mise run recipes:verify bash-local-shadows-exit'),
+        ),
+      );
+    }
+  });
+
+  it('Layer 3 + no state → roundtrip_path under layer3_thirdway', async () => {
+    const r = await verifyAndReportFix({ slug: 'lost-update' });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.layer, 3);
+      assert.equal(
+        r.roundtrip_path,
+        'src/layer3_thirdway/lost-update/roundtrip.json',
+      );
+    }
+  });
+
+  it('verified state without vivarium_pr → next_action=open_vivarium_pr + sl pr submit', async () => {
+    const r = await verifyAndReportFix({
+      slug: 'pandas-56679',
+      current_state: {
+        status: 'verified',
+        verdicts: {
+          unfixed: {
+            verdict: 'reproduced',
+            captured_at: '2026-05-17T00:00:00Z',
+            source: 'layer1-headless',
+          },
+          fixed: {
+            verdict: 'unreproduced',
+            captured_at: '2026-05-17T00:10:00Z',
+            source: 'layer1-headless',
+          },
+        },
+      },
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.next_action, 'open_vivarium_pr');
+      assert.ok(r.commands.some((c) => c === 'sl pr submit'));
+    }
+  });
+
+  it('verified + vivarium_pr + fork → next_action=open_fork_pr + draft gh pr create', async () => {
+    const r = await verifyAndReportFix({
+      slug: 'pandas-56679',
+      current_state: {
+        status: 'verified',
+        vivarium_pr: 'https://github.com/aletheia-works/vivarium/pull/200',
+        fork: {
+          owner: 'JamBalaya56562',
+          repo: 'pandas',
+          branch: 'fix-issue-56679',
+        },
+        verdicts: {
+          unfixed: {
+            verdict: 'reproduced',
+            captured_at: '2026-05-17T00:00:00Z',
+            source: 'layer1-headless',
+          },
+          fixed: {
+            verdict: 'unreproduced',
+            captured_at: '2026-05-17T00:10:00Z',
+            source: 'layer1-headless',
+          },
+        },
+      },
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.next_action, 'open_fork_pr');
+      const ghCmd = r.commands.find((c) => c.startsWith('gh pr create'));
+      assert.ok(ghCmd, 'open_fork_pr commands should contain a gh pr create line');
+      assert.match(ghCmd!, /--repo JamBalaya56562\/pandas/);
+      assert.match(ghCmd!, /--head JamBalaya56562:fix-issue-56679/);
+      assert.match(ghCmd!, /--draft/);
+      assert.match(ghCmd!, /--label 'ai: generated'/);
+    }
+  });
+
+  it('upstream_pr present → next_action=complete + empty commands', async () => {
+    const r = await verifyAndReportFix({
+      slug: 'pandas-56679',
+      current_state: {
+        status: 'upstream_open',
+        upstream_pr: 'https://github.com/pandas-dev/pandas/pull/12345',
+      },
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.next_action, 'complete');
+      assert.equal(r.commands.length, 0);
     }
   });
 });


### PR DESCRIPTION

Review of PR #250 surfaced four issues that would break next-phase
follow-ups even though Phase 1 CI is green. Three are now addressed
directly; the fourth (full ajv-based schema validation in the
generator) is intentionally deferred to Phase 3 in favour of minimal
mechanical checks that match this PR's scaffolding scope.

[P1] recipes.schema.json was rejecting recipeEntry.roundtrip under
  additionalProperties: false. Added an optional `roundtrip` field
  (typed as a plain object) with a description that points to
  roundtrip.schema.json for the inner shape. Deliberately keeps the
  inner unconstrained so the round-trip schema can evolve (verdict
  sources, status enum, fork shape) without forcing a lockstep
  recipes-index revision.

[P1] open_fork_pr was producing `gh pr create --repo <fork>` which
  would have routed the PR to the contributor's mirror, not upstream.
  Added parseUpstreamIssue to derive upstream owner/repo from
  roundtrip.json#/upstream_issue. The PR now correctly uses
  --repo <upstream> --head <fork>:<branch>. If upstream_issue is
  missing or malformed, the command is suppressed and a warning
  comment surfaces instead — automation never silently mis-targets.

[P2] computeNextAction was treating `status: blocked` as if it were
  any other in-progress status, advancing to verify_fixed /
  open_fork_pr from verdict fields alone. Added a `manual_intervention`
  enum value to RoundtripNextAction and a short-circuit at the top
  of computeNextAction. manual_intervention emits stop-the-line
  commentary commands — no gh / sl executables.

[P2] loadRoundtripState in generate-recipes-index now mechanically
  rejects merges where slug ≠ directory name, or upstream_issue /
  status / updated_at are missing. Catches the most likely
  hand-edit mistakes before they reach the public catalogue. Full
  ajv-based schema validation is deferred to Phase 3 where the
  verify_and_report_fix tool consumes the file directly.

Tests +8 (78 pass / 0 fail total): parseUpstreamIssue (canonical
issue URL, /pull/ form, non-github, malformed, missing path
segment), blocked → manual_intervention, open_fork_pr upstream
repo derivation, open_fork_pr without upstream_issue suppression.

Verification:
- mise run mcp:test → 78 pass / 0 fail.
- mise run mcp:build → tsc clean.
- mise run recipes:index → recipes.json + projects.json idempotent
  (no diff), validator generation still clean.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/251).
* __->__ #251
* #250