### PR TITLE
feat(mcp): phase 2 input side + retire _context/ memo system

### DIFF
--- a/.claude/rules/recipe-authoring.md
+++ b/.claude/rules/recipe-authoring.md
@@ -215,8 +215,7 @@ maintainer host with:
 - Linux/x86_64 (rr does not support arm64, Windows, or macOS).
 - A CPU with an exposed PMU (Intel/AMD bare metal, or VMs that
   pass through performance counters — Hyper-V / WSL2 / GHA hosted
-  Ubuntu **do not** qualify; see ADR-0011 in
-  `_context/decisions/`).
+  Ubuntu **do not** qualify).
 - CPUID faulting enabled in the kernel (Intel Ivy Bridge+ or
   modern AMD with stock recent Linux meets this).
 
@@ -282,9 +281,10 @@ Layer 2. CI does not regenerate it.
   `docs/site/public/api/projects.json` are tracked but generated.
   Always run the generators before committing; never hand-edit.
 - **Recipe selection policy.** Must already match
-  `_context/strategy/issue_selection_policy.md` (gitignored,
-  local-only) before authoring. Selection criteria are not
-  re-litigated at PR time.
+  [`upstream-issue-selection.md`](upstream-issue-selection.md)
+  (Vivarium-internal operating rule, auto-loaded by Claude Code
+  for the same paths as this checklist). Selection criteria are
+  not re-litigated at PR time.
 
 ## When this checklist is wrong
 

--- a/.claude/rules/upstream-issue-selection.md
+++ b/.claude/rules/upstream-issue-selection.md
@@ -1,0 +1,171 @@
+---
+description: Vivarium-internal operating rule for picking which upstream issues to reproduce. NOT a public Vivarium policy — visitors using Vivarium as a tool follow their own selection criteria; this file describes how the maintainers decide. Auto-loads when Claude works on the upstream-search MCP tool, the scaffold-recipe-from-issue skill, or any recipe directory.
+paths:
+  - "packages/mcp-server/src/tools/search_upstream_issues.ts"
+  - "packages/mcp-server/src/tools/prepare_new_recipe.ts"
+  - ".claude/skills/scaffold-recipe-from-issue/**"
+  - "src/layer1_wasm/**"
+  - "src/layer2_docker/**"
+  - "src/layer3_thirdway/**"
+---
+
+# Upstream-issue selection — Vivarium operating preferences
+
+> Path-scoped rule: this file auto-loads when Claude Code works on
+> the upstream-search MCP tool, the scaffold-recipe-from-issue
+> skill, or any recipe directory under `src/layer*_*/`. It is NOT
+> loaded for unrelated work.
+>
+> **Vivarium-internal operating rule for picking which upstream issues
+> to reproduce. NOT a public Vivarium policy**: visitors using
+> Vivarium as a tool have their own goals, and this file does not
+> constrain them. The MCP server enforces only the slug regex; this
+> file describes how the maintainers decide.
+
+---
+
+## Filters (AND)
+
+A candidate upstream issue is in scope only when all six checks
+below pass:
+
+### 1. Latest version reproducible
+
+The bug still reproduces against the upstream project's current
+release. Old-only reproductions are out of scope — the goal is
+"what's hurting upstream right now", not historical bug
+preservation.
+
+Carve-out: a reproduction can pin to a specific buggy version
+(language / library) when the bug-firing version is what matters,
+provided the bug still triggers on that version's latest release.
+
+### 2. No related PR yet
+
+If a PR already exists for the issue (linked via GitHub's
+`linked:pr` relation), skip — someone is already working on it.
+Overriding in-flight work does not grow the merged-fix count.
+
+`search_upstream_issues` applies this server-side via the
+`-linked:pr` query qualifier in strict mode.
+
+### 3. Bug, not feature request
+
+Vivarium's verdict semantics (YES / NO) match bug reproduction.
+Feature requests ("this should exist") map poorly to that shape.
+
+### 4. No equivalent in-house tooling on the upstream side
+
+Some ecosystems run automated reproduction bots that cover the
+same ground; Vivarium's added value is low there. Pass those repos
+to `search_upstream_issues` via the `exclude_repos` argument:
+
+```jsonc
+{
+  "selection_policy": "strict",
+  "exclude_repos": ["oven-sh/bun"]
+}
+```
+
+This is a **"complementary tooling exists in this ecosystem"**
+judgement — not a quality assessment. The MCP server itself ships
+no built-in list, and the entry above is an example, not a
+maintained registry.
+
+### 5. Layer 2 build budget tractable
+
+Branch-fix verification needs the contributor to build an upstream
+fix as a Docker image. If that build cannot finish on a free-tier
+CI runner or a developer-class machine (a few GB of RAM, tens of
+minutes), Layer 2 is the wrong tier. Options:
+
+- **Layer 1 carve-out**: if the bug reproduces in WASM (Pyodide,
+  Ruby.wasm, php-wasm), use Layer 1 instead.
+- **PAT-push branch-fix**: for the rare case where Layer 2 is the
+  only option and the build is heavy, use the
+  `mise run branch-fix:publish` path — the contributor builds
+  locally and pushes to GHCR.
+
+Recipe-side images that wrap a pre-built upstream image
+(`python:3.13-slim`, `node:26-slim`, etc.) are not affected — only
+the branch-fix image build matters here.
+
+### 6. Project is actively maintained
+
+No PRs land = no path to the merged outcome the core loop needs.
+Concrete check (calibrate the threshold to your own workflow):
+
+```bash
+gh pr list --repo <owner>/<repo> \
+  --state merged \
+  --search "merged:>=$(date -d '90 days ago' +%Y-%m-%d)" \
+  --json number,author \
+  --limit 50 \
+  | jq '[.[] | select(.author.is_bot == false)] | length'
+```
+
+The maintainers running this rule use **≥ 5 human-merged PRs in 90
+days** as the threshold, cached 30 days per project. Pick a
+number that suits the upstream you target — a niche tool moves
+slower than a major runtime, and both can be healthy.
+
+Also scan the README, pinned issues, and discussions for explicit
+maintainer signals ("on hiatus", "looking for new maintainer",
+"unmaintained"). Those override the count.
+
+If an upstream you already authored a recipe against later goes
+dormant: keep the recipe in the catalogue (it still documents a
+real bug), but do not add new ones from that project.
+
+---
+
+## Ranking among candidates
+
+Multiple issues passing all six filters → prefer the project with
+the **highest activity score** (90-day human merge count). Star
+counts and ecosystem popularity are tiebreakers only — popular
+projects often have backlogged PR queues, while smaller actively-
+maintained projects land contributions faster, which matters more
+for the core loop's merge-time KPI.
+
+Tiebreaking on near-equal activity scores:
+
+1. More recent default-branch commit wins.
+2. Then ecosystem reach (e.g. wheel / image availability for
+   Layer 1 carve-out feasibility).
+3. Then maintainer responsiveness signals from recent PR threads
+   (review latency, willingness to accept external contributions).
+
+Vivarium-side ergonomics (recipe authoring effort, Layer 1 vs
+Layer 2 fit) can override ranking — author the easier recipe first
+when the activity scores tie.
+
+---
+
+## What this file is NOT
+
+- **Not a Vivarium contract or guarantee.** Vivarium ships the tool
+  (MCP server, skill, CI scaffolding); the policy here is one
+  workflow for using it.
+- **Not enforced by the MCP server.** `search_upstream_issues` has
+  a generic `selection_policy` mode (`strict` adds `-linked:pr` and
+  applies caller-supplied `exclude_repos`; `permissive` does
+  neither) and ships no built-in skip list or hard-coded
+  thresholds.
+- **Not a public stance on listed projects.** Any `exclude_repos`
+  entry reflects a "complementary tooling exists in this
+  ecosystem" judgement, not a quality assessment.
+- **Not loaded for visitors.** Vivarium documentation (`docs/site/`)
+  intentionally omits this rule. Visitors using Vivarium as a tool
+  have their own goals; this file is for the maintainers' workflow
+  only.
+
+---
+
+## When this rule is wrong
+
+If a check above diverges from how recipes are actually authored
+today (a new exception path, a tooling change, an upstream
+changing how it is maintained), update this file in the same PR
+that introduces the divergence. Path-scoped rules are load-bearing
+for the next agent.

