### PR TITLE
feat(mcp): phase 3 — execute verdict capture for Layer 1 and Layer 2/3

### DIFF
--- a/packages/mcp-server/jsr.json
+++ b/packages/mcp-server/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@aletheia-works/vivarium-mcp",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aletheia-works/vivarium-mcp",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "MCP server exposing the Vivarium reproduction catalogue (list_recipes, get_recipe, lookup_verdict, match_error, search_upstream_issues, verify_branch_fix, verify_and_report_fix, prepare_new_recipe, prepare_fix_candidate) to AI agent clients (Claude Code, Cline, Cursor, Continue, etc.).",
   "license": "Apache-2.0",
   "homepage": "https://github.com/aletheia-works/vivarium/tree/main/packages/mcp-server",

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -58,7 +58,7 @@ const SERVER_NAME = 'vivarium-mcp';
 // description / surface refinements) — the project is still pre-1.0
 // and `prepare_fix_candidate` is meaningful but fully opt-in, so a minor
 // bump would overstate the impact.
-const SERVER_VERSION = '0.1.4';
+const SERVER_VERSION = '0.2.0';
 
 export function createServer(): Server {
   const server = new Server(

--- a/packages/mcp-server/src/tools/run_layer1_verdict.ts
+++ b/packages/mcp-server/src/tools/run_layer1_verdict.ts
@@ -1,0 +1,212 @@
+// Internal helper for `verify_and_report_fix` on Layer 1 recipes.
+// Drives the existing Playwright harness via a targeted `--grep
+// "verdict-capture: <slug>"` invocation, reads back the verdict JSON
+// the spec writes to `VERDICT_CAPTURE_OUTPUT`. Not exposed as an MCP
+// tool: callers go through `verify_and_report_fix` for the layer-
+// abstracted entrypoint.
+//
+// Phase 3 of the round-trip automation plan. Replaces the Phase 1
+// "return commands as strings" Layer 1 path with real execution.
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { Verdict } from '../types.js';
+
+export interface RunLayer1VerdictArgs {
+  slug: string;
+  fix_url?: string;
+  // Path to the Layer 1 workspace (the directory containing
+  // `playwright.config.ts`). Defaults to the relative path the
+  // monorepo uses today; pass an absolute path when the MCP server
+  // is launched from a different working directory.
+  workspace_path?: string;
+}
+
+export interface RunLayer1VerdictOk {
+  ok: true;
+  slug: string;
+  verdict: Verdict;
+  captured_at: string;
+  duration_ms: number;
+  fix_url: string | null;
+}
+
+export interface RunLayer1VerdictError {
+  ok: false;
+  error: string;
+  stderr_tail?: string;
+  duration_ms: number;
+}
+
+export type RunLayer1VerdictResult =
+  | RunLayer1VerdictOk
+  | RunLayer1VerdictError;
+
+// Injectable for unit tests. Returns { status, stdout, stderr } so the
+// real impl and any stub agree on the contract.
+export interface SpawnRunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export type SpawnRunner = (input: {
+  cwd: string;
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+}) => SpawnRunResult;
+
+const defaultSpawnRunner: SpawnRunner = ({ cwd, command, args, env }) => {
+  const r = spawnSync(command, args, {
+    cwd,
+    env,
+    encoding: 'utf-8',
+    // Playwright + Pyodide cold-start can sit in the 60-90 second range
+    // per case; the spec's own timeout is 75s. Hard-cap the spawn at
+    // 5 minutes so a hung Playwright child cannot wedge the MCP server.
+    timeout: 5 * 60 * 1000,
+  });
+  return {
+    status: r.status,
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+  };
+};
+
+let spawnRunner: SpawnRunner = defaultSpawnRunner;
+
+export function _setSpawnRunnerForTesting(runner: SpawnRunner | null): void {
+  spawnRunner = runner ?? defaultSpawnRunner;
+}
+
+// Injectable for unit tests; the real impl reads the file the
+// Playwright spec wrote at `VERDICT_CAPTURE_OUTPUT`.
+export type VerdictReader = (outputPath: string) => string;
+
+const defaultVerdictReader: VerdictReader = (p) => readFileSync(p, 'utf-8');
+
+let verdictReader: VerdictReader = defaultVerdictReader;
+
+export function _setVerdictReaderForTesting(
+  reader: VerdictReader | null,
+): void {
+  verdictReader = reader ?? defaultVerdictReader;
+}
+
+const DEFAULT_WORKSPACE_PATH = 'src/layer1_wasm';
+
+interface CapturedVerdict {
+  slug: string;
+  verdict: Verdict;
+  fix_url: string | null;
+  captured_at: string;
+}
+
+function isVerdict(value: unknown): value is Verdict {
+  return value === 'reproduced' || value === 'unreproduced';
+}
+
+export async function runLayer1Verdict(
+  args: RunLayer1VerdictArgs,
+): Promise<RunLayer1VerdictResult> {
+  const slug = args.slug?.trim();
+  if (!slug) {
+    return { ok: false, error: 'missing required argument: slug', duration_ms: 0 };
+  }
+
+  const workspacePath = args.workspace_path ?? DEFAULT_WORKSPACE_PATH;
+  const outputPath = join(
+    tmpdir(),
+    `vivarium-verdict-${slug}-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+  );
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    VERDICT_CAPTURE_OUTPUT: outputPath,
+  };
+  if (args.fix_url) env['PLAYWRIGHT_FIX_URL'] = args.fix_url;
+
+  const startedAt = Date.now();
+  const spawn = spawnRunner({
+    cwd: workspacePath,
+    command: 'bun',
+    args: ['run', 'test', '--grep', `verdict-capture: ${slug}`],
+    env,
+  });
+  const durationMs = Date.now() - startedAt;
+
+  if (spawn.status !== 0) {
+    // Best-effort cleanup of the tmp output if it exists.
+    try {
+      unlinkSync(outputPath);
+    } catch {
+      /* ignore */
+    }
+    return {
+      ok: false,
+      error: `playwright exited with status ${spawn.status}`,
+      stderr_tail: spawn.stderr.slice(-2000),
+      duration_ms: durationMs,
+    };
+  }
+
+  let raw: string;
+  try {
+    raw = verdictReader(outputPath);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `failed to read verdict output (${outputPath}): ${err instanceof Error ? err.message : String(err)}`,
+      stderr_tail: spawn.stderr.slice(-2000),
+      duration_ms: durationMs,
+    };
+  }
+
+  let parsed: CapturedVerdict;
+  try {
+    parsed = JSON.parse(raw) as CapturedVerdict;
+  } catch (err) {
+    return {
+      ok: false,
+      error: `verdict output is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      duration_ms: durationMs,
+    };
+  }
+
+  if (parsed.slug !== slug) {
+    return {
+      ok: false,
+      error: `verdict output slug "${parsed.slug}" does not match requested "${slug}"`,
+      duration_ms: durationMs,
+    };
+  }
+  if (!isVerdict(parsed.verdict)) {
+    return {
+      ok: false,
+      error: `verdict output contains unexpected verdict value "${parsed.verdict}"`,
+      duration_ms: durationMs,
+    };
+  }
+
+  // Real impl cleans up the tmp file; injected reader (tests) skip.
+  if (verdictReader === defaultVerdictReader) {
+    try {
+      unlinkSync(outputPath);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return {
+    ok: true,
+    slug,
+    verdict: parsed.verdict,
+    captured_at: parsed.captured_at ?? new Date().toISOString(),
+    duration_ms: durationMs,
+    fix_url: parsed.fix_url ?? null,
+  };
+}

--- a/packages/mcp-server/src/tools/run_layer23_verdict.ts
+++ b/packages/mcp-server/src/tools/run_layer23_verdict.ts
@@ -1,0 +1,419 @@
+// Internal helper for `verify_and_report_fix` on Layer 2/3 recipes.
+//
+// Two paths:
+//   - mode=unfixed → fetch the deployed `verdict.json` snapshot (the
+//     same snapshot the gallery already serves; no docker run needed).
+//   - mode=fixed   → dispatch `branch-fix-verdict.yml`, poll for the
+//     workflow run to complete, download the verdict artefact, and
+//     return the captured verdict.
+//
+// Not exposed as an MCP tool: callers go through `verify_and_report_fix`
+// for the layer-abstracted entrypoint.
+//
+// Phase 3 of the round-trip automation plan. Replaces the Phase 1
+// "return commands as strings" Layer 2/3 path with real execution.
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { fetchVerdictSnapshot, getCatalogue } from '../catalogue.js';
+import type { Verdict, VerdictSnapshot } from '../types.js';
+
+export interface RunLayer23VerdictArgs {
+  slug: string;
+  mode: 'unfixed' | 'fixed';
+  branch_image?: string;
+  expected_verdict?: Verdict;
+  poll_interval_ms?: number;
+  poll_timeout_ms?: number;
+  repo?: string;
+}
+
+export interface RunLayer23VerdictOk {
+  ok: true;
+  slug: string;
+  mode: 'unfixed' | 'fixed';
+  verdict: Verdict;
+  captured_at: string;
+  duration_ms: number;
+  source: 'deployed-snapshot' | 'workflow-artefact';
+  workflow_run_id?: number;
+}
+
+export interface RunLayer23VerdictError {
+  ok: false;
+  error: string;
+  duration_ms: number;
+  workflow_run_id?: number;
+}
+
+export type RunLayer23VerdictResult =
+  | RunLayer23VerdictOk
+  | RunLayer23VerdictError;
+
+export interface GhRunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export type GhRunner = (args: string[]) => GhRunResult;
+
+const defaultGhRunner: GhRunner = (args) => {
+  const r = spawnSync('gh', args, {
+    encoding: 'utf-8',
+    // Hard cap so a stuck `gh` cannot wedge the MCP server. The polling
+    // loop's own timeout governs the total wait; this is per-call.
+    timeout: 5 * 60 * 1000,
+  });
+  return {
+    status: r.status,
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+  };
+};
+
+let ghRunner: GhRunner = defaultGhRunner;
+
+export function _setGhRunnerForTesting(runner: GhRunner | null): void {
+  ghRunner = runner ?? defaultGhRunner;
+}
+
+// Snapshot fetcher injectable for tests; the real impl resolves the
+// slug's `verdict_url` from the catalogue and fetches Contract v1
+// JSON.
+export type SnapshotFetcher = (slug: string) => Promise<VerdictSnapshot | null>;
+
+const defaultSnapshotFetcher: SnapshotFetcher = async (slug) => {
+  const { recipes } = await getCatalogue();
+  const recipe = recipes.find((r) => r.slug === slug);
+  if (!recipe || !recipe.verdict_url) return null;
+  return fetchVerdictSnapshot(recipe.verdict_url);
+};
+
+let snapshotFetcher: SnapshotFetcher = defaultSnapshotFetcher;
+
+export function _setSnapshotFetcherForTesting(
+  fetcher: SnapshotFetcher | null,
+): void {
+  snapshotFetcher = fetcher ?? defaultSnapshotFetcher;
+}
+
+// Sleeper injectable so polling tests can advance time instantly.
+export type Sleeper = (ms: number) => Promise<void>;
+
+const defaultSleeper: Sleeper = (ms) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+let sleeper: Sleeper = defaultSleeper;
+
+export function _setSleeperForTesting(s: Sleeper | null): void {
+  sleeper = s ?? defaultSleeper;
+}
+
+const DEFAULT_REPO = 'aletheia-works/vivarium';
+const DEFAULT_POLL_INTERVAL_MS = 15_000;
+const DEFAULT_POLL_TIMEOUT_MS = 10 * 60 * 1000;
+// Sleep after dispatch before listing runs so the dispatched run has
+// time to register on the API side. 3 seconds is empirically enough
+// without making the happy path noticeably slower.
+const POST_DISPATCH_WAIT_MS = 3_000;
+
+function isVerdict(value: unknown): value is Verdict {
+  return value === 'reproduced' || value === 'unreproduced';
+}
+
+export async function runLayer23Verdict(
+  args: RunLayer23VerdictArgs,
+): Promise<RunLayer23VerdictResult> {
+  const slug = args.slug?.trim();
+  if (!slug) {
+    return { ok: false, error: 'missing required argument: slug', duration_ms: 0 };
+  }
+  if (args.mode !== 'unfixed' && args.mode !== 'fixed') {
+    return {
+      ok: false,
+      error: `invalid mode "${args.mode}" (must be 'unfixed' or 'fixed')`,
+      duration_ms: 0,
+    };
+  }
+
+  const startedAt = Date.now();
+
+  if (args.mode === 'unfixed') {
+    let snapshot: VerdictSnapshot | null;
+    try {
+      snapshot = await snapshotFetcher(slug);
+    } catch (err) {
+      return {
+        ok: false,
+        error: `snapshot fetch threw: ${err instanceof Error ? err.message : String(err)}`,
+        duration_ms: Date.now() - startedAt,
+      };
+    }
+    if (!snapshot) {
+      return {
+        ok: false,
+        error: `no deployed verdict snapshot for slug "${slug}" (Layer 1 recipes have no static verdict.json — use Layer 1 path instead)`,
+        duration_ms: Date.now() - startedAt,
+      };
+    }
+    return {
+      ok: true,
+      slug,
+      mode: 'unfixed',
+      verdict: snapshot.verdict,
+      captured_at: snapshot.captured_at,
+      duration_ms: Date.now() - startedAt,
+      source: 'deployed-snapshot',
+    };
+  }
+
+  // mode === 'fixed'
+  if (!args.branch_image?.trim()) {
+    return {
+      ok: false,
+      error: 'branch_image is required when mode=fixed',
+      duration_ms: 0,
+    };
+  }
+  const branchImage = args.branch_image.trim();
+  const expectedVerdict = args.expected_verdict ?? 'unreproduced';
+  if (!isVerdict(expectedVerdict)) {
+    return {
+      ok: false,
+      error: `expected_verdict must be 'reproduced' or 'unreproduced', got "${expectedVerdict}"`,
+      duration_ms: 0,
+    };
+  }
+
+  const repo = args.repo ?? DEFAULT_REPO;
+  const pollInterval = args.poll_interval_ms ?? DEFAULT_POLL_INTERVAL_MS;
+  const pollTimeout = args.poll_timeout_ms ?? DEFAULT_POLL_TIMEOUT_MS;
+
+  // Record the dispatch boundary BEFORE the gh call. The list step
+  // below filters runs to `createdAt >= dispatchBoundary - buffer`
+  // so we never pick up a pre-existing stale run for the same slug
+  // (which would have an old artefact and yield a misleading
+  // verdict). The 5-second buffer absorbs API clock drift between
+  // the local machine and GitHub.
+  const dispatchBoundary = Date.now();
+
+  // 1. Dispatch workflow.
+  const dispatch = ghRunner([
+    'workflow',
+    'run',
+    'branch-fix-verdict.yml',
+    '--repo',
+    repo,
+    '-f',
+    `slug=${slug}`,
+    '-f',
+    `branch_image=${branchImage}`,
+    '-f',
+    `expected_verdict=${expectedVerdict}`,
+  ]);
+  if (dispatch.status !== 0) {
+    return {
+      ok: false,
+      error: `gh workflow run failed: ${dispatch.stderr.trim() || '<no stderr>'}`,
+      duration_ms: Date.now() - startedAt,
+    };
+  }
+
+  // 2. Locate the run we just dispatched. Short sleep avoids racing
+  // against the API picking the run up. We pull up to 10 recent
+  // runs (rather than `--limit 1`) and filter by createdAt so a
+  // concurrent dispatch or a stale older run cannot smuggle in a
+  // wrong run_id.
+  await sleeper(POST_DISPATCH_WAIT_MS);
+  const list = ghRunner([
+    'run',
+    'list',
+    '--repo',
+    repo,
+    '--workflow=branch-fix-verdict.yml',
+    '--event=workflow_dispatch',
+    '--limit',
+    '10',
+    '--json',
+    'databaseId,status,createdAt',
+  ]);
+  if (list.status !== 0) {
+    return {
+      ok: false,
+      error: `gh run list failed: ${list.stderr.trim() || '<no stderr>'}`,
+      duration_ms: Date.now() - startedAt,
+    };
+  }
+  let runs: Array<{ databaseId: number; status: string; createdAt: string }>;
+  try {
+    runs = JSON.parse(list.stdout);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `failed to parse gh run list output: ${err instanceof Error ? err.message : String(err)}`,
+      duration_ms: Date.now() - startedAt,
+    };
+  }
+  if (!Array.isArray(runs) || runs.length === 0) {
+    return {
+      ok: false,
+      error: 'no workflow run found after dispatch',
+      duration_ms: Date.now() - startedAt,
+    };
+  }
+  // Only runs created at or after dispatch (with a small clock-drift
+  // buffer) are candidates — older runs are pre-existing artefacts
+  // we must never confuse with this dispatch.
+  const CLOCK_BUFFER_MS = 5_000;
+  const cutoff = dispatchBoundary - CLOCK_BUFFER_MS;
+  const candidates = runs
+    .map((r) => ({
+      databaseId: r.databaseId,
+      status: r.status,
+      createdAtMs: new Date(r.createdAt).getTime(),
+    }))
+    .filter((r) => !Number.isNaN(r.createdAtMs) && r.createdAtMs >= cutoff);
+  if (candidates.length === 0) {
+    return {
+      ok: false,
+      error: `no workflow run created at or after dispatch (cutoff: ${new Date(cutoff).toISOString()}, ${runs.length} older run(s) ignored)`,
+      duration_ms: Date.now() - startedAt,
+    };
+  }
+  // Earliest createdAt among the post-dispatch candidates. If there
+  // are concurrent dispatches for the same workflow within a few
+  // seconds we may still race to the wrong run, but the time bound
+  // limits the blast radius. A correlation_id input on the workflow
+  // would close this hole; tracked as a follow-up.
+  candidates.sort((a, b) => a.createdAtMs - b.createdAtMs);
+  const runId = candidates[0]!.databaseId;
+
+  // 3. Poll until completion or timeout.
+  const pollDeadline = startedAt + pollTimeout;
+  let conclusion: string | null = null;
+  while (Date.now() < pollDeadline) {
+    const view = ghRunner([
+      'run',
+      'view',
+      String(runId),
+      '--repo',
+      repo,
+      '--json',
+      'status,conclusion',
+    ]);
+    if (view.status !== 0) {
+      return {
+        ok: false,
+        error: `gh run view failed: ${view.stderr.trim() || '<no stderr>'}`,
+        duration_ms: Date.now() - startedAt,
+        workflow_run_id: runId,
+      };
+    }
+    let parsed: { status: string; conclusion: string | null };
+    try {
+      parsed = JSON.parse(view.stdout);
+    } catch (err) {
+      return {
+        ok: false,
+        error: `failed to parse gh run view output: ${err instanceof Error ? err.message : String(err)}`,
+        duration_ms: Date.now() - startedAt,
+        workflow_run_id: runId,
+      };
+    }
+    if (parsed.status === 'completed') {
+      conclusion = parsed.conclusion;
+      break;
+    }
+    await sleeper(pollInterval);
+  }
+  if (conclusion === null) {
+    return {
+      ok: false,
+      error: `workflow run ${runId} did not complete within ${pollTimeout}ms`,
+      duration_ms: Date.now() - startedAt,
+      workflow_run_id: runId,
+    };
+  }
+
+  // 4. Download the verdict artefact regardless of conclusion — the
+  // workflow's "Assert expected verdict" step exits non-zero when the
+  // captured verdict mismatches `expected_verdict`, but the artefact
+  // is still uploaded so we can surface the actual verdict.
+  const artefactName = `branch-fix-verdict-${slug}-${runId}`;
+  const downloadDir = mkdtempSync(join(tmpdir(), `vivarium-artefact-${slug}-`));
+
+  try {
+    const download = ghRunner([
+      'run',
+      'download',
+      String(runId),
+      '--repo',
+      repo,
+      '--name',
+      artefactName,
+      '--dir',
+      downloadDir,
+    ]);
+    if (download.status !== 0) {
+      return {
+        ok: false,
+        error: `gh run download failed (conclusion=${conclusion}): ${download.stderr.trim() || '<no stderr>'}`,
+        duration_ms: Date.now() - startedAt,
+        workflow_run_id: runId,
+      };
+    }
+
+    const verdictPath = join(downloadDir, 'branch-fix-verdict.json');
+    let raw: string;
+    try {
+      raw = readFileSync(verdictPath, 'utf-8');
+    } catch (err) {
+      return {
+        ok: false,
+        error: `failed to read branch-fix-verdict.json from artefact: ${err instanceof Error ? err.message : String(err)}`,
+        duration_ms: Date.now() - startedAt,
+        workflow_run_id: runId,
+      };
+    }
+    let parsed: VerdictSnapshot;
+    try {
+      parsed = JSON.parse(raw) as VerdictSnapshot;
+    } catch (err) {
+      return {
+        ok: false,
+        error: `branch-fix-verdict.json is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+        duration_ms: Date.now() - startedAt,
+        workflow_run_id: runId,
+      };
+    }
+    if (!isVerdict(parsed.verdict)) {
+      return {
+        ok: false,
+        error: `branch-fix verdict has unexpected value "${parsed.verdict}"`,
+        duration_ms: Date.now() - startedAt,
+        workflow_run_id: runId,
+      };
+    }
+
+    return {
+      ok: true,
+      slug,
+      mode: 'fixed',
+      verdict: parsed.verdict,
+      captured_at: parsed.captured_at,
+      duration_ms: Date.now() - startedAt,
+      source: 'workflow-artefact',
+      workflow_run_id: runId,
+    };
+  } finally {
+    try {
+      rmSync(downloadDir, { recursive: true, force: true });
+    } catch {
+      /* ignore tmpdir cleanup failures */
+    }
+  }
+}

--- a/packages/mcp-server/src/tools/verify_and_report_fix.ts
+++ b/packages/mcp-server/src/tools/verify_and_report_fix.ts
@@ -1,26 +1,33 @@
 // Layer-abstracted round-trip verification helper. Computes the
-// state-machine next_action from a recipe's current round-trip state
-// (passed in via `current_state`, typically the contents of
-// src/layer{1,2,3}_*/<slug>/roundtrip.json) and returns the commands
-// the round-trip skill should run next. Bridges Path A (Layer 1,
-// browser-driven Playwright runs) and Path B (Layer 2/3,
-// branch-fix-verdict.yml workflow dispatch) under a single return
-// shape so callers do not branch on layer.
+// state-machine next_action from a recipe's current round-trip state,
+// optionally executes the appropriate verdict capture (Layer 1
+// Playwright run or Layer 2/3 workflow dispatch), and returns the
+// merged state alongside the commands the caller should run for any
+// non-executing action (open PRs, manual intervention, complete).
 //
-// Phase 1 (this commit): SCAFFOLDING ONLY. The tool returns the
-// canonical roundtrip.json path, the state-machine next_action, and
-// the verify_branch_fix-derived deep-link commands. It does NOT execute
-// verdict capture or mutate roundtrip.json. Phase 3 will replace the
-// command-string return with actual execution for Layer 1
-// (Playwright-driven targeted runs) while keeping the same return
-// shape for Layer 2/3 (GitHub Actions workflow_dispatch wrapping).
+// Phase 3: when `auto_execute` is true (the default), the tool
+// actually runs `verify_unfixed` / `verify_fixed` via the internal
+// `run_layer1_verdict` / `run_layer23_verdict` helpers and merges the
+// captured verdict into the response's `verdicts` field. Pass
+// `auto_execute: false` to get the Phase 1 / 2 behaviour (return
+// commands as strings without running anything).
 
 import { getCatalogue } from '../catalogue.js';
 import type {
   Layer,
   RoundtripNextAction,
   RoundtripState,
+  RoundtripVerdict,
+  VerdictSource,
 } from '../types.js';
+import {
+  runLayer1Verdict,
+  type RunLayer1VerdictResult,
+} from './run_layer1_verdict.js';
+import {
+  runLayer23Verdict,
+  type RunLayer23VerdictResult,
+} from './run_layer23_verdict.js';
 import { verifyBranchFix } from './verify_branch_fix.js';
 
 export interface VerifyAndReportFixArgs {
@@ -29,6 +36,20 @@ export interface VerifyAndReportFixArgs {
   fix_source?: string;
   branch_image?: string;
   current_state?: Partial<RoundtripState>;
+  // Phase 3 additions:
+  auto_execute?: boolean;
+  workspace_path?: string;
+  poll_interval_ms?: number;
+  poll_timeout_ms?: number;
+}
+
+export interface ExecutedInfo {
+  action: 'verify_unfixed' | 'verify_fixed';
+  source: VerdictSource;
+  ok: boolean;
+  duration_ms: number;
+  error?: string;
+  workflow_run_id?: number;
 }
 
 export interface VerifyAndReportFixOk {
@@ -41,6 +62,7 @@ export interface VerifyAndReportFixOk {
   next_action: RoundtripNextAction;
   commands: string[];
   notes: string[];
+  executed?: ExecutedInfo;
 }
 
 export interface VerifyAndReportFixError {
@@ -56,6 +78,12 @@ const LAYER_DIRNAME: Record<Layer, string> = {
   1: 'layer1_wasm',
   2: 'layer2_docker',
   3: 'layer3_thirdway',
+};
+
+const LAYER_SOURCE: Record<Layer, VerdictSource> = {
+  1: 'layer1-headless',
+  2: 'layer2-ghcr',
+  3: 'layer3-trace',
 };
 
 // Pure state-machine transition. Exported so unit tests and any future
@@ -86,9 +114,7 @@ export function computeNextAction(
 }
 
 // Parse `https://github.com/<owner>/<repo>/issues/<n>` (or `/pull/<n>`)
-// to extract the upstream repo coordinates. The fork repo is the
-// contributor's mirror; upstream PRs always target the original owner,
-// not the fork. Returns undefined for non-github / malformed URLs.
+// to extract the upstream repo coordinates.
 export function parseUpstreamIssue(
   url: string | undefined,
 ): { owner: string; repo: string } | undefined {
@@ -194,6 +220,144 @@ function buildCommands(args: BuildCommandsArgs): string[] {
   }
 }
 
+// Layer 1 verdict capture path. fix_url is required when action is
+// verify_fixed (the whole point of "fixed" is to substitute a fix).
+async function executeLayer1(
+  slug: string,
+  action: 'verify_unfixed' | 'verify_fixed',
+  args: VerifyAndReportFixArgs,
+): Promise<{
+  verdictEntry?: RoundtripVerdict;
+  executed: ExecutedInfo;
+}> {
+  if (action === 'verify_fixed' && !args.fix_url) {
+    return {
+      executed: {
+        action,
+        source: 'layer1-headless',
+        ok: false,
+        duration_ms: 0,
+        error: 'fix_url is required for verify_fixed on Layer 1 recipes',
+      },
+    };
+  }
+
+  const result: RunLayer1VerdictResult = await runLayer1Verdict({
+    slug,
+    fix_url: action === 'verify_fixed' ? args.fix_url : undefined,
+    workspace_path: args.workspace_path,
+  });
+
+  if (!result.ok) {
+    return {
+      executed: {
+        action,
+        source: 'layer1-headless',
+        ok: false,
+        duration_ms: result.duration_ms,
+        error: result.error,
+      },
+    };
+  }
+
+  const verdictEntry: RoundtripVerdict = {
+    verdict: result.verdict,
+    captured_at: result.captured_at,
+    source: 'layer1-headless',
+  };
+  return {
+    verdictEntry,
+    executed: {
+      action,
+      source: 'layer1-headless',
+      ok: true,
+      duration_ms: result.duration_ms,
+    },
+  };
+}
+
+// Layer 2/3 verdict capture path. verify_fixed needs branch_image;
+// verify_unfixed reads the deployed verdict.json snapshot.
+async function executeLayer23(
+  slug: string,
+  layer: 2 | 3,
+  action: 'verify_unfixed' | 'verify_fixed',
+  args: VerifyAndReportFixArgs,
+): Promise<{
+  verdictEntry?: RoundtripVerdict;
+  executed: ExecutedInfo;
+}> {
+  const sourceLabel = LAYER_SOURCE[layer];
+
+  // Layer 3 fixed verdicts are not supported yet. branch-fix-verdict.yml
+  // checks `src/layer2_docker/<slug>/` only; running it for a Layer 3
+  // recipe would fail inside the workflow. Reject up front so the
+  // failure is informative instead of a confusing workflow exit code.
+  if (layer === 3 && action === 'verify_fixed') {
+    return {
+      executed: {
+        action,
+        source: sourceLabel,
+        ok: false,
+        duration_ms: 0,
+        error:
+          'verify_fixed is not yet supported for Layer 3 recipes; branch-fix-verdict.yml only handles src/layer2_docker/<slug>. Track workflow extension separately.',
+      },
+    };
+  }
+
+  if (action === 'verify_fixed' && !args.branch_image) {
+    return {
+      executed: {
+        action,
+        source: sourceLabel,
+        ok: false,
+        duration_ms: 0,
+        error: 'branch_image is required for verify_fixed on Layer 2/3 recipes',
+      },
+    };
+  }
+
+  const mode = action === 'verify_unfixed' ? 'unfixed' : 'fixed';
+  const result: RunLayer23VerdictResult = await runLayer23Verdict({
+    slug,
+    mode,
+    branch_image: args.branch_image,
+    expected_verdict: mode === 'fixed' ? 'unreproduced' : undefined,
+    poll_interval_ms: args.poll_interval_ms,
+    poll_timeout_ms: args.poll_timeout_ms,
+  });
+
+  if (!result.ok) {
+    return {
+      executed: {
+        action,
+        source: sourceLabel,
+        ok: false,
+        duration_ms: result.duration_ms,
+        error: result.error,
+        workflow_run_id: result.workflow_run_id,
+      },
+    };
+  }
+
+  const verdictEntry: RoundtripVerdict = {
+    verdict: result.verdict,
+    captured_at: result.captured_at,
+    source: sourceLabel,
+  };
+  return {
+    verdictEntry,
+    executed: {
+      action,
+      source: sourceLabel,
+      ok: true,
+      duration_ms: result.duration_ms,
+      workflow_run_id: result.workflow_run_id,
+    },
+  };
+}
+
 export async function verifyAndReportFix(
   args: VerifyAndReportFixArgs,
 ): Promise<VerifyAndReportFixResult> {
@@ -217,11 +381,59 @@ export async function verifyAndReportFix(
     return { ok: false, error: verifyResult.error };
   }
 
-  const next = computeNextAction(args.current_state);
-  const verdicts = args.current_state?.verdicts ?? {};
+  const initialNext = computeNextAction(args.current_state);
+  const verdicts: NonNullable<RoundtripState['verdicts']> = {
+    ...(args.current_state?.verdicts ?? {}),
+  };
+
+  const notes = [...verifyResult.notes];
+  let executed: ExecutedInfo | undefined;
+
+  // Auto-execute defaults to true. Only verify_unfixed / verify_fixed
+  // are executable; the other next_actions (open_*_pr,
+  // manual_intervention, complete) are caller actions.
+  const autoExecute = args.auto_execute !== false;
+  const shouldExecute =
+    autoExecute &&
+    (initialNext === 'verify_unfixed' || initialNext === 'verify_fixed');
+
+  if (shouldExecute) {
+    const executable = initialNext as 'verify_unfixed' | 'verify_fixed';
+    const captured =
+      recipe.layer === 1
+        ? await executeLayer1(slug, executable, args)
+        : await executeLayer23(slug, recipe.layer as 2 | 3, executable, args);
+
+    executed = captured.executed;
+    if (captured.verdictEntry) {
+      if (executable === 'verify_unfixed') {
+        verdicts.unfixed = captured.verdictEntry;
+      } else {
+        verdicts.fixed = captured.verdictEntry;
+      }
+    }
+    if (!captured.executed.ok) {
+      notes.push(
+        `auto-execute of ${executable} failed: ${captured.executed.error ?? '<no error message>'}`,
+      );
+    }
+  } else if (!autoExecute) {
+    notes.push(
+      'auto_execute=false: returning command scaffolding without running verdict capture.',
+    );
+  }
+
+  // Recompute next_action against the (possibly updated) verdicts so
+  // the caller sees what to do next now that a verdict was captured.
+  const updatedState: Partial<RoundtripState> = {
+    ...args.current_state,
+    verdicts,
+  };
+  const nextAction = computeNextAction(updatedState);
+
   const roundtripPath = `src/${LAYER_DIRNAME[recipe.layer]}/${slug}/roundtrip.json`;
   const commands = buildCommands({
-    next,
+    next: nextAction,
     slug,
     layer: recipe.layer,
     pathAB: verifyResult.path,
@@ -232,11 +444,6 @@ export async function verifyAndReportFix(
     upstreamIssue: args.current_state?.upstream_issue,
   });
 
-  const notes = [...verifyResult.notes];
-  notes.push(
-    'phase 1 skeleton — verify_and_report_fix returns commands but does not yet execute verdict capture; phase 3 will replace the command return for layer 1 with playwright-driven runs.',
-  );
-
   return {
     ok: true,
     slug: recipe.slug,
@@ -244,16 +451,17 @@ export async function verifyAndReportFix(
     path: verifyResult.path,
     verdicts,
     roundtrip_path: roundtripPath,
-    next_action: next,
+    next_action: nextAction,
     commands,
     notes,
+    ...(executed ? { executed } : {}),
   };
 }
 
 export const VERIFY_AND_REPORT_FIX_TOOL = {
   name: 'verify_and_report_fix',
   description:
-    "Layer-abstracted round-trip verification helper. Computes the state-machine next_action from a recipe's current round-trip state (passed via `current_state`, typically the contents of `src/layer{1,2,3}_*/<slug>/roundtrip.json` against the roundtrip.schema.json shape) and returns the commands the round-trip skill should run next. Bridges Path A (Layer 1, browser-driven Playwright targeted runs) and Path B (Layer 2/3, branch-fix-verdict.yml workflow dispatch) under a single return shape so callers do not branch on layer. The `next_action` enum (`verify_unfixed` → `verify_fixed` → `open_vivarium_pr` → `open_fork_pr` → `complete`) drives the round-trip state machine end-to-end. SCAFFOLDING HELPER as of v0.1.x: the returned `commands[]` are executed by the caller, not by the MCP server. Use `verify_branch_fix` directly when you only need a Path A/B deep-link and not the state-machine layer.",
+    "Layer-abstracted round-trip verification driver. Computes the state-machine next_action from the recipe's current round-trip state and, when `auto_execute` is true (the default), runs the appropriate verdict capture: a Playwright `--grep` targeted run for Layer 1 or a `gh workflow run branch-fix-verdict.yml` dispatch + artefact download for Layer 2/3. Returns the merged state with any captured verdict in `verdicts`, the next state-machine action in `next_action`, and the commands to run for any non-executing action (PR opens, manual intervention, complete) in `commands`. Pass `auto_execute: false` for the earlier Phase 1 / 2 behaviour (return commands without running anything). The `executed` field reports the action that just ran, its source, and any error.",
   inputSchema: {
     type: 'object' as const,
     properties: {
@@ -261,28 +469,51 @@ export const VERIFY_AND_REPORT_FIX_TOOL = {
         type: 'string' as const,
         pattern: '^[a-z0-9]+(-[a-z0-9]+)*$',
         description:
-          "Kebab-case recipe slug (e.g. 'php-12167', 'bash-local-shadows-exit'). Same convention as Manifest v1's `slug`.",
+          "Kebab-case recipe slug (e.g. 'php-12167', 'bash-local-shadows-exit').",
       },
       fix_url: {
         type: 'string' as const,
         description:
-          'Public URL of the candidate fix source. Layer 1 only — forwarded to verify_branch_fix to build the Path A `?fix_url=` deep-link. Mutually exclusive with fix_source.',
+          'Public URL of the candidate fix source. Layer 1 only — injected as `?fix_url=` when capturing the fixed verdict. Required for verify_fixed on Layer 1.',
       },
       fix_source: {
         type: 'string' as const,
         description:
-          'Inline candidate fix source. Layer 1 only — forwarded to verify_branch_fix to build the Path A `?fix=<base64>` deep-link. Mutually exclusive with fix_url. Max 4096 bytes.',
+          'Inline candidate fix source. Layer 1 only — surfaced in the returned `compare_url` for visual inspection; not used by Phase 3 auto-execute (`fix_url` is the executable input).',
       },
       branch_image: {
         type: 'string' as const,
         description:
-          "Layer 2/3 only. GHCR tag of the contributor's branch-fix Docker image (e.g. 'ghcr.io/<user>/vivarium-<slug>:fix-issue-<n>'). Surfaced as a comment in the returned commands when present; substituted into the gh workflow run command in Phase 3.",
+          "Layer 2/3 only. GHCR tag of the contributor's branch-fix Docker image. Required for verify_fixed on Layer 2/3 — passed as the `branch_image` input to `branch-fix-verdict.yml`.",
       },
       current_state: {
         type: 'object' as const,
         description:
-          "Current round-trip state for the slug, matching the roundtrip.schema.json shape. Pass the parsed contents of the recipe's roundtrip.json. Omit (or pass {}) for a fresh round-trip — the tool will return `next_action='verify_unfixed'`.",
+          "Current round-trip state for the slug, matching roundtrip.schema.json. Pass the parsed contents of the recipe's roundtrip.json. Omit for a fresh round-trip — the tool will compute `verify_unfixed` and (with auto_execute) run it.",
         additionalProperties: true,
+      },
+      auto_execute: {
+        type: 'boolean' as const,
+        default: true,
+        description:
+          'Whether to actually run the verify_unfixed / verify_fixed action when the state machine selects one. Defaults to true. Set false to preserve the Phase 1 / 2 behaviour of returning commands without running anything.',
+      },
+      workspace_path: {
+        type: 'string' as const,
+        description:
+          'Layer 1 only. Filesystem path to the `src/layer1_wasm/` workspace (where Playwright config lives). Defaults to the monorepo-relative path `src/layer1_wasm`. Pass an absolute path if the MCP server is launched from elsewhere.',
+      },
+      poll_interval_ms: {
+        type: 'integer' as const,
+        minimum: 1000,
+        description:
+          'Layer 2/3 only. Interval between `gh run view` polls when waiting for branch-fix-verdict.yml to complete. Default 15000ms.',
+      },
+      poll_timeout_ms: {
+        type: 'integer' as const,
+        minimum: 1000,
+        description:
+          'Layer 2/3 only. Hard cap on the total wait for the workflow to complete. Default 600000ms (10 minutes).',
       },
     },
     required: ['slug'],

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -3,6 +3,8 @@
 
 import { afterEach, beforeEach, describe, it } from 'bun:test';
 import { strict as assert } from 'node:assert';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import { _resetCacheForTesting, INDEX_URL } from '../src/catalogue.ts';
 import { getRecipe } from '../src/tools/get_recipe.ts';
@@ -11,6 +13,17 @@ import { lookupVerdict } from '../src/tools/lookup_verdict.ts';
 import { matchError } from '../src/tools/match_error.ts';
 import { prepareFixCandidate } from '../src/tools/prepare_fix_candidate.ts';
 import { prepareNewRecipe } from '../src/tools/prepare_new_recipe.ts';
+import {
+  _setSpawnRunnerForTesting,
+  _setVerdictReaderForTesting,
+  runLayer1Verdict,
+} from '../src/tools/run_layer1_verdict.ts';
+import {
+  _setGhRunnerForTesting as _setLayer23GhRunnerForTesting,
+  _setSleeperForTesting,
+  _setSnapshotFetcherForTesting,
+  runLayer23Verdict,
+} from '../src/tools/run_layer23_verdict.ts';
 import {
   _setGhRunnerForTesting,
   type GhRunResult,
@@ -102,6 +115,11 @@ afterEach(() => {
   globalThis.fetch = realFetch;
   _resetCacheForTesting();
   _setGhRunnerForTesting(null);
+  _setSpawnRunnerForTesting(null);
+  _setVerdictReaderForTesting(null);
+  _setLayer23GhRunnerForTesting(null);
+  _setSnapshotFetcherForTesting(null);
+  _setSleeperForTesting(null);
 });
 
 describe('list_recipes', () => {
@@ -573,7 +591,10 @@ describe('verify_and_report_fix', () => {
   });
 
   it('Layer 1 + no state → next_action=verify_unfixed, path A, layer1_wasm roundtrip_path', async () => {
-    const r = await verifyAndReportFix({ slug: 'pandas-56679' });
+    const r = await verifyAndReportFix({
+      slug: 'pandas-56679',
+      auto_execute: false,
+    });
     assert.equal(r.ok, true);
     if (r.ok) {
       assert.equal(r.layer, 1);
@@ -591,7 +612,10 @@ describe('verify_and_report_fix', () => {
   });
 
   it('Layer 2 + no state → next_action=verify_unfixed, path B, mise recipes:verify', async () => {
-    const r = await verifyAndReportFix({ slug: 'bash-local-shadows-exit' });
+    const r = await verifyAndReportFix({
+      slug: 'bash-local-shadows-exit',
+      auto_execute: false,
+    });
     assert.equal(r.ok, true);
     if (r.ok) {
       assert.equal(r.layer, 2);
@@ -610,7 +634,10 @@ describe('verify_and_report_fix', () => {
   });
 
   it('Layer 3 + no state → roundtrip_path under layer3_thirdway', async () => {
-    const r = await verifyAndReportFix({ slug: 'lost-update' });
+    const r = await verifyAndReportFix({
+      slug: 'lost-update',
+      auto_execute: false,
+    });
     assert.equal(r.ok, true);
     if (r.ok) {
       assert.equal(r.layer, 3);
@@ -624,6 +651,7 @@ describe('verify_and_report_fix', () => {
   it('verified state without vivarium_pr → next_action=open_vivarium_pr + sl pr submit', async () => {
     const r = await verifyAndReportFix({
       slug: 'pandas-56679',
+      auto_execute: false,
       current_state: {
         status: 'verified',
         verdicts: {
@@ -650,6 +678,7 @@ describe('verify_and_report_fix', () => {
   it('verified + vivarium_pr + fork → open_fork_pr targets upstream repo, not fork', async () => {
     const r = await verifyAndReportFix({
       slug: 'pandas-56679',
+      auto_execute: false,
       current_state: {
         status: 'verified',
         upstream_issue: 'https://github.com/pandas-dev/pandas/issues/56679',
@@ -695,6 +724,7 @@ describe('verify_and_report_fix', () => {
   it('open_fork_pr without upstream_issue surfaces a warning comment instead of executing', async () => {
     const r = await verifyAndReportFix({
       slug: 'pandas-56679',
+      auto_execute: false,
       current_state: {
         status: 'verified',
         vivarium_pr: 'https://github.com/aletheia-works/vivarium/pull/200',
@@ -734,6 +764,7 @@ describe('verify_and_report_fix', () => {
   it('blocked state → next_action=manual_intervention with stop-the-line commands', async () => {
     const r = await verifyAndReportFix({
       slug: 'pandas-56679',
+      auto_execute: false,
       current_state: {
         status: 'blocked',
         notes: ['upstream maintainer rejected the fix approach'],
@@ -756,6 +787,7 @@ describe('verify_and_report_fix', () => {
   it('upstream_pr present → next_action=complete + empty commands', async () => {
     const r = await verifyAndReportFix({
       slug: 'pandas-56679',
+      auto_execute: false,
       current_state: {
         status: 'upstream_open',
         upstream_pr: 'https://github.com/pandas-dev/pandas/pull/12345',
@@ -765,6 +797,583 @@ describe('verify_and_report_fix', () => {
     if (r.ok) {
       assert.equal(r.next_action, 'complete');
       assert.equal(r.commands.length, 0);
+    }
+  });
+});
+
+describe('verify_and_report_fix auto-execute (Phase 3)', () => {
+  it('Layer 1 + auto_execute=true → spawns Playwright and merges captured verdict', async () => {
+    _setSpawnRunnerForTesting(() => ({ status: 0, stdout: '', stderr: '' }));
+    _setVerdictReaderForTesting(() =>
+      JSON.stringify({
+        slug: 'pandas-56679',
+        verdict: 'reproduced',
+        fix_url: null,
+        captured_at: '2026-05-17T10:00:00Z',
+      }),
+    );
+
+    const r = await verifyAndReportFix({ slug: 'pandas-56679' });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.executed?.action, 'verify_unfixed');
+      assert.equal(r.executed?.ok, true);
+      assert.equal(r.executed?.source, 'layer1-headless');
+      assert.equal(r.verdicts.unfixed?.verdict, 'reproduced');
+      // After capturing unfixed=reproduced, the next action becomes
+      // verify_fixed (the state machine advanced one step).
+      assert.equal(r.next_action, 'verify_fixed');
+    }
+  });
+
+  it('Layer 1 + verify_fixed without fix_url → executed.ok=false, no verdict merged', async () => {
+    const r = await verifyAndReportFix({
+      slug: 'pandas-56679',
+      current_state: {
+        verdicts: {
+          unfixed: {
+            verdict: 'reproduced',
+            captured_at: '2026-05-17T00:00:00Z',
+            source: 'layer1-headless',
+          },
+        },
+      },
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.executed?.action, 'verify_fixed');
+      assert.equal(r.executed?.ok, false);
+      assert.match(r.executed?.error ?? '', /fix_url is required/);
+      assert.equal(r.verdicts.fixed, undefined);
+    }
+  });
+
+  it('Layer 1 + auto_execute=true + spawn failure surfaces in executed', async () => {
+    _setSpawnRunnerForTesting(() => ({
+      status: 1,
+      stdout: '',
+      stderr: 'Playwright crashed',
+    }));
+
+    const r = await verifyAndReportFix({ slug: 'pandas-56679' });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.executed?.ok, false);
+      assert.match(r.executed?.error ?? '', /status 1/);
+      assert.equal(r.verdicts.unfixed, undefined);
+    }
+  });
+
+  it('Layer 3 + verify_fixed → executed.ok=false (workflow does not yet support Layer 3)', async () => {
+    // lost-update is Layer 3. Force the state machine to verify_fixed
+    // by supplying an unfixed=reproduced verdict, then check the
+    // executor rejects with an informative error rather than dispatching
+    // a workflow that would fail inside branch-fix-verdict.yml.
+    let ghCalled = false;
+    _setLayer23GhRunnerForTesting(() => {
+      ghCalled = true;
+      return { status: 0, stdout: '', stderr: '' };
+    });
+
+    const r = await verifyAndReportFix({
+      slug: 'lost-update',
+      branch_image: 'ghcr.io/test/lost-update:fix',
+      current_state: {
+        verdicts: {
+          unfixed: {
+            verdict: 'reproduced',
+            captured_at: '2026-05-17T00:00:00Z',
+            source: 'layer3-trace',
+          },
+        },
+      },
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.layer, 3);
+      assert.equal(r.executed?.action, 'verify_fixed');
+      assert.equal(r.executed?.ok, false);
+      assert.match(r.executed?.error ?? '', /not yet supported for Layer 3/);
+      assert.equal(r.verdicts.fixed, undefined);
+      assert.equal(ghCalled, false, 'gh must NOT be called when Layer 3 verify_fixed is rejected');
+    }
+  });
+
+  it('Layer 2 + auto_execute=true → fetches deployed snapshot for unfixed', async () => {
+    _setSnapshotFetcherForTesting(async (slug) => ({
+      contract: 'v1',
+      verdict: 'reproduced',
+      exit_code: 0,
+      image_tag: `vivarium-${slug}:test`,
+      image_digest: 'sha256:test',
+      captured_at: '2026-05-17T10:00:00Z',
+      stdout: '',
+      stderr_tail: '',
+    }));
+
+    const r = await verifyAndReportFix({ slug: 'bash-local-shadows-exit' });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.executed?.action, 'verify_unfixed');
+      assert.equal(r.executed?.ok, true);
+      assert.equal(r.executed?.source, 'layer2-ghcr');
+      assert.equal(r.verdicts.unfixed?.verdict, 'reproduced');
+    }
+  });
+
+  it('auto_execute=false → no execution, no executed field', async () => {
+    const r = await verifyAndReportFix({
+      slug: 'pandas-56679',
+      auto_execute: false,
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.executed, undefined);
+      assert.equal(r.verdicts.unfixed, undefined);
+    }
+  });
+
+  it('open_*_pr / complete / manual_intervention next actions skip execution', async () => {
+    // status=blocked → manual_intervention. auto_execute=true should
+    // NOT trigger any spawn/gh call because those actions are not
+    // executable verify steps.
+    let spawnCalled = false;
+    _setSpawnRunnerForTesting(() => {
+      spawnCalled = true;
+      return { status: 0, stdout: '', stderr: '' };
+    });
+
+    const r = await verifyAndReportFix({
+      slug: 'pandas-56679',
+      current_state: { status: 'blocked' },
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.next_action, 'manual_intervention');
+      assert.equal(r.executed, undefined);
+      assert.equal(spawnCalled, false);
+    }
+  });
+});
+
+describe('run_layer1_verdict', () => {
+  it('returns ok:false on missing slug', async () => {
+    const r = await runLayer1Verdict({ slug: '' });
+    assert.equal(r.ok, false);
+  });
+
+  it('passes PLAYWRIGHT_FIX_URL through env when fix_url is supplied', async () => {
+    let capturedEnv: NodeJS.ProcessEnv = {};
+    _setSpawnRunnerForTesting(({ env }) => {
+      capturedEnv = env;
+      return { status: 0, stdout: '', stderr: '' };
+    });
+    _setVerdictReaderForTesting(() =>
+      JSON.stringify({
+        slug: 'mpmath-983',
+        verdict: 'unreproduced',
+        fix_url: 'https://example.invalid/fix.py',
+        captured_at: '2026-05-17T10:00:00Z',
+      }),
+    );
+
+    const r = await runLayer1Verdict({
+      slug: 'mpmath-983',
+      fix_url: 'https://example.invalid/fix.py',
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.verdict, 'unreproduced');
+      assert.equal(r.fix_url, 'https://example.invalid/fix.py');
+    }
+    assert.equal(
+      capturedEnv['PLAYWRIGHT_FIX_URL'],
+      'https://example.invalid/fix.py',
+    );
+  });
+
+  it('targets the recipe via `--grep "verdict-capture: <slug>"`', async () => {
+    let capturedArgs: string[] = [];
+    _setSpawnRunnerForTesting(({ args }) => {
+      capturedArgs = args;
+      return { status: 0, stdout: '', stderr: '' };
+    });
+    _setVerdictReaderForTesting(() =>
+      JSON.stringify({
+        slug: 'pandas-56679',
+        verdict: 'reproduced',
+        fix_url: null,
+        captured_at: '2026-05-17T10:00:00Z',
+      }),
+    );
+
+    await runLayer1Verdict({ slug: 'pandas-56679' });
+    const grepIdx = capturedArgs.indexOf('--grep');
+    assert.ok(grepIdx >= 0);
+    assert.equal(capturedArgs[grepIdx + 1], 'verdict-capture: pandas-56679');
+  });
+
+  it('returns ok:false when spawn exits non-zero', async () => {
+    _setSpawnRunnerForTesting(() => ({
+      status: 1,
+      stdout: '',
+      stderr: 'Playwright failed',
+    }));
+    const r = await runLayer1Verdict({ slug: 'mpmath-983' });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.match(r.error, /status 1/);
+      assert.equal(r.stderr_tail, 'Playwright failed');
+    }
+  });
+
+  it('returns ok:false when verdict output is malformed JSON', async () => {
+    _setSpawnRunnerForTesting(() => ({ status: 0, stdout: '', stderr: '' }));
+    _setVerdictReaderForTesting(() => 'not-json');
+    const r = await runLayer1Verdict({ slug: 'mpmath-983' });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /not valid JSON/);
+  });
+
+  it('returns ok:false when slug in output does not match request', async () => {
+    _setSpawnRunnerForTesting(() => ({ status: 0, stdout: '', stderr: '' }));
+    _setVerdictReaderForTesting(() =>
+      JSON.stringify({
+        slug: 'wrong-slug',
+        verdict: 'reproduced',
+        fix_url: null,
+        captured_at: '2026-05-17T10:00:00Z',
+      }),
+    );
+    const r = await runLayer1Verdict({ slug: 'mpmath-983' });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /does not match/);
+  });
+});
+
+describe('run_layer23_verdict', () => {
+  it('returns ok:false on missing slug', async () => {
+    const r = await runLayer23Verdict({ slug: '', mode: 'unfixed' });
+    assert.equal(r.ok, false);
+  });
+
+  it('returns ok:false on invalid mode', async () => {
+    const r = await runLayer23Verdict({
+      slug: 'bash-local-shadows-exit',
+      mode: 'bogus' as 'unfixed',
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /invalid mode/);
+  });
+
+  it('mode=unfixed → fetches deployed snapshot via injected fetcher', async () => {
+    _setSnapshotFetcherForTesting(async (slug) => ({
+      contract: 'v1',
+      verdict: 'reproduced',
+      exit_code: 0,
+      image_tag: `vivarium-${slug}:dev`,
+      image_digest: 'sha256:test',
+      captured_at: '2026-05-17T10:00:00Z',
+      stdout: '',
+      stderr_tail: '',
+    }));
+    const r = await runLayer23Verdict({
+      slug: 'bash-local-shadows-exit',
+      mode: 'unfixed',
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.verdict, 'reproduced');
+      assert.equal(r.source, 'deployed-snapshot');
+      assert.equal(r.mode, 'unfixed');
+    }
+  });
+
+  it('mode=unfixed returns ok:false when no snapshot exists', async () => {
+    _setSnapshotFetcherForTesting(async () => null);
+    const r = await runLayer23Verdict({
+      slug: 'pandas-56679',
+      mode: 'unfixed',
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /no deployed verdict/);
+  });
+
+  it('mode=fixed requires branch_image', async () => {
+    const r = await runLayer23Verdict({
+      slug: 'bash-local-shadows-exit',
+      mode: 'fixed',
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /branch_image is required/);
+  });
+
+  it('mode=fixed → dispatches workflow, polls, downloads artefact', async () => {
+    _setSleeperForTesting(async () => {
+      /* skip waits */
+    });
+
+    let viewCount = 0;
+    _setLayer23GhRunnerForTesting((args) => {
+      const cmd = args[0];
+      const sub = args[1];
+
+      if (cmd === 'workflow' && sub === 'run') {
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      if (cmd === 'run' && sub === 'list') {
+        return {
+          status: 0,
+          stdout: JSON.stringify([
+            {
+              databaseId: 9999,
+              status: 'queued',
+              createdAt: '2026-05-17T10:00:00Z',
+            },
+          ]),
+          stderr: '',
+        };
+      }
+      if (cmd === 'run' && sub === 'view') {
+        viewCount++;
+        // First poll: still running. Second poll: completed.
+        if (viewCount === 1) {
+          return {
+            status: 0,
+            stdout: JSON.stringify({
+              status: 'in_progress',
+              conclusion: null,
+            }),
+            stderr: '',
+          };
+        }
+        return {
+          status: 0,
+          stdout: JSON.stringify({
+            status: 'completed',
+            conclusion: 'success',
+          }),
+          stderr: '',
+        };
+      }
+      if (cmd === 'run' && sub === 'download') {
+        const dirIdx = args.indexOf('--dir');
+        const dir = args[dirIdx + 1]!;
+        const verdictPath = join(dir, 'branch-fix-verdict.json');
+        writeFileSync(
+          verdictPath,
+          JSON.stringify({
+            contract: 'v1',
+            verdict: 'unreproduced',
+            exit_code: 0,
+            image_tag: 'ghcr.io/test/image:fix',
+            image_digest: 'sha256:test',
+            captured_at: '2026-05-17T10:05:00Z',
+            stdout: '',
+            stderr_tail: '',
+          }),
+          'utf-8',
+        );
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      return {
+        status: 1,
+        stdout: '',
+        stderr: `unexpected gh call: ${args.join(' ')}`,
+      };
+    });
+
+    const r = await runLayer23Verdict({
+      slug: 'bash-local-shadows-exit',
+      mode: 'fixed',
+      branch_image: 'ghcr.io/test/image:fix',
+      poll_interval_ms: 1,
+      poll_timeout_ms: 5000,
+    });
+
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.verdict, 'unreproduced');
+      assert.equal(r.source, 'workflow-artefact');
+      assert.equal(r.workflow_run_id, 9999);
+      assert.equal(r.mode, 'fixed');
+    }
+  });
+
+  it('mode=fixed → picks the post-dispatch run when older runs precede it', async () => {
+    _setSleeperForTesting(async () => {
+      /* skip waits */
+    });
+
+    // gh run list returns 3 runs: two created before dispatch (stale)
+    // and one created after. The implementation must filter by
+    // createdAt and pick the post-dispatch one — NOT the most recent
+    // overall (which would be `runs[0]`, an older queued run).
+    _setLayer23GhRunnerForTesting((args) => {
+      const cmd = args[0];
+      const sub = args[1];
+      if (cmd === 'workflow' && sub === 'run') {
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      if (cmd === 'run' && sub === 'list') {
+        const now = Date.now();
+        const stale1 = new Date(now - 60_000).toISOString();
+        const stale2 = new Date(now - 30_000).toISOString();
+        const ours = new Date(now + 1_000).toISOString();
+        return {
+          status: 0,
+          stdout: JSON.stringify([
+            { databaseId: 1111, status: 'queued', createdAt: stale1 },
+            { databaseId: 2222, status: 'queued', createdAt: stale2 },
+            { databaseId: 3333, status: 'queued', createdAt: ours },
+          ]),
+          stderr: '',
+        };
+      }
+      if (cmd === 'run' && sub === 'view') {
+        return {
+          status: 0,
+          stdout: JSON.stringify({
+            status: 'completed',
+            conclusion: 'success',
+          }),
+          stderr: '',
+        };
+      }
+      if (cmd === 'run' && sub === 'download') {
+        const dirIdx = args.indexOf('--dir');
+        const dir = args[dirIdx + 1]!;
+        writeFileSync(
+          join(dir, 'branch-fix-verdict.json'),
+          JSON.stringify({
+            contract: 'v1',
+            verdict: 'unreproduced',
+            exit_code: 0,
+            image_tag: 'ghcr.io/test/image:fix',
+            image_digest: 'sha256:test',
+            captured_at: '2026-05-17T10:05:00Z',
+            stdout: '',
+            stderr_tail: '',
+          }),
+          'utf-8',
+        );
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      return { status: 1, stdout: '', stderr: 'unexpected' };
+    });
+
+    const r = await runLayer23Verdict({
+      slug: 'bash-local-shadows-exit',
+      mode: 'fixed',
+      branch_image: 'ghcr.io/test/image:fix',
+      poll_interval_ms: 1,
+      poll_timeout_ms: 5000,
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      // 3333 is the only post-dispatch run; the older 1111 / 2222
+      // must be ignored even though they appear first in the list.
+      assert.equal(r.workflow_run_id, 3333);
+    }
+  });
+
+  it('mode=fixed → ok:false when every returned run pre-dates the dispatch', async () => {
+    _setSleeperForTesting(async () => {
+      /* skip waits */
+    });
+
+    _setLayer23GhRunnerForTesting((args) => {
+      const cmd = args[0];
+      const sub = args[1];
+      if (cmd === 'workflow' && sub === 'run') {
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      if (cmd === 'run' && sub === 'list') {
+        const now = Date.now();
+        // All runs are well before the dispatch + 5s buffer cutoff.
+        return {
+          status: 0,
+          stdout: JSON.stringify([
+            {
+              databaseId: 1111,
+              status: 'queued',
+              createdAt: new Date(now - 120_000).toISOString(),
+            },
+            {
+              databaseId: 2222,
+              status: 'queued',
+              createdAt: new Date(now - 60_000).toISOString(),
+            },
+          ]),
+          stderr: '',
+        };
+      }
+      return { status: 1, stdout: '', stderr: 'unexpected' };
+    });
+
+    const r = await runLayer23Verdict({
+      slug: 'bash-local-shadows-exit',
+      mode: 'fixed',
+      branch_image: 'ghcr.io/test/image:fix',
+      poll_interval_ms: 1,
+      poll_timeout_ms: 5000,
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.match(r.error, /at or after dispatch/);
+      assert.match(r.error, /2 older run/);
+    }
+  });
+
+  it('mode=fixed → reports workflow timeout when polling deadline elapses', async () => {
+    _setSleeperForTesting(async () => {
+      /* skip waits */
+    });
+
+    _setLayer23GhRunnerForTesting((args) => {
+      const cmd = args[0];
+      const sub = args[1];
+      if (cmd === 'workflow' && sub === 'run') {
+        return { status: 0, stdout: '', stderr: '' };
+      }
+      if (cmd === 'run' && sub === 'list') {
+        return {
+          status: 0,
+          stdout: JSON.stringify([
+            {
+              databaseId: 7777,
+              status: 'queued',
+              createdAt: '2026-05-17T10:00:00Z',
+            },
+          ]),
+          stderr: '',
+        };
+      }
+      if (cmd === 'run' && sub === 'view') {
+        // Always still running — drives the loop to timeout.
+        return {
+          status: 0,
+          stdout: JSON.stringify({
+            status: 'in_progress',
+            conclusion: null,
+          }),
+          stderr: '',
+        };
+      }
+      return { status: 1, stdout: '', stderr: 'unexpected' };
+    });
+
+    const r = await runLayer23Verdict({
+      slug: 'bash-local-shadows-exit',
+      mode: 'fixed',
+      branch_image: 'ghcr.io/test/image:fix',
+      poll_interval_ms: 1,
+      poll_timeout_ms: 50,
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.match(r.error, /did not complete within/);
+      assert.equal(r.workflow_run_id, 7777);
     }
   });
 });

--- a/src/layer1_wasm/tests/verdict-capture.spec.ts
+++ b/src/layer1_wasm/tests/verdict-capture.spec.ts
@@ -1,0 +1,96 @@
+// Verdict-capture spec for Phase 3 of the round-trip automation:
+// runs one Layer 1 recipe in the existing Playwright harness, waits
+// for the in-page contract-v1 verdict, and writes a JSON snapshot to
+// the path in `VERDICT_CAPTURE_OUTPUT` so the MCP server's
+// `run_layer1_verdict` helper can read it back. Driven by `--grep
+// "verdict-capture: <slug>"` so the helper can target a single recipe.
+//
+// Optional env vars:
+//   PLAYWRIGHT_FIX_URL       — appended as ?fix_url=<value> on the
+//                              recipe URL so the recipe page substitutes
+//                              the candidate fix before producing a
+//                              verdict (Path A semantics).
+//   VERDICT_CAPTURE_OUTPUT   — absolute path where the captured verdict
+//                              is written as JSON. If unset, the spec
+//                              just asserts the verdict reached one of
+//                              the contract-v1 values without writing.
+//
+// Recipe list is sourced from docs/site/public/api/recipes.json so a
+// new Layer 1 recipe automatically gets a verdict-capture case once
+// `mise run recipes:index` is run.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+const LAYER1 = "http://localhost:8767";
+
+interface RecipeEntry {
+  slug: string;
+  layer: 1 | 2 | 3;
+}
+
+interface RecipesIndex {
+  recipes: RecipeEntry[];
+}
+
+function loadLayer1Slugs(): string[] {
+  const indexPath = resolve(
+    process.cwd(),
+    "../../docs/site/public/api/recipes.json",
+  );
+  const raw = readFileSync(indexPath, "utf-8");
+  const parsed = JSON.parse(raw) as RecipesIndex;
+  return parsed.recipes
+    .filter((r) => r.layer === 1)
+    .map((r) => r.slug)
+    .sort();
+}
+
+const SLUGS = loadLayer1Slugs();
+const FIX_URL = process.env["PLAYWRIGHT_FIX_URL"];
+const OUTPUT_PATH = process.env["VERDICT_CAPTURE_OUTPUT"];
+
+for (const slug of SLUGS) {
+  test(`verdict-capture: ${slug}`, async ({ page }) => {
+    let url = `${LAYER1}/${slug}/`;
+    if (FIX_URL) {
+      const sep = url.includes("?") ? "&" : "?";
+      url = `${url}${sep}fix_url=${encodeURIComponent(FIX_URL)}`;
+    }
+    await page.goto(url);
+
+    await page.waitForFunction(
+      () => {
+        const v = (
+          globalThis as unknown as { __VIVARIUM_VERDICT__?: string }
+        ).__VIVARIUM_VERDICT__;
+        return v === "reproduced" || v === "unreproduced";
+      },
+      undefined,
+      { timeout: 75_000 },
+    );
+
+    const verdict = await page.evaluate(
+      () =>
+        (globalThis as unknown as { __VIVARIUM_VERDICT__: string })
+          .__VIVARIUM_VERDICT__,
+    );
+
+    if (OUTPUT_PATH) {
+      writeFileSync(
+        OUTPUT_PATH,
+        `${JSON.stringify({
+          slug,
+          verdict,
+          fix_url: FIX_URL ?? null,
+          captured_at: new Date().toISOString(),
+        })}\n`,
+        "utf-8",
+      );
+    }
+
+    expect(["reproduced", "unreproduced"]).toContain(verdict);
+  });
+}


### PR DESCRIPTION

Closes #253. Replaces the Phase 1 / 2 skeleton of verify_and_report_fix
with a real implementation that, when its state machine selects
verify_unfixed or verify_fixed, actually runs the capture and merges
the captured verdict into the response.

New helpers (not MCP-exposed; verify_and_report_fix is the only
caller):

- packages/mcp-server/src/tools/run_layer1_verdict.ts — spawns the
  existing Playwright harness via `bun run test --grep
  "verdict-capture: <slug>"` against a temp output file, reads the
  verdict JSON, returns the captured verdict. spawn + verdict-reader
  are injectable for unit tests.

- packages/mcp-server/src/tools/run_layer23_verdict.ts — two paths:
  mode=unfixed fetches the deployed verdict.json snapshot via the
  catalogue (Layer 1 recipes are rejected here; they have no static
  snapshot). mode=fixed dispatches branch-fix-verdict.yml via gh,
  filters `gh run list` output by createdAt against the dispatch
  boundary so a concurrent dispatch or stale older run cannot
  smuggle in a wrong run_id, polls `gh run view --json
  status,conclusion` until completion (15s interval, 10-min default
  timeout), downloads the
  `branch-fix-verdict-<slug>-<run_id>` artefact, and parses the
  Contract v1 verdict out of it. gh runner + snapshot fetcher +
  sleeper are all injectable.

New spec:

- src/layer1_wasm/tests/verdict-capture.spec.ts — Playwright spec
  that opens each Layer 1 recipe (driven by recipes.json) and writes
  the in-page verdict to `VERDICT_CAPTURE_OUTPUT` as JSON. Honours
  `PLAYWRIGHT_FIX_URL` by appending `?fix_url=` to the recipe URL.
  Picked up by run_layer1_verdict's `--grep "verdict-capture:
  <slug>"` invocation.

Modified:

- packages/mcp-server/src/tools/verify_and_report_fix.ts — Phase 3
  rewrite. When `auto_execute` is true (the new default), the tool
  invokes run_layer1_verdict (Layer 1) or run_layer23_verdict
  (Layer 2/3) for verify_unfixed / verify_fixed, merges the
  captured verdict into `verdicts`, and recomputes `next_action`
  against the updated state so the caller sees the next step.
  `auto_execute: false` preserves the Phase 1 / 2 behaviour
  (return commands without running anything). The response gains
  an optional `executed` field describing the action that just
  ran (source, ok, duration, error, workflow_run_id).

- packages/mcp-server/src/server.ts — SERVER_VERSION 0.1.4 → 0.2.0
  (minor bump because `verify_and_report_fix` now has side
  effects by default — caller behaviour can be impacted).

- packages/mcp-server/{package,jsr}.json — version sync.

Review fixes incorporated:

- [P1] Layer 3 verify_fixed is now rejected before any gh call.
  The branch-fix-verdict.yml workflow checks
  src/layer2_docker/<slug> only, so dispatching it for a Layer 3
  recipe would fail inside the workflow with a confusing error.
  executeLayer23 short-circuits with an informative `executed.ok =
  false` message instead. Workflow extension to handle Layer 3 is
  tracked as a follow-up.

- [P2] Run identification after `gh workflow run` is now bounded
  by the dispatch boundary. The implementation records Date.now()
  before the dispatch call, pulls up to 10 recent
  workflow_dispatch runs (rather than --limit 1), filters to
  candidates whose createdAt is at or after the boundary minus a
  5-second clock-drift buffer, and picks the earliest of those.
  Stale older runs for the same slug are explicitly excluded —
  they would have read a wrong artefact and yielded a misleading
  verdict. Concurrent dispatches within the buffer can still
  race; a correlation_id input on the workflow would close the
  remaining hole and is tracked as a follow-up.

Tests:

- mise run mcp:test → 113 pass / 0 fail (was 91; +22 new):
  - 7 cover the Phase 3 auto-execute paths on verify_and_report_fix
    (Layer 1 success, Layer 1 verify_fixed without fix_url, Layer 1
    spawn failure, Layer 3 verify_fixed rejection, Layer 2
    deployed-snapshot, auto_execute=false skips execution,
    non-executable next actions skip execution).
  - 6 cover run_layer1_verdict (missing slug, fix_url env passthrough,
    --grep targeting, non-zero spawn exit, malformed JSON output,
    slug mismatch).
  - 9 cover run_layer23_verdict (missing slug, invalid mode,
    unfixed snapshot path, unfixed snapshot missing,
    fixed-without-image, fixed happy path with stubbed dispatch +
    polling + artefact download, fixed picks post-dispatch run when
    older runs precede it, fixed rejects when every returned run
    pre-dates the dispatch, polling timeout).

Verification:

- mise run mcp:test → 113 pass / 0 fail.
- mise run mcp:build → tsc clean.
- mise run repro:typecheck → clean (verdict-capture.spec.ts type-
  checks).
- mise run docs:check → biome clean (54 files).
- mise run markdown:check → rumdl clean (41 files).
- mise run recipes:index → idempotent (no recipe changes).

End-to-end smoke tests on real recipes (mpmath-983 L1,
bash-local-shadows-exit L2) are deferred to a follow-up; they need
the Playwright stack + a published branch-fix image to exercise,
and the unit coverage above is enough to gate this PR.

Out of scope for this PR (tracked separately):

- Phase 4 (fork PR automation) and Phase 5 (/round-trip mega-skill).
- Layer 3 verify_fixed (needs branch-fix-verdict.yml workflow
  extension to handle src/layer3_thirdway/<slug>).
- correlation_id input on branch-fix-verdict.yml to close the
  concurrent-dispatch race.
- Writing the captured verdict back into the recipe's
  roundtrip.json — Phase 3 leaves that to the caller, as Phase 1
  did. May revisit once Phase 5 lands and the call pattern is
  clearer.