--- a/.claude/skills/scaffold-recipe-from-issue/SKILL.md
+++ b/.claude/skills/scaffold-recipe-from-issue/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: scaffold-recipe-from-issue
+description: Scaffold a new Vivarium reproduction recipe from an upstream GitHub issue URL (or owner/repo + issue number). Use when the user provides an upstream issue and asks to "reproduce it in Vivarium", "make a Layer N recipe for", "scaffold a recipe for", or similar phrasing. The skill calls the search_upstream_issues MCP tool to confirm the issue is reachable and (by default) has no linked PR, calls prepare_new_recipe to get the slug and scaffold commands, runs `mise run recipes:new` for Layer 2 (or guides copy-from-existing for Layer 1/3), and writes the initial roundtrip.json (status=draft) per the round-trip schema. Does NOT implement the reproduction itself — that is the user's next step. Read-only against the upstream issue; never auto-commits.
+---
+
+# scaffold-recipe-from-issue
+
+Scaffold a new Vivarium reproduction recipe end-to-end from an upstream
+GitHub issue. Phase 2 of the round-trip automation: input side.
+
+## When to invoke
+
+The user provides an upstream issue (URL, or `<owner>/<repo>` + issue
+number) and asks to:
+
+- "make a Layer N recipe for <issue>"
+- "reproduce <upstream issue URL> in Vivarium"
+- "scaffold a recipe for <project>#<issue>"
+- equivalents in Japanese ("〜の再現レシピを作って" etc.)
+
+Do NOT invoke for issues filed against the Vivarium repository itself —
+those are tracked separately and do not need round-trip scaffolding.
+
+## Inputs needed
+
+Confirm these are known before starting; ask if missing:
+
+1. **Upstream issue identifier** — URL like
+   `https://github.com/nodejs/node/issues/63041`, or `<owner>/<repo>` +
+   issue number.
+2. **Target layer** — 1 (WASM in-browser), 2 (Docker), or 3 (record-
+   replay). Default 2 unless the bug is clearly browser-runnable
+   (Layer 1) or replay-required (Layer 3).
+3. **One-line bug title** — used as the README H1 and the scaffold
+   command argument.
+4. **Layer 2 only — Docker base image** — e.g. `node:26-slim`.
+
+## Steps
+
+### 0. Pre-flight checks (caller's discretion)
+
+Before scaffolding, run whatever sanity checks your workflow calls
+for. Common ones:
+
+- **Is the upstream project actively maintained?** Recent commits to
+  the default branch, recent PR merges by humans, no "looking for new
+  maintainer" / "unmaintained" notice in the README. If the project
+  looks dormant, scaffolding a recipe whose upstream PR will never
+  land is wasted effort — stop and tell the user.
+- **Does the bug still reproduce on the project's latest release?**
+  If the bug was fixed upstream after the issue was filed, there is
+  nothing left to reproduce.
+- **Is the bug actually a bug?** Feature requests are out of scope
+  for this skill.
+
+The exact thresholds (how recent, how many merges) are up to you. This
+skill does not enforce any.
+
+### 1. Verify the specific issue (exact, by number)
+
+Use `gh issue view` directly against the issue number — search-based
+verification is unreliable because title-keyword matching and limits
+can drop a real issue from the result set.
+
+```bash
+gh issue view <issue-number> --repo <owner>/<repo> \
+  --json state,title,body,labels,closedByPullRequestsReferences
+```
+
+Confirm before continuing:
+
+- **`state` is `OPEN`.** Closed issues are out of scope.
+- **The body describes a reproducible bug.** Not a feature request.
+- **`closedByPullRequestsReferences` is empty.** A non-empty array
+  means an upstream PR is already in flight to close this issue;
+  skip and tell the user (per the upstream-issue-selection rule,
+  filter §2). On older gh versions where that field is unavailable,
+  inspect the issue page in a browser to confirm no linked PR.
+
+### 1b. (Optional) Browse adjacent candidates in the same repo
+
+If the user gave you a project but no specific issue number — i.e.
+you need to surface candidates rather than verify a known one — use
+the `search_upstream_issues` MCP tool:
+
+```jsonc
+{
+  "tool": "search_upstream_issues",
+  "args": {
+    "repo": "<owner>/<repo>",
+    "selection_policy": "strict",
+    "limit": 10,
+    "exclude_repos": []  // pass your own exclusions if any
+  }
+}
+```
+
+Strict mode applies GitHub's `-linked:pr` server-side and any
+caller-supplied `exclude_repos` filter. This is a ranking aid for
+"what should I look at next?" — NOT a substitute for the exact
+`gh issue view` check above on a specific issue number.
+
+### 2. Prepare scaffolding artefacts
+
+Call the `prepare_new_recipe` MCP tool:
+
+```jsonc
+{
+  "tool": "prepare_new_recipe",
+  "args": {
+    "project": "<project>",      // e.g. "node"
+    "issue":   <issue_number>,   // e.g. 63041
+    "title":   "<one-line title>",
+    "layer":   1 | 2 | 3,
+    "base_image": "<docker image, layer 2 only>"
+  }
+}
+```
+
+The tool returns:
+
+- `slug` — `<project>-<issue>` (validated against the slug regex).
+- `scaffold_command` — for Layer 2, the exact `mise run recipes:new`
+  invocation to run. For Layer 1/3, a comment directing copy-from-
+  existing.
+- `verify_command` — the recipe verifier (Layer 2 only today).
+- `recipe_facets_row` — append (after filling in real values) to
+  `docs/site/_data/recipe-facets.json`.
+- `projects_row` — append to `docs/site/_data/projects.json` ONLY if
+  this is the project's first recipe.
+- `roundtrip_init` — the JSON payload to write to `roundtrip_path`.
+- `roundtrip_path` — the canonical relative path for the new
+  roundtrip.json.
+- `next_steps` — sequenced checklist for the user.
+
+### 3. Run the scaffold command
+
+**Layer 2:**
+
+```bash
+# Use the exact scaffold_command from prepare_new_recipe.
+mise run recipes:new -- <project> <issue> "<title>" --base <image>
+```
+
+**Layer 1 / Layer 3:** copy from an existing recipe in the same layer
+(e.g. `src/layer1_wasm/pandas-56679/` for a Pyodide recipe). The
+scaffold command from `prepare_new_recipe` is a comment for these
+layers — there is no scaffolder yet.
+
+### 4. Write the initial roundtrip.json
+
+Write the file at `roundtrip_path` (returned by `prepare_new_recipe`)
+with the `roundtrip_init` payload. The payload validates against
+`docs/site/public/spec/roundtrip.schema.json` (schema_version 1) and
+starts in `status: draft`.
+
+Sapling tracks the file automatically once `sl addremove` runs at PR
+time.
+
+### 5. Report next steps to the user
+
+Hand the user the `next_steps` array from `prepare_new_recipe`. The
+skill ENDS here. The actual reproduction implementation, verdict
+capture, and PR opening are subsequent steps the user (or the
+`/round-trip` skill, when Phase 5 lands) drives.
+
+## Guardrails
+
+- **Read-only against the upstream issue.** Do not add comments, set
+  labels, close, or otherwise modify the upstream issue. `gh issue
+  view` for reading is fine; `gh issue comment` is not.
+- **No auto-commit.** The recipe directory contains TODO stubs from
+  the scaffolder; the user fills them in. Committing scaffold output
+  as-is is a defect.
+- **No PR opening.** Phase 4 handles fork PR creation; Phase 2 stops
+  at "recipe directory + roundtrip.json on disk".
+- **Layer 2 build weight.** If reproducing the bug requires building
+  a particularly heavy upstream (e.g. a browser engine, an LLVM-class
+  project), a normal CI runner may not finish the branch-fix image
+  build in time. In that case, walk the user through the
+  `mise run branch-fix:publish` PAT-push path before they invest in
+  the recipe.
+
+## References
+
+- `.claude/rules/recipe-authoring.md` — operational checklist for
+  recipe authoring (slug rules, data files, layer specifics).
+- `docs/site/public/spec/roundtrip.schema.json` — canonical shape of
+  the roundtrip.json this skill writes.

--- a/.gitignore
+++ b/.gitignore
@@ -140,9 +140,6 @@ temp/
 .aider*
 .cursor-server/
 
-# ─── Local-only docs (design/strategy memos) ───
-/_context/
-
 # ─── Test / coverage ─────────────────────────
 coverage/
 .coverage

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -53,9 +53,7 @@ exclude = [
 #   rspress pages, which trips MD041 even though the rendered page is
 #   well-formed.
 # - MD057 (relative-link-exists): false positives in this repo because
-#   we link `.md` paths that resolve to `.mdx` files in rspress, and
-#   to filenames that exist in `_context/` (gitignored from rumdl's
-#   POV).
+#   we link `.md` paths that resolve to `.mdx` files in rspress.
 disable = ["MD013", "MD033", "MD036", "MD041", "MD057"]
 
 respect-gitignore = true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,8 @@
 - **AI-delegated development.** Humans set direction and merge; AI agents
   implement, review, and iterate.
 - **Current phase: Phase 8.** Phases 0–7 are closed (see
-  [`docs/site/en/roadmap.mdx`](docs/site/en/roadmap.mdx) and
-  `_context/phase_summaries/` for what shipped).
-
-Deeper strategy context is in `_context/` (local-only, gitignored). Treat those
-documents as canonical when they conflict with anything here.
+  [`docs/site/en/roadmap.mdx`](docs/site/en/roadmap.mdx) for what
+  shipped, and the GitHub issue tracker for the active phase's plan).
 
 ## 2. Non-negotiable guardrails
 
@@ -116,27 +113,20 @@ vivarium/
 │   ├── layer2_docker/     # Layer 2 reproductions (Docker images, GHCR-published)
 │   ├── layer3_thirdway/   # Layer 3 reproductions (record-replay, etc.)
 │   └── external_examples/ # reference Manifest v1 fixtures, one per layer
-└── _context/              # gitignored: private strategy memos, handoffs, ADRs, drafts
 ```
 
 `src/` is reserved for reproduction recipes; runtime artefacts the
 project publishes (npm / JSR packages, future CLI, etc.) live under
 `packages/`.
 
-### 4.2 `docs/` vs `_context/`
+### 4.2 `docs/` directory
 
-- `docs/` — tracked. The rspress documentation app lives here; its
-  configuration, scripts, tests, package metadata, and lockfile sit at the
-  top of `docs/`. The site source itself lives under `docs/site/`: markdown
-  content, MDX-mounted UI components, global styles, hand-curated data
-  overlays, generated site-only modules, and public assets. Visitor-facing
-  pages and public machine-readable assets stay under `docs/site/`.
-- `_context/` — gitignored. Private strategy memos, chat handoffs,
-  half-formed drafts, and the project's Architecture Decision Records
-  (`_context/decisions/`). AI agents may *read* these freely for
-  context and *write* new notes here during exploration, but must
-  never propose moving content from `_context/` into `docs/` without
-  explicit human sign-off.
+The rspress documentation app lives here; its configuration, scripts,
+tests, package metadata, and lockfile sit at the top of `docs/`. The
+site source itself lives under `docs/site/`: markdown content, MDX-
+mounted UI components, global styles, hand-curated data overlays,
+generated site-only modules, and public assets. Visitor-facing pages
+and public machine-readable assets stay under `docs/site/`.
 
 ### 4.3 Source-control
 
@@ -257,12 +247,12 @@ When adding a new tool, pin it in `mise.toml` first.
 ### 4.10 Spec evolution policy
 
 Public specs (Contract v1, Manifest v1, Recipes index v1) follow a
-two-tier policy per ADR-0018:
+two-tier policy:
 
 | Change shape | Verdict |
 |---|---|
-| New **optional** field v1 consumers can ignore | Same-page **revision** — append to the revision-history footer with date and ADR reference; version literal stays `"v1"`. |
-| Rename, remove, type change, semantics change, optional → required | **vN+1** — new spec page + JSON Schema sibling + new ADR. Old spec page stays readable so consumers can dispatch on the version literal. |
+| New **optional** field v1 consumers can ignore | Same-page **revision** — append to the revision-history footer with date; version literal stays `"v1"`. |
+| Rename, remove, type change, semantics change, optional → required | **vN+1** — new spec page + JSON Schema sibling. Old spec page stays readable so consumers can dispatch on the version literal. |
 
 Every spec page carries its version literal in the file consumers
 read (`<meta name="vivarium-contract">`, `manifest = "v1"`,
@@ -271,38 +261,13 @@ feature-detect new optional surface.
 
 ### 4.11 Package distribution
 
-Per ADR-0019, runtime artefacts (Vivarium MCP today, future CLI /
-SDK) dual-publish to JSR (canonical) and npm (npx ergonomics) with
-OIDC trusted publishing + Sigstore provenance — no long-lived
-registry tokens. Tag form: `<package-name>-v<semver>`
+Runtime artefacts (Vivarium MCP today, future CLI / SDK) dual-
+publish to JSR (canonical) and npm (npx ergonomics) with OIDC
+trusted publishing + Sigstore provenance — no long-lived registry
+tokens. Tag form: `<package-name>-v<semver>`
 (e.g. `mcp-server-v0.1.0`).
 
-### 4.12 Architecture decision records
-
-Strategic and load-bearing decisions land as ADRs in
-`_context/decisions/NNNN-<short-slug>.md`, using
-`_context/decisions/_template.md` as the starting structure. Numbering
-is sequential and never re-used; superseded ADRs keep their original
-number with a `Status: Superseded by ADR-NNNN` note rather than being
-deleted. ADRs are gitignored — they are private working memos, not
-public docs. Reasoning that should be visitor-facing belongs in
-`docs/site/` (vision, architecture, roadmap, guide, spec).
-
-Write an ADR when:
-
-- The decision has meaningful alternatives a reasonable person could
-  prefer.
-- The decision affects multiple areas of the project (architecture,
-  infrastructure, workflow).
-- The decision is hard to reverse — changing it later costs more
-  than a normal refactor.
-- The decision is load-bearing on other decisions.
-
-A trivial style choice or a day-to-day implementation pick does not
-warrant an ADR; AGENTS.md or tooling configuration is the right home
-for those.
-
-### 4.13 Pre-PR local validation
+### 4.12 Pre-PR local validation
 
 **Run the matching CI checks locally before pushing.** Each PR triggers
 the workflows under `.github/workflows/` whose `paths:` filter matches
@@ -350,9 +315,10 @@ for the per-layer catalogue model.
 
 ## 6. When in doubt
 
-1. Re-read `_context/strategy/ambitious_integrated_platform_strategy.md` —
-   the project's north star.
-2. Re-read the latest `_context/phase_summaries/phase*_*.md` for the
-   most recent operational context.
-3. If still unclear, stop and ask the human. Deferring is cheaper than
-   unwinding a wrong decision on a lifelong project.
+1. Re-read [`docs/site/en/roadmap.mdx`](docs/site/en/roadmap.mdx) for
+   the project's current phase scope and what each prior phase
+   shipped.
+2. Check the active phase's plan on the GitHub issue tracker for
+   the concrete near-term work.
+3. If still unclear, stop and ask the human. Deferring is cheaper
+   than unwinding a wrong decision on a lifelong project.

--- a/docs/site/en/guide/glossary.mdx
+++ b/docs/site/en/guide/glossary.mdx
@@ -163,18 +163,9 @@ import {
       <dt id="phase"><strong>Phase</strong></dt>
       <dd>
         A coherent stretch of work measured in months-to-years, not sprints.
-        Each phase has an opener ADR, a close ADR, and a roadmap entry.
-        Closure is by partial-but-honest completion (precedent: ADR-0012),
-        not by exhaustive feature list. See <a href="/roadmap">Roadmap</a>.
-      </dd>
-
-      <dt id="adr"><strong>ADR</strong> (Architecture Decision Record)</dt>
-      <dd>
-        Numbered design memo recording <em>why</em> a decision was made,
-        what alternatives were considered, and what trade-offs were
-        accepted. Lives privately under <code>_context/decisions/</code> —
-        load-bearing for AI agents and future maintainers; not part of
-        the public docs surface.
+        Each phase has a roadmap entry that records its opener and closure.
+        Closure is by partial-but-honest completion, not by exhaustive
+        feature list. See <a href="/roadmap">Roadmap</a>.
       </dd>
 
       <dt id="layer-uniform"><strong>Layer-uniform</strong></dt>

--- a/docs/site/ja/guide/glossary.mdx
+++ b/docs/site/ja/guide/glossary.mdx
@@ -157,19 +157,9 @@ import {
       <dt id="phase"><strong>フェーズ (Phase)</strong></dt>
       <dd>
         スプリント単位ではなく、月から年単位で測る一貫したまとまりの作業。
-        各フェーズはオープナー ADR、クローズ ADR、ロードマップエントリを持つ。
-        クローズは網羅的な機能リストではなく、
-        部分的だが正直な完成（ADR-0012 の precedent）で行う。
+        各フェーズは、オープナーとクローズを記録するロードマップエントリを持つ。
+        クローズは網羅的な機能リストではなく、部分的だが正直な完成で行う。
         詳細は <a href="/vivarium/ja/roadmap">ロードマップ</a>。
-      </dd>
-
-      <dt id="adr"><strong>ADR</strong>（Architecture Decision Record / アーキテクチャ決定記録）</dt>
-      <dd>
-        <em>なぜ</em>その決定がなされたか、どの代替案が検討されたか、
-        どのトレードオフが受け入れられたかを記録する番号付き設計メモ。
-        <code>_context/decisions/</code> 以下にプライベートに置かれる——
-        AI エージェントと将来のメンテナーにとって load-bearing だが、
-        公開ドキュメントサーフェスの一部ではない。
       </dd>
 
       <dt id="layer-uniform"><strong>Layer-uniform（レイヤー一様）</strong></dt>

--- a/packages/mcp-server/jsr.json
+++ b/packages/mcp-server/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@aletheia-works/vivarium-mcp",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aletheia-works/vivarium-mcp",
-  "version": "0.1.2",
-  "description": "MCP server exposing the Vivarium reproduction catalogue (list_recipes, get_recipe, lookup_verdict, match_error, verify_branch_fix, verify_and_report_fix, prepare_new_recipe, prepare_fix_candidate) to AI agent clients (Claude Code, Cline, Cursor, Continue, etc.).",
+  "version": "0.1.4",
+  "description": "MCP server exposing the Vivarium reproduction catalogue (list_recipes, get_recipe, lookup_verdict, match_error, search_upstream_issues, verify_branch_fix, verify_and_report_fix, prepare_new_recipe, prepare_fix_candidate) to AI agent clients (Claude Code, Cline, Cursor, Continue, etc.).",
   "license": "Apache-2.0",
   "homepage": "https://github.com/aletheia-works/vivarium/tree/main/packages/mcp-server",
   "bugs": {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -35,6 +35,11 @@ import {
   type PrepareNewRecipeArgs,
 } from './tools/prepare_new_recipe.js';
 import {
+  SEARCH_UPSTREAM_ISSUES_TOOL,
+  searchUpstreamIssues,
+  type SearchUpstreamIssuesArgs,
+} from './tools/search_upstream_issues.js';
+import {
   VERIFY_AND_REPORT_FIX_TOOL,
   verifyAndReportFix,
   type VerifyAndReportFixArgs,
@@ -53,7 +58,7 @@ const SERVER_NAME = 'vivarium-mcp';
 // description / surface refinements) — the project is still pre-1.0
 // and `prepare_fix_candidate` is meaningful but fully opt-in, so a minor
 // bump would overstate the impact.
-const SERVER_VERSION = '0.1.2';
+const SERVER_VERSION = '0.1.4';
 
 export function createServer(): Server {
   const server = new Server(
@@ -67,6 +72,7 @@ export function createServer(): Server {
       GET_RECIPE_TOOL,
       LOOKUP_VERDICT_TOOL,
       MATCH_ERROR_TOOL,
+      SEARCH_UPSTREAM_ISSUES_TOOL,
       VERIFY_BRANCH_FIX_TOOL,
       VERIFY_AND_REPORT_FIX_TOOL,
       PREPARE_NEW_RECIPE_TOOL,
@@ -92,6 +98,11 @@ export function createServer(): Server {
           break;
         case 'match_error':
           payload = await matchError(args as unknown as MatchErrorArgs);
+          break;
+        case 'search_upstream_issues':
+          payload = await searchUpstreamIssues(
+            args as unknown as SearchUpstreamIssuesArgs,
+          );
           break;
         case 'verify_branch_fix':
           payload = await verifyBranchFix(

--- a/packages/mcp-server/src/tools/prepare_fix_candidate.ts
+++ b/packages/mcp-server/src/tools/prepare_fix_candidate.ts
@@ -1,8 +1,10 @@
 // Scaffolding helper for registering a fix-candidate spec on an
-// existing Layer 1 recipe (per ADR-0040 — fix-candidate.json + CI
-// wheel build). Returns the spec content and the gh / git command
-// bundle the agent should run; no git or network operations happen
-// inside the MCP server.
+// existing Layer 1 recipe — writes a `fix-candidate.json` next to
+// the recipe, and the CI deploy-docs workflow turns the linked fix
+// branch into a wheel built on the runner so the recipe page can run
+// it side-by-side with the released build. Returns the spec content
+// and the gh / git command bundle the agent should run; no git or
+// network operations happen inside the MCP server.
 
 import { getCatalogue } from '../catalogue.js';
 import type { RecipeEntry } from '../types.js';
@@ -39,7 +41,6 @@ interface PrepareFixCandidateOk {
   next_steps: string[];
   references: {
     rules: string;
-    adr: string;
     builder_script: string;
   };
 }
@@ -74,7 +75,7 @@ function buildPrBody(args: {
 }): string {
   const lines: string[] = [];
   lines.push(
-    `Register a fix-candidate spec for \`${args.slug}\` so the recipe page runs the fix branch's wheel side-by-side with the released build (per ADR-0040).`,
+    `Register a fix-candidate spec for \`${args.slug}\` so the recipe page runs the fix branch's wheel side-by-side with the released build.`,
   );
   lines.push('');
   lines.push(`- Recipe: <${args.recipeUrl}>`);
@@ -90,7 +91,7 @@ function buildPrBody(args: {
   lines.push('<summary>How fix-candidate verification works</summary>');
   lines.push('');
   lines.push(
-    "`fix-candidate.json` is a tracked one-screen JSON spec at the recipe root (introduced by ADR-0040 to keep wheel binaries out of the repo). On every push to `main`, the deploy-docs workflow:",
+    "`fix-candidate.json` is a tracked one-screen JSON spec at the recipe root; it keeps wheel binaries out of the repo while still letting the recipe page run the fix branch live. On every push to `main`, the deploy-docs workflow:",
   );
   lines.push('');
   lines.push('1. Reads each `src/layer1_wasm/<slug>/fix-candidate.json`.');
@@ -146,7 +147,7 @@ export async function prepareFixCandidate(
   if (entry.layer !== 1) {
     return {
       ok: false,
-      error: `fix-candidate verification (ADR-0040) is currently only wired up for Layer 1 recipes; "${slug}" is layer ${entry.layer}. Layers 2/3 use a different verification path — see verify_branch_fix.`,
+      error: `fix-candidate verification is currently only wired up for Layer 1 recipes; "${slug}" is layer ${entry.layer}. Layers 2/3 use a different verification path — see verify_branch_fix.`,
     };
   }
 
@@ -235,7 +236,6 @@ export async function prepareFixCandidate(
     references: {
       rules:
         'https://github.com/aletheia-works/vivarium/blob/main/.claude/rules/recipe-authoring.md',
-      adr: 'ADR-0040 — _context/decisions/0040-layer1-fix-candidate-wheels-from-ci.md (private; PR #213 carries the public-facing summary)',
       builder_script:
         'https://github.com/aletheia-works/vivarium/blob/main/scripts/build-layer1-wheels.sh',
     },
@@ -245,7 +245,7 @@ export async function prepareFixCandidate(
 export const PREPARE_FIX_CANDIDATE_TOOL = {
   name: 'prepare_fix_candidate',
   description:
-    "Register a fix-candidate spec on an existing Layer 1 (WASM/Pyodide) Vivarium recipe so the recipe page runs the fix branch's wheel side-by-side with the released build (per ADR-0040). SCAFFOLDING HELPER, not an execution engine — same pattern as prepare_new_recipe and verify_branch_fix. Given a recipe slug + fork repo URL + branch name, returns: the `fix-candidate.json` content the agent should write, the recommended commit subject + PR title, a ready-to-paste PR body (with the AI-authorship and ADR-0040 details tucked inside a `<details>` block), and the exact `gh` / `git` commands to fork-and-clone aletheia-works/vivarium, branch off main, drop the spec in, commit, push, and open the cross-repo PR. Use this immediately after opening an upstream fix branch (e.g. on a fork of mpmath/mpmath) when you want Vivarium to verify the fix live in-browser without waiting for upstream merge + a PyPI release. Validates the slug against the bundled catalogue and rejects non-Layer-1 recipes (Layers 2/3 use a different verification path — see verify_branch_fix).",
+    "Register a fix-candidate spec on an existing Layer 1 (WASM/Pyodide) Vivarium recipe so the recipe page runs the fix branch's wheel side-by-side with the released build. SCAFFOLDING HELPER, not an execution engine — same pattern as prepare_new_recipe and verify_branch_fix. Given a recipe slug + fork repo URL + branch name, returns: the `fix-candidate.json` content the agent should write, the recommended commit subject + PR title, a ready-to-paste PR body (with the AI-authorship and fix-candidate spec details tucked inside a `<details>` block), and the exact `gh` / `git` commands to fork-and-clone aletheia-works/vivarium, branch off main, drop the spec in, commit, push, and open the cross-repo PR. Use this immediately after opening an upstream fix branch (e.g. on a fork of mpmath/mpmath) when you want Vivarium to verify the fix live in-browser without waiting for upstream merge + a PyPI release. Validates the slug against the bundled catalogue and rejects non-Layer-1 recipes (Layers 2/3 use a different verification path — see verify_branch_fix).",
   inputSchema: {
     type: 'object' as const,
     properties: {

--- a/packages/mcp-server/src/tools/prepare_new_recipe.ts
+++ b/packages/mcp-server/src/tools/prepare_new_recipe.ts
@@ -4,7 +4,7 @@
 // steps). The MCP server returns the commands and metadata; the
 // agent's shell tool actually invokes mise.
 
-import type { Layer } from '../types.js';
+import type { Layer, RoundtripState } from '../types.js';
 
 export interface PrepareNewRecipeArgs {
   project?: string;
@@ -53,6 +53,13 @@ interface PrepareNewRecipeOk {
     layer_readme: string;
     selection_policy: string;
   };
+  // Initial round-trip state to write into
+  // src/layer<N>_*/<slug>/roundtrip.json after scaffolding. Validates
+  // against roundtrip.schema.json (schema_version 1). Caller (typically
+  // the scaffold-recipe-from-issue skill) is responsible for the write;
+  // the MCP server does no filesystem mutation itself.
+  roundtrip_init: RoundtripState;
+  roundtrip_path: string;
 }
 
 interface PrepareNewRecipeError {
@@ -68,6 +75,13 @@ export type PrepareNewRecipeResult =
 // Single-sourced as a literal here because the MCP package is published
 // independently and cannot import from docs/.
 const SLUG_REGEX = /^([a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*?)-(\d+)$/;
+
+// Mirror of LAYER_DIRNAME in verify_and_report_fix — keep in sync.
+const LAYER_DIRNAME: Record<Layer, string> = {
+  1: 'layer1_wasm',
+  2: 'layer2_docker',
+  3: 'layer3_thirdway',
+};
 
 // Default upstream owner/repo for common projects, mirroring the lookup
 // in docs/scripts/new-recipe.ts. Override via repo_owner.
@@ -200,6 +214,16 @@ export async function prepareNewRecipe(
           `Submit the PR.`,
         ];
 
+  const roundtripInit: RoundtripState = {
+    schema_version: 1,
+    slug,
+    upstream_issue: upstreamIssueUrl,
+    status: 'draft',
+    updated_at: new Date().toISOString(),
+    notes: ['scaffolded from upstream issue'],
+  };
+  const roundtripPath = `src/${LAYER_DIRNAME[layer]}/${slug}/roundtrip.json`;
+
   return {
     ok: true,
     slug,
@@ -216,8 +240,10 @@ export async function prepareNewRecipe(
         'https://github.com/aletheia-works/vivarium/blob/main/.claude/rules/recipe-authoring.md',
       layer_readme: `https://github.com/aletheia-works/vivarium/blob/main/src/layer${layer}_${layer === 1 ? 'wasm' : layer === 2 ? 'docker' : 'thirdway'}/README.md`,
       selection_policy:
-        'https://github.com/aletheia-works/vivarium (issue selection policy is in _context/strategy/issue_selection_policy.md, gitignored)',
+        'caller-defined — issue selection criteria vary by user workflow and are not enforced by the MCP server beyond the slug regex',
     },
+    roundtrip_init: roundtripInit,
+    roundtrip_path: roundtripPath,
   };
 }
 

--- a/packages/mcp-server/src/tools/search_upstream_issues.ts
+++ b/packages/mcp-server/src/tools/search_upstream_issues.ts
@@ -1,0 +1,330 @@
+// Upstream issue search helper. Wraps `gh search issues`. Strict mode
+// applies two filters: GitHub's standard `-linked:pr` qualifier (drops
+// issues that already have a related PR — these are usually already
+// being worked on upstream), and an optional caller-supplied
+// `exclude_repos` list (drops matches from repositories the caller
+// wants to skip). Permissive mode applies neither and surfaces
+// everything for manual triage.
+//
+// Vivarium ships no built-in exclusion list and no built-in activity
+// thresholds. Whether a repository is worth searching, what the
+// activity bar is, what counts as a "good" candidate — all of that is
+// up to the caller. This tool is a thin convenience over `gh`, not a
+// curated policy engine.
+
+import { spawnSync } from 'node:child_process';
+
+export interface SearchUpstreamIssuesArgs {
+  project?: string;
+  repo?: string;
+  query?: string;
+  state?: 'open' | 'closed';
+  limit?: number;
+  selection_policy?: 'strict' | 'permissive';
+  labels?: string[];
+  exclude_repos?: string[];
+}
+
+export interface SearchMatch {
+  repo: string;
+  number: number;
+  title: string;
+  url: string;
+  body_snippet: string;
+  posted_at: string;
+  labels: string[];
+  state: string;
+  // strict mode: always false (guaranteed by `-linked:pr` query qualifier).
+  // permissive mode: omitted (computing this per issue would require an
+  // extra `gh issue view --json linkedPullRequests` round-trip per match;
+  // callers that need it should issue that query themselves).
+  has_pr?: boolean;
+}
+
+interface SearchUpstreamIssuesOk {
+  ok: true;
+  count: number;
+  repo: string;
+  query: string;
+  selection_policy: 'strict' | 'permissive';
+  matches: SearchMatch[];
+  notes: string[];
+}
+
+interface SearchUpstreamIssuesError {
+  ok: false;
+  error: string;
+}
+
+export type SearchUpstreamIssuesResult =
+  | SearchUpstreamIssuesOk
+  | SearchUpstreamIssuesError;
+
+// Mirror of DEFAULT_REPO in prepare_new_recipe.ts — keep in sync. Lifted
+// to module scope so both tools resolve project → repo identically.
+const DEFAULT_REPO: Record<string, string> = {
+  node: 'nodejs/node',
+  cpython: 'python/cpython',
+  typescript: 'microsoft/TypeScript',
+  rust: 'rust-lang/rust',
+  pandas: 'pandas-dev/pandas',
+  numpy: 'numpy/numpy',
+  php: 'php/php-src',
+  ruby: 'ruby/ruby',
+  regex: 'rust-lang/regex',
+};
+
+function defaultRepoFor(project: string): string {
+  return DEFAULT_REPO[project] ?? `${project}/${project}`;
+}
+
+// Injectable for unit tests. Returns { status, stdout, stderr } so the
+// real impl and any stub agree on the contract — we never expose the
+// raw spawn result.
+export interface GhRunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+export type GhRunner = (args: string[]) => GhRunResult;
+
+const defaultGhRunner: GhRunner = (args) => {
+  const r = spawnSync('gh', args, { encoding: 'utf-8' });
+  return {
+    status: r.status,
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+  };
+};
+
+let ghRunner: GhRunner = defaultGhRunner;
+
+export function _setGhRunnerForTesting(runner: GhRunner | null): void {
+  ghRunner = runner ?? defaultGhRunner;
+}
+
+interface GhSearchIssue {
+  number: number;
+  title: string;
+  url: string;
+  body?: string;
+  labels?: Array<{ name?: string }>;
+  createdAt?: string;
+  state?: string;
+  repository?: { nameWithOwner?: string };
+}
+
+const BODY_SNIPPET_LIMIT = 500;
+
+function normalizeExclusions(input: string[] | undefined): string[] {
+  if (!Array.isArray(input)) return [];
+  return input.map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+export async function searchUpstreamIssues(
+  args: SearchUpstreamIssuesArgs,
+): Promise<SearchUpstreamIssuesResult> {
+  let repo = args.repo?.trim();
+  if (!repo) {
+    const project = args.project?.trim();
+    if (!project) {
+      return { ok: false, error: 'either project or repo is required' };
+    }
+    repo = defaultRepoFor(project);
+  }
+  if (!/^[^/\s]+\/[^/\s]+$/.test(repo)) {
+    return {
+      ok: false,
+      error: `repo must be of the form owner/repo (got "${repo}")`,
+    };
+  }
+
+  const state = args.state ?? 'open';
+  const limit = Math.min(Math.max(args.limit ?? 10, 1), 50);
+  const policy = args.selection_policy ?? 'strict';
+  const excludeRepos = normalizeExclusions(args.exclude_repos);
+
+  // Whole-repo short-circuit: strict policy + the search repo itself
+  // appears in exclude_repos → return empty without paying for gh.
+  if (policy === 'strict' && excludeRepos.includes(repo)) {
+    return {
+      ok: true,
+      count: 0,
+      repo,
+      query: '',
+      selection_policy: policy,
+      matches: [],
+      notes: [
+        `repo ${repo} is in the caller-supplied exclude_repos list; strict policy returns no matches. Pass selection_policy='permissive' to override.`,
+      ],
+    };
+  }
+
+  const queryParts: string[] = [];
+  if (args.query?.trim()) queryParts.push(args.query.trim());
+  if (policy === 'strict') queryParts.push('-linked:pr');
+  const queryString = queryParts.join(' ');
+
+  const ghArgs = [
+    'search',
+    'issues',
+    '--repo',
+    repo,
+    '--state',
+    state,
+    '--limit',
+    String(limit),
+    '--json',
+    'number,title,url,body,labels,createdAt,state,repository',
+  ];
+  if (Array.isArray(args.labels)) {
+    for (const label of args.labels) {
+      if (label.trim()) ghArgs.push('--label', label.trim());
+    }
+  }
+  // `--` separator so leading-dash qualifiers like `-linked:pr` are
+  // parsed by gh as the search query, not as flags. Without this,
+  // strict mode with no caller-supplied query fails immediately with
+  // `unknown shorthand flag: 'l' in -linked:pr`.
+  if (queryString) ghArgs.push('--', queryString);
+
+  let result: GhRunResult;
+  try {
+    result = ghRunner(ghArgs);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `failed to spawn gh: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim();
+    return {
+      ok: false,
+      error: `gh exit ${result.status}: ${stderr || '<no stderr>'}`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `failed to parse gh JSON output: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (!Array.isArray(parsed)) {
+    return {
+      ok: false,
+      error: `gh JSON output is not an array (got ${typeof parsed})`,
+    };
+  }
+
+  const issues = parsed as GhSearchIssue[];
+  const matches: SearchMatch[] = issues.map((item) => {
+    const itemRepo = item.repository?.nameWithOwner ?? repo;
+    const m: SearchMatch = {
+      repo: itemRepo,
+      number: item.number,
+      title: item.title,
+      url: item.url,
+      body_snippet: (item.body ?? '').slice(0, BODY_SNIPPET_LIMIT),
+      posted_at: item.createdAt ?? '',
+      labels: (item.labels ?? [])
+        .map((l) => l.name ?? '')
+        .filter((n) => n.length > 0),
+      state: item.state ?? state,
+    };
+    if (policy === 'strict') m.has_pr = false;
+    return m;
+  });
+
+  const notes: string[] = [];
+  let filtered = matches;
+  if (policy === 'strict') {
+    const before = matches.length;
+    filtered =
+      excludeRepos.length > 0
+        ? matches.filter((m) => !excludeRepos.includes(m.repo))
+        : matches;
+    if (filtered.length < before) {
+      notes.push(
+        `strict policy excluded ${before - filtered.length} match(es) from the caller-supplied exclude_repos list.`,
+      );
+    }
+    notes.push(
+      'strict policy: query included `-linked:pr` to exclude issues with related PRs. Any additional filtering (project activity, label conventions, etc.) is the caller’s responsibility.',
+    );
+  }
+
+  return {
+    ok: true,
+    count: filtered.length,
+    repo,
+    query: queryString,
+    selection_policy: policy,
+    matches: filtered,
+    notes,
+  };
+}
+
+export const SEARCH_UPSTREAM_ISSUES_TOOL = {
+  name: 'search_upstream_issues',
+  description:
+    "Search an upstream GitHub repository for issues that are candidates for Vivarium reproduction. Thin wrapper over `gh search issues`. Strict mode (default) applies two filters: GitHub's standard `-linked:pr` qualifier (drops issues with related PRs), and a caller-supplied `exclude_repos` list (drops matches whose repo is in that list). Permissive mode applies neither and surfaces everything for manual triage with `has_pr` left unset. Returns the first `limit` matches with body snippets, labels, and `posted_at` so the caller can rank further. This tool ships no built-in exclusion list and no activity thresholds — those are caller decisions.",
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      project: {
+        type: 'string' as const,
+        pattern: '^[a-z][a-z0-9]*(-[a-z][a-z0-9]*)*$',
+        description:
+          "Kebab-case project name (e.g. 'node', 'cpython'). Resolves to a default owner/repo via the same map used by prepare_new_recipe. Either project or repo must be supplied.",
+      },
+      repo: {
+        type: 'string' as const,
+        description:
+          "Full upstream `owner/repo` (e.g. 'nodejs/node'). Overrides the project's default mapping when both are passed. Either project or repo must be supplied.",
+      },
+      query: {
+        type: 'string' as const,
+        description:
+          "Optional extra search query appended to the gh search invocation (e.g. 'in:title parser', 'comments:>5'). Combined with the policy's automatic qualifiers.",
+      },
+      state: {
+        type: 'string' as const,
+        enum: ['open', 'closed'],
+        default: 'open',
+        description:
+          'Issue state. Defaults to open since closed issues are usually already resolved upstream.',
+      },
+      limit: {
+        type: 'integer' as const,
+        minimum: 1,
+        maximum: 50,
+        default: 10,
+        description: 'Maximum number of matches to return. Clamped to [1, 50].',
+      },
+      selection_policy: {
+        type: 'string' as const,
+        enum: ['strict', 'permissive'],
+        default: 'strict',
+        description:
+          "Selection policy. 'strict' (default) appends `-linked:pr` server-side and drops matches whose repo is in `exclude_repos`. 'permissive' surfaces everything for manual triage and leaves has_pr unset.",
+      },
+      labels: {
+        type: 'array' as const,
+        items: { type: 'string' as const },
+        description:
+          "Optional label filter. Each label is passed as `--label <label>` to gh, requiring ALL labels (gh's AND semantics).",
+      },
+      exclude_repos: {
+        type: 'array' as const,
+        items: { type: 'string' as const },
+        description:
+          "Optional list of `owner/repo` strings to exclude in strict mode. The tool itself ships no defaults — pass your own if your workflow has reasons to skip specific projects (e.g. they already operate equivalent tooling internally). Permissive mode ignores this list.",
+      },
+    },
+  },
+} as const;

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -12,6 +12,11 @@ import { matchError } from '../src/tools/match_error.ts';
 import { prepareFixCandidate } from '../src/tools/prepare_fix_candidate.ts';
 import { prepareNewRecipe } from '../src/tools/prepare_new_recipe.ts';
 import {
+  _setGhRunnerForTesting,
+  type GhRunResult,
+  searchUpstreamIssues,
+} from '../src/tools/search_upstream_issues.ts';
+import {
   computeNextAction,
   parseUpstreamIssue,
   verifyAndReportFix,
@@ -96,6 +101,7 @@ beforeEach(() => {
 afterEach(() => {
   globalThis.fetch = realFetch;
   _resetCacheForTesting();
+  _setGhRunnerForTesting(null);
 });
 
 describe('list_recipes', () => {
@@ -794,6 +800,22 @@ describe('prepare_new_recipe', () => {
         'feat(layer2): node-63041 reproduction (...)',
       );
       assert.ok(r.next_steps.length > 0);
+      // roundtrip_init for the scaffold-recipe-from-issue skill to write.
+      assert.equal(r.roundtrip_init.schema_version, 1);
+      assert.equal(r.roundtrip_init.slug, 'node-63041');
+      assert.equal(
+        r.roundtrip_init.upstream_issue,
+        'https://github.com/nodejs/node/issues/63041',
+      );
+      assert.equal(r.roundtrip_init.status, 'draft');
+      assert.match(r.roundtrip_init.updated_at, /^\d{4}-\d{2}-\d{2}T/);
+      assert.deepEqual(r.roundtrip_init.notes, [
+        'scaffolded from upstream issue',
+      ]);
+      assert.equal(
+        r.roundtrip_path,
+        'src/layer2_docker/node-63041/roundtrip.json',
+      );
     }
   });
 
@@ -813,6 +835,10 @@ describe('prepare_new_recipe', () => {
       assert.equal(
         r.upstream_issue_url,
         'https://github.com/python/cpython/issues/12345',
+      );
+      assert.equal(
+        r.roundtrip_path,
+        'src/layer1_wasm/cpython-12345/roundtrip.json',
       );
     }
   });
@@ -1049,5 +1075,242 @@ describe('prepare_fix_candidate', () => {
         'https://github.com/example-fork/pandas',
       );
     }
+  });
+});
+
+describe('search_upstream_issues', () => {
+  // Build a gh-runner stub returning a fixture issue list. Returns the
+  // last captured argv so tests can assert how gh was invoked.
+  function stubGh(
+    issues: unknown[],
+    overrides: Partial<GhRunResult> = {},
+  ): { capturedArgs: string[][] } {
+    const capturedArgs: string[][] = [];
+    _setGhRunnerForTesting((args) => {
+      capturedArgs.push(args);
+      return {
+        status: 0,
+        stdout: JSON.stringify(issues),
+        stderr: '',
+        ...overrides,
+      };
+    });
+    return { capturedArgs };
+  }
+
+  it('returns ok:false when neither project nor repo is passed', async () => {
+    const r = await searchUpstreamIssues({});
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /project or repo is required/);
+  });
+
+  it('rejects malformed repo shape', async () => {
+    const r = await searchUpstreamIssues({ repo: 'not-a-valid-repo' });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /owner\/repo/);
+  });
+
+  it('resolves project → default repo via the shared map', async () => {
+    const { capturedArgs } = stubGh([]);
+    const r = await searchUpstreamIssues({ project: 'node' });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.repo, 'nodejs/node');
+      // gh was called with --repo nodejs/node
+      const repoIdx = capturedArgs[0]!.indexOf('--repo');
+      assert.ok(repoIdx >= 0);
+      assert.equal(capturedArgs[0]![repoIdx + 1], 'nodejs/node');
+    }
+  });
+
+  it('strict policy short-circuits when the search repo is in exclude_repos (no gh call)', async () => {
+    const { capturedArgs } = stubGh([
+      {
+        number: 1,
+        title: 'x',
+        url: '',
+        body: '',
+        repository: { nameWithOwner: 'example-org/skip-me' },
+      },
+    ]);
+    const r = await searchUpstreamIssues({
+      repo: 'example-org/skip-me',
+      exclude_repos: ['example-org/skip-me'],
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.count, 0);
+      assert.equal(r.matches.length, 0);
+      assert.equal(capturedArgs.length, 0, 'gh must NOT be called for excluded repos');
+      assert.ok(r.notes.some((n) => /exclude_repos/.test(n)));
+    }
+  });
+
+  it('strict policy appends `-linked:pr` after a `--` separator', async () => {
+    // Without `--`, gh parses `-linked:pr` as a flag and fails with
+    // `unknown shorthand flag: 'l' in -linked:pr`. The separator
+    // forces the rest of argv to be treated as the search query.
+    const { capturedArgs } = stubGh([]);
+    await searchUpstreamIssues({ repo: 'nodejs/node' });
+    const argv = capturedArgs[0]!;
+    const sepIdx = argv.indexOf('--');
+    assert.ok(sepIdx >= 0, '`--` separator must appear in argv');
+    const afterSep = argv.slice(sepIdx + 1).join(' ');
+    assert.match(afterSep, /-linked:pr/);
+  });
+
+  it('permissive policy omits `-linked:pr` and leaves has_pr unset', async () => {
+    const { capturedArgs } = stubGh([
+      {
+        number: 42,
+        title: 'foo',
+        url: 'https://github.com/nodejs/node/issues/42',
+        body: 'snippet body',
+        labels: [{ name: 'bug' }],
+        createdAt: '2026-05-01T00:00:00Z',
+        state: 'open',
+        repository: { nameWithOwner: 'nodejs/node' },
+      },
+    ]);
+    const r = await searchUpstreamIssues({
+      repo: 'nodejs/node',
+      selection_policy: 'permissive',
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.selection_policy, 'permissive');
+      assert.equal(r.matches[0]!.has_pr, undefined);
+      // No `-linked:pr` qualifier anywhere in argv; the `--` separator
+      // also has nothing to guard, so it should be absent too.
+      const argv = capturedArgs[0]!;
+      assert.ok(
+        !argv.some((a) => /-linked:pr/.test(a)),
+        'permissive must NOT inject -linked:pr',
+      );
+      assert.ok(
+        !argv.includes('--'),
+        'permissive with no caller query must NOT emit a `--` separator',
+      );
+    }
+  });
+
+  it('parses gh issue JSON into SearchMatch shape', async () => {
+    stubGh([
+      {
+        number: 12345,
+        title: 'Intl.DateTimeFormat drops month',
+        url: 'https://github.com/nodejs/node/issues/12345',
+        body: 'long body '.repeat(100),
+        labels: [{ name: 'bug' }, { name: 'i18n' }],
+        createdAt: '2026-05-12T03:00:00Z',
+        state: 'open',
+        repository: { nameWithOwner: 'nodejs/node' },
+      },
+    ]);
+    const r = await searchUpstreamIssues({ project: 'node', limit: 1 });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.count, 1);
+      const m = r.matches[0]!;
+      assert.equal(m.repo, 'nodejs/node');
+      assert.equal(m.number, 12345);
+      assert.equal(m.posted_at, '2026-05-12T03:00:00Z');
+      assert.deepEqual(m.labels, ['bug', 'i18n']);
+      assert.equal(m.has_pr, false);
+      // body should be truncated to <= 500 chars
+      assert.ok(m.body_snippet.length <= 500);
+    }
+  });
+
+  it('strict policy drops cross-repo matches whose repository is in exclude_repos', async () => {
+    // Search runs against `example-org/main-repo` but a result is from
+    // `example-org/skip-me` (e.g. the user passed an `org:` query
+    // qualifier). Caller-supplied exclude_repos must drop it.
+    stubGh([
+      {
+        number: 1,
+        title: 'a',
+        url: 'https://github.com/example-org/main-repo/issues/1',
+        body: '',
+        repository: { nameWithOwner: 'example-org/main-repo' },
+      },
+      {
+        number: 2,
+        title: 'b',
+        url: 'https://github.com/example-org/skip-me/issues/2',
+        body: '',
+        repository: { nameWithOwner: 'example-org/skip-me' },
+      },
+    ]);
+    const r = await searchUpstreamIssues({
+      repo: 'example-org/main-repo',
+      exclude_repos: ['example-org/skip-me'],
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.count, 1);
+      assert.equal(r.matches[0]!.number, 1);
+      assert.ok(r.notes.some((n) => /excluded 1 match/.test(n)));
+    }
+  });
+
+  it('strict policy with empty exclude_repos returns matches unchanged', async () => {
+    stubGh([
+      {
+        number: 1,
+        title: 'a',
+        url: '',
+        body: '',
+        repository: { nameWithOwner: 'example-org/main-repo' },
+      },
+    ]);
+    const r = await searchUpstreamIssues({
+      repo: 'example-org/main-repo',
+      // exclude_repos omitted — Vivarium ships no defaults
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.count, 1);
+      // The exclude_repos note must NOT appear when no exclusions
+      // were supplied — Vivarium has no built-in list to mention.
+      assert.ok(
+        !r.notes.some((n) => /exclude_repos/.test(n)),
+        'no exclude_repos note when none supplied',
+      );
+    }
+  });
+
+  it('returns ok:false on gh non-zero exit', async () => {
+    stubGh([], { status: 1, stdout: '', stderr: 'auth failed' });
+    const r = await searchUpstreamIssues({ repo: 'nodejs/node' });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.match(r.error, /gh exit 1/);
+      assert.match(r.error, /auth failed/);
+    }
+  });
+
+  it('returns ok:false on malformed gh JSON output', async () => {
+    stubGh([], { stdout: 'not-json' });
+    const r = await searchUpstreamIssues({ repo: 'nodejs/node' });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /parse gh JSON/);
+  });
+
+  it('clamps limit to [1, 50]', async () => {
+    const { capturedArgs } = stubGh([]);
+    await searchUpstreamIssues({ repo: 'nodejs/node', limit: 9999 });
+    const limitIdx = capturedArgs[0]!.indexOf('--limit');
+    assert.equal(capturedArgs[0]![limitIdx + 1], '50');
+  });
+
+  it('forwards --label flags for each provided label', async () => {
+    const { capturedArgs } = stubGh([]);
+    await searchUpstreamIssues({
+      repo: 'nodejs/node',
+      labels: ['bug', 'good first issue'],
+    });
+    const labelCount = capturedArgs[0]!.filter((a) => a === '--label').length;
+    assert.equal(labelCount, 2);
   });
 });

--- a/scripts/build-layer1-wheels.sh
+++ b/scripts/build-layer1-wheels.sh
@@ -19,8 +19,6 @@
 # Skips silently if no `fix-candidate.json` files exist. Per-spec
 # failure halts the script (set -e) so CI surfaces the build error
 # instead of deploying a stale page.
-#
-# See ADR-0040 (`_context/decisions/0040-layer1-fix-candidate-wheels-from-ci.md`).
 
 set -euo pipefail
 shopt -s nullglob

--- a/src/external_examples/README.md
+++ b/src/external_examples/README.md
@@ -63,8 +63,4 @@ similar is helpful.
 
 ## Phase context
 
-Phase 5 sub-stream C per
-[ADR-0013](../../_context/decisions/0013-phase5-opener.md)
-(private memo). Manifest format locked at v1 by
-[ADR-0015](../../_context/decisions/0015-third-party-manifest-format.md)
-(private memo).
+Manifest format is locked at v1.

--- a/src/layer2_docker/bash-local-shadows-exit/README.md
+++ b/src/layer2_docker/bash-local-shadows-exit/README.md
@@ -78,8 +78,7 @@ x=$(failing_cmd) || handle_failure
 
 ## Verdict contract
 
-Per [ADR-0010](../../_context/decisions/0010-phase3-catalogue-model.md)
-and [`src/layer2_docker/README.md`](../README.md):
+Per [`src/layer2_docker/README.md`](../README.md):
 
 - The gallery surfaces the **last verdict CI captured** alongside
   this page (`reproduced` / `unreproduced`, image digest, timestamp).

--- a/src/layer2_docker/find-xargs-whitespace/README.md
+++ b/src/layer2_docker/find-xargs-whitespace/README.md
@@ -61,7 +61,7 @@ apostrophe, or a newline.
 
 ## Verdict contract
 
-Per [ADR-0010](../../_context/decisions/0010-phase3-catalogue-model.md):
+Per [`src/layer2_docker/README.md`](../README.md):
 
 - The gallery surfaces the **last verdict CI captured**.
 - The visitor's local `docker run` is the **live confirmation**.

--- a/src/layer2_docker/flock-is-advisory/README.md
+++ b/src/layer2_docker/flock-is-advisory/README.md
@@ -55,8 +55,7 @@ hold. The `flock(2)` man page is explicit:
 
 ## Verdict contract
 
-Per [ADR-0010](../../_context/decisions/0010-phase3-catalogue-model.md)
-and [`src/layer2_docker/README.md`](../README.md):
+Per [`src/layer2_docker/README.md`](../README.md):
 
 - The gallery surfaces the **last verdict CI captured** alongside
   this page (`reproduced` / `unreproduced`, image digest, timestamp).

--- a/src/layer2_docker/node-63041/README.md
+++ b/src/layer2_docker/node-63041/README.md
@@ -66,8 +66,7 @@ default calendar.
 
 ## Verdict contract
 
-Per [ADR-0010](../../../_context/decisions/0010-phase3-catalogue-model.md)
-and [`src/layer2_docker/README.md`](../README.md):
+Per [`src/layer2_docker/README.md`](../README.md):
 
 - The gallery surfaces the **last verdict CI captured** alongside
   this page (`reproduced` / `unreproduced`, image digest, timestamp).

--- a/src/layer2_docker/postgres-lost-update/README.md
+++ b/src/layer2_docker/postgres-lost-update/README.md
@@ -65,8 +65,7 @@ optimistic-concurrency check on the write.
 
 ## Verdict contract
 
-Per [ADR-0010 (private memo)](../../_context/decisions/0010-phase3-catalogue-model.md)
-and [`src/layer2_docker/README.md`](../README.md):
+Per [`src/layer2_docker/README.md`](../README.md):
 
 - The gallery card surfaces the **last verdict CI captured**
   alongside this page (`reproduced` / `unreproduced`, image digest,

--- a/src/layer3_thirdway/lost-update/README.md
+++ b/src/layer3_thirdway/lost-update/README.md
@@ -84,8 +84,7 @@ not substitutes.
 
 ## Verdict snapshot
 
-Per [ADR-0011 (private memo)](../../../_context/decisions/0011-phase4-first-vertical-rr.md):
-the Layer 3 catalogue degrades the verdict pipeline to a
+The Layer 3 catalogue degrades the verdict pipeline to a
 **maintainer-local** snapshot, committed alongside the recipe.
 
 GitHub Actions hosted runners cannot host either side of the


### PR DESCRIPTION

Phase 2 of the round-trip automation plan: the input side. Adds the
search_upstream_issues MCP tool that wraps `gh search issues`, the
scaffold-recipe-from-issue Claude Code skill that drives the issue
→ recipe-on-disk loop, and a roundtrip_init field on prepare_new_recipe
so the skill knows what to write into the recipe's roundtrip.json.
Lifts the maintainers' upstream-issue selection rule into a tracked,
path-scoped Claude Code rule so cloud Claude / fresh checkouts see
the same operating preferences the local maintainers do. Also retires
the gitignored _context/ memo system and the ADR-NNNN scaffolding
policy that lived inside it; near-term planning now happens on the
GitHub issue tracker.

New:

- packages/mcp-server/src/tools/search_upstream_issues.ts — MCP tool
  wrapping `gh search issues`. Strict mode appends GitHub's standard
  `-linked:pr` qualifier and applies a caller-supplied `exclude_repos`
  filter. Permissive mode applies neither. The tool ships no built-in
  exclusion list and no activity thresholds — those are caller
  decisions. gh runner is injectable for unit tests.

- .claude/skills/scaffold-recipe-from-issue/SKILL.md — Claude Code
  skill driving the input-side flow: pre-flight sanity checks
  (caller-defined), exact-issue verification via gh issue view,
  optional candidate browse via search_upstream_issues,
  prepare_new_recipe, mise run recipes:new, write the initial
  roundtrip.json (status: draft).

- .claude/rules/upstream-issue-selection.md — Vivarium-internal
  operating rule covering the six AND-filters for picking upstream
  issues and the activity-first ranking. Path-scoped: auto-loads
  only for the search/scaffold paths and the recipe directories.
  Explicitly framed as "not a public Vivarium policy" and "not a
  stance on listed projects".

Modified:

- packages/mcp-server/src/tools/prepare_new_recipe.ts — return value
  gains roundtrip_init (the validated RoundtripState payload with
  status: draft) and roundtrip_path. references.selection_policy
  text generalised to "caller-defined".

- packages/mcp-server/src/tools/prepare_fix_candidate.ts —
  references.adr field removed (was pointing at the now-retired
  _context/decisions/0040-... memo). The functional description
  is unchanged; the breaking shape change is fine because
  v0.1.3 has not been published yet.

- packages/mcp-server/src/server.ts — register the new tool;
  SERVER_VERSION 0.1.2 → 0.1.4 (one bump for phase 2, one for
  the references.adr removal).

- packages/mcp-server/{package,jsr}.json — version + description.

Repository hygiene — retire _context/ and the ADR convention:

- AGENTS.md drops §4.2 (docs/ vs _context/), §4.12 (Architecture
  decision records — write ADR when…), the layout-tree _context/
  line, the "Re-read _context/strategy/..." entries in §6, and
  every Per-ADR-NNNN reference in §4.10 and §4.11. §4.13
  (Pre-PR local validation) is renumbered to §4.12.

- .claude/rules/recipe-authoring.md drops the remaining
  _context/decisions/ link in the Layer 3 PMU preconditions
  paragraph.

- .rumdl.toml drops the _context/-aware MD057 comment.

- .gitignore drops the /_context/ entry.

- src/layer2_docker/{bash-local-shadows-exit,find-xargs-whitespace,
  flock-is-advisory,node-63041,postgres-lost-update}/README.md,
  src/layer3_thirdway/lost-update/README.md, and
  src/external_examples/README.md drop their ADR-NNNN dead-links
  into _context/decisions/.

- docs/site/{en,ja}/guide/glossary.mdx drops the ADR term entry
  and the "opener ADR / close ADR" phrasing from the Phase term.

- scripts/build-layer1-wheels.sh drops the trailing ADR-0040
  reference in the header comment.

Review fixes incorporated:

- [P1, blocker] search_upstream_issues now pushes the gh query past
  a `--` separator. Strict mode's default `-linked:pr` qualifier
  starts with a dash, so without the separator gh parses it as
  `-l inked:pr` and fails with `unknown shorthand flag: 'l' in
  -linked:pr`. The unit test was passing because the gh runner is
  stubbed; a new assertion now verifies the `--` separator appears
  in argv before `-linked:pr`, and the permissive-mode test
  asserts neither `--` nor `-linked:pr` is emitted when no query
  is supplied.

- [P2] scaffold-recipe-from-issue Step 1 is rewritten. Issue
  verification now goes through gh issue view <n> --json
  state,title,body,labels,closedByPullRequestsReferences, which
  checks the EXACT issue number and reads the linked-PR field
  directly from the issue. The earlier "title-keyword search,
  skip if missing from result set" heuristic was too lossy
  (title keywords, limits, and ranking could all drop a real
  issue). search_upstream_issues is repositioned as Step 1b
  (optional, for browsing adjacent candidates when no specific
  issue number is in hand) — not the verifier of a known number.

Rationale: tracking phase plans and design rationale in two parallel
places (gitignored _context/ + the public roadmap / PR descriptions)
got expensive without paying off — cloud Claude / fresh checkouts
could not see _context/ anyway, and the ADR-NNNN dead-links from
public READMEs into a private directory were a recurring confusion.
From this PR onward: phase-level plans live in GitHub issues, the
public roadmap is the canonical phase-shipment view, and any
operating preference that needs to be visible to AI agents lives as
a tracked path-scoped rule under .claude/rules/.

Verification:

- mise run mcp:test → 91 pass / 0 fail.
- mise run mcp:build → tsc clean.
- mise run recipes:index → mcpTools=9, recipes.json + projects.json
  idempotent.
- mise run docs:check → biome clean (54 files).
- mise run markdown:check → rumdl clean (41 files).

Phases 3-5 (Layer 1 headless execution, fork PR automation, /round-
trip mega-skill) land in follow-up PRs.
