### PR TITLE
docs(guide): add round-trip page and clean up /en/ prefix across en guides

### DIFF
--- a/docs/site/en/guide/_meta.json
+++ b/docs/site/en/guide/_meta.json
@@ -26,6 +26,11 @@
   },
   {
     "type": "file",
+    "name": "round-trip",
+    "label": "Run the full round-trip"
+  },
+  {
+    "type": "file",
     "name": "fork-your-own",
     "label": "Run on your own fork"
   },

--- a/docs/site/en/guide/integrate-with-your-repo.mdx
+++ b/docs/site/en/guide/integrate-with-your-repo.mdx
@@ -29,12 +29,12 @@ import {
       <li>
         <code>.vivarium/manifest.toml</code> — a declaration that says
         "Vivarium-compatible reproduction lives here"
-        (spec: <a href="/vivarium/en/spec/manifest-v1">Manifest v1</a>).
+        (spec: <a href="/vivarium/spec/manifest-v1">Manifest v1</a>).
       </li>
       <li>
         <code>.github/workflows/check-bug.yml</code> — a one-job CI workflow
         that <code>uses:</code> the
-        {' '}<a href="/vivarium/en/spec/consumer-workflow">reusable verdict workflow</a>.
+        {' '}<a href="/vivarium/spec/consumer-workflow">reusable verdict workflow</a>.
       </li>
     </ul>
     <p>That's enough to make "is this upstream bug still reproducing?" a green / red signal in your own CI, on every PR or on a daily schedule. The day upstream ships a fix, the workflow turns red — and that red is your "we no longer need to track this bug" signal.</p>
@@ -54,11 +54,11 @@ import {
       <li><code>bash-local-shadows-exit</code> (Layer 2 / bash)</li>
       <li><code>pandas-56679</code> (Layer 1 / pandas)</li>
     </ul>
-    <p>The faceted{' '}<a href="/vivarium/en/repro/">recipe gallery</a>{' '} is the way to browse. If you have a concrete error message in hand, the{' '} <a href="/vivarium/en/repro/match">error → recipe matcher</a>{' '} ranks candidates for you.</p>
+    <p>The faceted{' '}<a href="/vivarium/repro/">recipe gallery</a>{' '} is the way to browse. If you have a concrete error message in hand, the{' '} <a href="/vivarium/repro/match">error → recipe matcher</a>{' '} ranks candidates for you.</p>
     <Callout>
       If the upstream bug isn't in the catalogue yet, you're in the "build a
       new recipe" path instead, which is documented in{' '}
-      <a href="/vivarium/en/guide/fork-your-own">Run on your own fork</a>.
+      <a href="/vivarium/guide/fork-your-own">Run on your own fork</a>.
     </Callout>
   </Section>
 
@@ -70,7 +70,7 @@ import {
       items={[
         {
           lead: 'Generate via the scaffolder.',
-          body: <>An interactive form lives at <a href="/vivarium/en/spec/manifest-create">Create a manifest</a>. Fill in slug, layer, bug.project, bug.issue, bug.upstream_url, hit "Generate," and the TOML pops out.</>,
+          body: <>An interactive form lives at <a href="/vivarium/spec/manifest-create">Create a manifest</a>. Fill in slug, layer, bug.project, bug.issue, bug.upstream_url, hit "Generate," and the TOML pops out.</>,
         },
         {
           lead: 'Drop it at the repo root.',
@@ -85,7 +85,7 @@ import {
     <Callout>
       Hand-writing the manifest is fine — the scaffolder is just there to spit
       out the canonical shape. The authoritative spec is{' '}
-      <a href="/vivarium/en/spec/manifest-v1">Manifest v1</a>, and
+      <a href="/vivarium/spec/manifest-v1">Manifest v1</a>, and
       <code>verdict.schema.json</code> is published, so CI-side validation is
       possible too.
     </Callout>
@@ -153,8 +153,8 @@ jobs:
     <Callout>
       <strong>Red means "fixed," not "broken."</strong> The verdict semantics
       flip the test-mindset direction; the glossary{' '}
-      <a href="/vivarium/en/guide/glossary#verdict">verdict</a> entry and the{' '}
-      <a href="/vivarium/en/spec/contract-v1#verdict-semantics">Contract v1</a>{' '}
+      <a href="/vivarium/guide/glossary#verdict">verdict</a> entry and the{' '}
+      <a href="/vivarium/spec/contract-v1#verdict-semantics">Contract v1</a>{' '}
       page nail this down.
     </Callout>
   </Section>
@@ -167,11 +167,11 @@ jobs:
       items={[
         {
           lead: 'Verify a candidate fix actually flips the verdict.',
-          body: <>The comparison surface lets you put the post-fix verdict next to the pre-fix one: <a href="/vivarium/en/repro/compare">Compare reproductions</a>. It's the page built for AI-generated patches — a reproduced → unreproduced flip is exactly the "the fix worked" signal.</>,
+          body: <>The comparison surface lets you put the post-fix verdict next to the pre-fix one: <a href="/vivarium/repro/compare">Compare reproductions</a>. It's the page built for AI-generated patches — a reproduced → unreproduced flip is exactly the "the fix worked" signal.</>,
         },
         {
           lead: 'Pin to a specific image tag.',
-          body: <>The reusable workflow takes an <code>image:</code> input that overrides the default. A git-sha-tagged image, a private fork build — anything in GHCR — is fair game. Reference: the input table in <a href="/vivarium/en/spec/consumer-workflow">consumer workflow</a>.</>,
+          body: <>The reusable workflow takes an <code>image:</code> input that overrides the default. A git-sha-tagged image, a private fork build — anything in GHCR — is fair game. Reference: the input table in <a href="/vivarium/spec/consumer-workflow">consumer workflow</a>.</>,
         },
         {
           lead: 'Declare without scheduled checks.',
@@ -179,7 +179,7 @@ jobs:
         },
         {
           lead: 'The bug isn\'t in the catalogue yet.',
-          body: <>Then you're writing a new recipe, not consuming one. <a href="/vivarium/en/guide/fork-your-own">Run on your own fork</a> covers that flow. Layer 1 is fully self-contained inside a fork.</>,
+          body: <>Then you're writing a new recipe, not consuming one. <a href="/vivarium/guide/fork-your-own">Run on your own fork</a> covers that flow. Layer 1 is fully self-contained inside a fork.</>,
         },
       ]}
     />
@@ -201,8 +201,8 @@ jobs:
     </>
   }
   sub="The terms used here — manifest, verdict, layer, slug — are pinned to fixed meanings in the glossary."
-  primary={{ label: 'Glossary →', href: '/vivarium/en/guide/glossary' }}
-  ghost={{ label: 'Manifest v1 spec', href: '/vivarium/en/spec/manifest-v1' }}
+  primary={{ label: 'Glossary →', href: '/vivarium/guide/glossary' }}
+  ghost={{ label: 'Manifest v1 spec', href: '/vivarium/spec/manifest-v1' }}
 />
 
 <BottomNote

--- a/docs/site/en/guide/round-trip.mdx
+++ b/docs/site/en/guide/round-trip.mdx
@@ -1,0 +1,302 @@
+---
+pageType: doc
+title: Run the full round-trip
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  NumberedList,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../_components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · ROUND-TRIP"
+    title="Reproduce, fix, verify, open both PRs — in one orchestrated loop."
+    sub="The Vivarium round-trip skill walks an AI agent and a human through the full path from an upstream bug report to a draft fix PR. Phases 1-5 of the round-trip automation plan ship the underlying tooling; this guide is the human-readable companion to the `round-trip` Claude Code skill."
+  />
+
+  <Section
+    eyebrow="// 0 · WHAT THIS GUIDE COVERS"
+    heading="End-to-end orchestration of the round-trip loop."
+  >
+    <p>
+      This guide describes the round-trip loop in human-readable form:
+      what happens at each stage, what is automated, and what stays a
+      human decision. The machine-readable orchestration itself lives
+      in <code>.claude/skills/round-trip/SKILL.md</code> — auto-loaded
+      by Claude Code when its triggers match; you usually do not read
+      it directly.
+    </p>
+    <p>
+      If you only want to scaffold a recipe — without the full fix-
+      and-PR loop — use the{' '}
+      <a href="/vivarium/guide/getting-started">Getting started</a>{' '}
+      guide instead.
+    </p>
+    <Callout>
+      <strong>This guide is still under iteration.</strong> Concrete
+      examples grow as the maintainer exercises the loop on real
+      upstream issues; expect this page to fill out over time.
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 1 · PREREQUISITES"
+    heading="What you need installed and configured."
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'gh CLI authenticated with repo scope.',
+          body: (
+            <>
+              Run <code>gh auth login</code> if not already done. The
+              skill calls <code>gh issue view</code>,{' '}
+              <code>gh pr create</code>, <code>gh workflow run</code>,
+              and <code>gh run download</code>; <code>repo</code> is
+              the minimum scope.
+            </>
+          ),
+        },
+        {
+          lead: 'MCP server registered with your client.',
+          body: (
+            <>
+              See{' '}
+              <a href="/vivarium/guide/use-from-ai-agent">
+                Use from your AI agent
+              </a>
+              . The round-trip skill invokes{' '}
+              <code>search_upstream_issues</code>,{' '}
+              <code>prepare_new_recipe</code>,{' '}
+              <code>verify_and_report_fix</code>, and (Layer 2){' '}
+              <code>create_fork_pr</code>.
+            </>
+          ),
+        },
+        {
+          lead: 'Sapling (sl) on this side.',
+          body: (
+            <>
+              Vivarium uses{' '}
+              <a href="https://sapling-scm.com">Sapling</a> as its SCM
+              rather than Git directly. The skill drives{' '}
+              <code>sl addremove</code> / <code>sl commit</code> /{' '}
+              <code>sl amend</code> / <code>sl pr submit</code> for
+              the Vivarium-side PR.
+            </>
+          ),
+        },
+        {
+          lead: 'Layer 2 only: GHCR PAT.',
+          body: (
+            <>
+              A classic PAT with <code>write:packages</code> scope,
+              stored per the one-time setup{' '}
+              <code>mise run ghcr:login</code> documents. Used by{' '}
+              <code>mise run branch-fix:publish</code> at Stage 5.5.
+            </>
+          ),
+        },
+      ]}
+    />
+  </Section>
+
+  <Section
+    eyebrow="// 2 · THE FLOW AT A GLANCE"
+    heading="Ten stages, with a layer-dependent verdict path."
+  >
+    <p>
+      Stages 0 – 5 are layer-independent; the path branches at Stage 6
+      depending on whether the recipe is Layer 1 (WASM in-browser) or
+      Layer 2 (Docker). Layer 3 (record-replay) is currently out of
+      scope for the fixed-verdict capture — see the cheat sheet
+      below.
+    </p>
+    <pre>
+      <code>{`Stage 0    Pre-flight (project activity, issue exists, no linked PR)
+Stage 1    Scaffold (prepare_new_recipe + mise run recipes:new)
+Stage 2    Implement reproduction (human + AI)
+Stage 3    Capture unfixed verdict (verify_and_report_fix)
+Stage 4    Open the Vivarium PR (sl pr submit, label ai: generated)
+Stage 5    Fork upstream + push fix branch (human)
+Stage 5.5  Layer 2 only: build & push branch-fix image
+             (mise run branch-fix:publish)
+Stage 6    Capture fixed verdict
+             - Layer 1: prepare_fix_candidate → CI wheel build →
+                        live recipe page (visual confirm by human)
+             - Layer 2: verify_and_report_fix with branch_image →
+                        branch-fix-verdict.yml + artefact
+Stage 7    Update Vivarium PR with fixed verdict
+             (Layer 2 only; sl amend + sl pr submit)
+Stage 8    Open upstream draft PR
+             - Layer 1: commands returned by prepare_fix_candidate
+             - Layer 2: create_fork_pr (dry_run: false)
+Stage 9    Final Vivarium-side commit
+             (Layer 2 only; sl amend + sl pr submit)`}</code>
+    </pre>
+  </Section>
+
+  <Section
+    eyebrow="// 3 · INVOKING THE SKILL"
+    heading="One sentence, the agent does the rest."
+  >
+    <p>Tell your AI agent (Claude Code, Cursor, Cline) something like:</p>
+    <blockquote>
+      <em>
+        Run the full round-trip on https://github.com/owner/repo/issues/N.
+        It is a Layer 2 bug; the title is &quot;short title&quot;; base
+        image is <code>node:26-slim</code>.
+      </em>
+    </blockquote>
+    <p>
+      The agent picks up the <code>round-trip</code> skill (auto-loaded
+      when its trigger conditions match) and walks you through each
+      stage. At every hand-off back to you (Stages 2, 5, sometimes 6
+      for Layer 1) you confirm and the agent continues. On any failure
+      the skill sets <code>roundtrip.json#/status</code> to{' '}
+      <code>&quot;blocked&quot;</code> and stops — see Troubleshooting
+      below.
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 4 · LAYER 1 vs LAYER 2 CHEAT SHEET"
+    heading="The fixed-verdict path differs; everything else lines up."
+  >
+    <table>
+      <thead>
+        <tr>
+          <th></th>
+          <th>Layer 1 (WASM)</th>
+          <th>Layer 2 (Docker)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Unfixed verdict source</td>
+          <td>
+            In-browser Pyodide / Ruby.wasm / php-wasm, captured by
+            Playwright against <code>src/layer1_wasm/&lt;slug&gt;/</code>
+          </td>
+          <td>
+            Deployed <code>verdict.json</code> snapshot CI captured at
+            recipe-merge time
+          </td>
+        </tr>
+        <tr>
+          <td>Fix delivery</td>
+          <td>
+            Fork branch → CI wheel build (fires on Vivarium PR merge
+            via <code>deploy-docs.yml</code>)
+          </td>
+          <td>
+            Fork branch → contributor builds the Docker image locally
+            → GHCR push
+          </td>
+        </tr>
+        <tr>
+          <td>Fixed verdict source</td>
+          <td>
+            Live recipe page renders baseline + fix-candidate
+            side-by-side; human confirms visually
+          </td>
+          <td>
+            <code>branch-fix-verdict.yml</code> workflow artefact
+            (Contract v1 <code>branch-fix-verdict.json</code>)
+          </td>
+        </tr>
+        <tr>
+          <td>Upstream PR opening</td>
+          <td>
+            Commands returned by <code>prepare_fix_candidate</code>,
+            run manually after the Vivarium PR merges
+          </td>
+          <td>
+            <code>create_fork_pr</code> MCP tool with{' '}
+            <code>dry_run: false</code> (draft PR + body footer
+            disclosure)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <p>
+      Layer 3 (record-replay): <code>verify_and_report_fix</code>{' '}
+      rejects Layer 3 <code>verify_fixed</code> with an informative
+      error — <code>branch-fix-verdict.yml</code> only handles{' '}
+      <code>src/layer2_docker/&lt;slug&gt;/</code>. Workflow extension
+      to handle <code>src/layer3_thirdway/&lt;slug&gt;/</code> is
+      tracked separately.
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 5 · TROUBLESHOOTING"
+    heading="When the skill bails with status: blocked."
+  >
+    <p>
+      Any stage failure flips{' '}
+      <code>roundtrip.json#/status</code> to{' '}
+      <code>&quot;blocked&quot;</code> and stops the skill. A
+      subsequent <code>/round-trip</code> invocation on the same slug
+      refuses to resume until the human clears it.
+    </p>
+    <p>To resume:</p>
+    <ol>
+      <li>
+        Read <code>roundtrip.json#/notes[]</code> for the failure
+        reason and stage number.
+      </li>
+      <li>
+        Fix the underlying issue (typically: re-run the failed command
+        manually with verbose flags to see what actually went wrong).
+      </li>
+      <li>
+        Edit <code>roundtrip.json</code> — set <code>status</code> back
+        to its expected value (likely <code>&quot;verifying&quot;</code>
+        or <code>&quot;verified&quot;</code> depending on how far you
+        got) and bump <code>updated_at</code>.
+      </li>
+      <li>
+        Re-invoke <code>/round-trip</code>. The skill re-reads{' '}
+        <code>roundtrip.json</code> and resumes from the appropriate
+        stage (the <code>computeNextAction</code> state machine in{' '}
+        <code>verify_and_report_fix</code> picks the resume point).
+      </li>
+    </ol>
+  </Section>
+
+  <Callout>
+    Found something this guide didn't cover? File an issue against{' '}
+    <a href="https://github.com/aletheia-works/vivarium/issues">
+      aletheia-works/vivarium
+    </a>{' '}
+    so we can fold the gap back into this page.
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      Compare a branch-fix verdict{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="The round-trip skill orchestrates branch-fix verification, but you can also drive it manually for one-off fix verification."
+  primary={{
+    label: 'Compare branch-fix guide →',
+    href: '/vivarium/guide/compare-branch-fix',
+  }}
+  ghost={{ label: 'Glossary', href: '/vivarium/guide/glossary' }}
+/>
+
+<BottomNote
+  text="VIVARIUM IS PART OF ALETHEIA-WORKS · SEE SOURCE ON GITHUB →"
+  href="https://github.com/aletheia-works/vivarium"
+/>

--- a/docs/site/en/guide/use-from-ai-agent.mdx
+++ b/docs/site/en/guide/use-from-ai-agent.mdx
@@ -131,7 +131,7 @@ bun run build
         Layer 2 / 3 returns Path B: a <code>/repro/compare</code> deep-link
         plus the <code>gh workflow run branch-fix-verdict.yml</code>{' '}
         command the contributor runs. Full walkthrough:{' '}
-        <a href="/vivarium/en/guide/compare-branch-fix">Verify a branch-fix</a>.
+        <a href="/vivarium/guide/compare-branch-fix">Verify a branch-fix</a>.
       </li>
       <li>
         <strong><code>prepare_new_recipe(project, issue, title, base_image?, repo_owner?, layer?)</code></strong> —
@@ -183,7 +183,7 @@ bun run build
     />
     <Callout>
       The <code>match_error</code> scoring is bit-identical to the{' '}
-      <a href="/vivarium/en/repro/match">error → recipe matcher</a>{' '}
+      <a href="/vivarium/repro/match">error → recipe matcher</a>{' '}
       page. MCP and UI return the same ranked candidates.
     </Callout>
   </Section>
@@ -215,7 +215,7 @@ bun run build
       <li>
         <strong>"Layer 1 verdict isn't a snapshot."</strong> By design
         — Layer 1's site of truth is the browser at view time
-        (<a href="/vivarium/en/spec/contract-v1">Contract v1</a>). The
+        (<a href="/vivarium/spec/contract-v1">Contract v1</a>). The
         agent should treat <code>kind: "live"</code> as "open this URL
         for the human to verify."
       </li>
@@ -230,11 +230,11 @@ bun run build
       items={[
         {
           lead: 'Pair with consumer-side CI.',
-          body: <><a href="/vivarium/en/guide/integrate-with-your-repo">Integrate with your own repo</a> sets up the verdict-watch side from your own CI. The two sides — agent + CI — close the loop.</>,
+          body: <><a href="/vivarium/guide/integrate-with-your-repo">Integrate with your own repo</a> sets up the verdict-watch side from your own CI. The two sides — agent + CI — close the loop.</>,
         },
         {
           lead: 'Verify a branch fix end-to-end.',
-          body: <>Confirming "did my candidate fix flip reproduced → unreproduced?" through the agent in one shot is wired up via <code>verify_branch_fix</code>. Full walkthrough: <a href="/vivarium/en/guide/compare-branch-fix">Verify a branch-fix</a>.</>,
+          body: <>Confirming "did my candidate fix flip reproduced → unreproduced?" through the agent in one shot is wired up via <code>verify_branch_fix</code>. Full walkthrough: <a href="/vivarium/guide/compare-branch-fix">Verify a branch-fix</a>.</>,
         },
       ]}
     />
@@ -255,8 +255,8 @@ bun run build
     </>
   }
   sub="With the agent side wired, adding the consumer-CI side closes the other half of the loop."
-  primary={{ label: 'Integrate guide →', href: '/vivarium/en/guide/integrate-with-your-repo' }}
-  ghost={{ label: 'Glossary', href: '/vivarium/en/guide/glossary' }}
+  primary={{ label: 'Integrate guide →', href: '/vivarium/guide/integrate-with-your-repo' }}
+  ghost={{ label: 'Glossary', href: '/vivarium/guide/glossary' }}
 />
 
 <BottomNote

--- a/docs/site/en/guide/write-your-first-reproduction.mdx
+++ b/docs/site/en/guide/write-your-first-reproduction.mdx
@@ -26,11 +26,11 @@ import { ExampleSlug } from '../../_components/LiveExamples';
     heading="A minimal Layer 1 (in-browser WASM) recipe."
   >
     <p>Layer 1 pulls the upstream code into the browser via{' '} <a href="https://pyodide.org/">Pyodide</a>,{' '} <a href="https://ruby.wasm.ie/">Ruby.wasm</a>, php-wasm, or the Rust{' '} <code>wasm32-wasip1</code> target, runs the reproduction script the moment the page loads, and returns a verdict. No install, no server — so a Layer 1 recipe is the lowest-cost first contribution to Vivarium.</p>
-    <p>Layer 2 (Docker) and Layer 3 (record-replay) have their own niches in{' '} <a href="/vivarium/en/architecture">architecture</a>, but if you are writing your first recipe, start at Layer 1.</p>
+    <p>Layer 2 (Docker) and Layer 3 (record-replay) have their own niches in{' '} <a href="/vivarium/architecture">architecture</a>, but if you are writing your first recipe, start at Layer 1.</p>
     <Callout>
       This guide ends at "I have a working recipe locally." Where to
       publish it is a separate two-way fork:{' '}
-      <a href="/vivarium/en/guide/fork-your-own">Run on your own fork</a>{' '}
+      <a href="/vivarium/guide/fork-your-own">Run on your own fork</a>{' '}
       or a PR to the upstream repo.
     </Callout>
   </Section>
@@ -56,7 +56,7 @@ import { ExampleSlug } from '../../_components/LiveExamples';
       items={[
         {
           lead: 'Pick a clone target.',
-          body: <>For an upstream PR, clone <code>aletheia-works/vivarium</code> directly. To self-publish, follow the <a href="/vivarium/en/guide/fork-your-own">fork guide</a> and clone your fork.</>,
+          body: <>For an upstream PR, clone <code>aletheia-works/vivarium</code> directly. To self-publish, follow the <a href="/vivarium/guide/fork-your-own">fork guide</a> and clone your fork.</>,
         },
         {
           lead: 'Set up the toolchain via mise.',
@@ -83,7 +83,7 @@ import { ExampleSlug } from '../../_components/LiveExamples';
     <p><strong>Do not touch</strong>:{' '} <code>&lt;meta name="vivarium-contract" content="v1"&gt;</code>, the{' '} <code>#verdict</code> element, or the link to{' '} <code>../_shared/style.css</code>. Those carry Contract v1, and removing any of them breaks machine-readable verdict capture.</p>
     <Callout>
       The authoritative spec lives at{' '}
-      <a href="/vivarium/en/spec/contract-v1">Contract v1</a>. The
+      <a href="/vivarium/spec/contract-v1">Contract v1</a>. The
       allowed values for <code>data-verdict</code> and the schema for the{' '}
       <code>__VIVARIUM_RESULT__</code> envelope come from there.
     </Callout>
@@ -155,7 +155,7 @@ cd docs && bun run generate
 `}</code></pre>
     <p>Check that <code>docs/site/public/api/recipes.json</code> contains your slug. With the docs site running locally, the new recipe shows up as a card on the gallery:</p>
     <pre><code>{`cd docs && bun run dev
-# http://localhost:3000/vivarium/en/repro/`}</code></pre>
+# http://localhost:3000/vivarium/repro/`}</code></pre>
   </Section>
 
   <Section
@@ -170,11 +170,11 @@ cd docs && bun run generate
         },
         {
           lead: 'Self-publish on your fork.',
-          body: <>Push the recipe to your own <code>vivarium</code> fork's main, enable deploy via the <a href="/vivarium/en/guide/fork-your-own">fork guide</a>, and the recipe appears at <code>&lt;you&gt;.github.io/vivarium/</code>. Sharing is just sharing the URL.</>,
+          body: <>Push the recipe to your own <code>vivarium</code> fork's main, enable deploy via the <a href="/vivarium/guide/fork-your-own">fork guide</a>, and the recipe appears at <code>&lt;you&gt;.github.io/vivarium/</code>. Sharing is just sharing the URL.</>,
         },
         {
           lead: 'Track an existing recipe from your project repo.',
-          body: <>If you only want to <em>watch</em> a recipe (no new authoring), you don't need this guide — see <a href="/vivarium/en/guide/integrate-with-your-repo">Integrate with your own repo</a>, which uses Manifest v1 plus the reusable consumer-workflow.</>,
+          body: <>If you only want to <em>watch</em> a recipe (no new authoring), you don't need this guide — see <a href="/vivarium/guide/integrate-with-your-repo">Integrate with your own repo</a>, which uses Manifest v1 plus the reusable consumer-workflow.</>,
         },
       ]}
     />
@@ -196,8 +196,8 @@ cd docs && bun run generate
     </>
   }
   sub="The terms used here — slug, verdict, contract, layer — are pinned to fixed meanings in the glossary."
-  primary={{ label: 'Glossary →', href: '/vivarium/en/guide/glossary' }}
-  ghost={{ label: 'Contract v1 spec', href: '/vivarium/en/spec/contract-v1' }}
+  primary={{ label: 'Glossary →', href: '/vivarium/guide/glossary' }}
+  ghost={{ label: 'Contract v1 spec', href: '/vivarium/spec/contract-v1' }}
 />
 
 <BottomNote

--- a/docs/site/ja/guide/_meta.json
+++ b/docs/site/ja/guide/_meta.json
@@ -26,6 +26,11 @@
   },
   {
     "type": "file",
+    "name": "round-trip",
+    "label": "round-trip ループ全体を回す"
+  },
+  {
+    "type": "file",
     "name": "fork-your-own",
     "label": "自分のフォークで動かす"
   },

--- a/docs/site/ja/guide/round-trip.mdx
+++ b/docs/site/ja/guide/round-trip.mdx
@@ -1,0 +1,270 @@
+---
+pageType: doc
+title: round-trip ループ全体を回す
+---
+
+import {
+  Page,
+  PageHero,
+  Section,
+  NumberedList,
+  Callout,
+  NextCta,
+  BottomNote,
+} from '../../_components/PageChrome';
+
+<Page>
+  <PageHero
+    eyebrow="// GUIDE · ROUND-TRIP"
+    title="再現 → 修正 → 検証 → 両 PR を、ひとつのオーケストレーションで。"
+    sub="Vivarium の round-trip スキルは、上流バグレポートからドラフトの修正 PR を出すまでの全工程を AI エージェントと人間が協調しながら進めるためのものです。Phase 1〜5 の round-trip 自動化計画で実装したツール群を、ここでは人間視点で読み下した手順として記述します。機械可読版は `.claude/skills/round-trip/SKILL.md` に置かれています (Claude Code が自動 load)。"
+  />
+
+  <Section
+    eyebrow="// 0 · このガイドが扱う範囲"
+    heading="round-trip ループの end-to-end オーケストレーション。"
+  >
+    <p>
+      このガイドは round-trip ループを人間視点で説明します — 各 stage で何が起こり、どこまでが自動化され、どこが人間判断のままかを並べます。機械可読の orchestration 本体は{' '}
+      <code>.claude/skills/round-trip/SKILL.md</code>{' '}
+      にあり、Claude Code がトリガー一致時に自動 load します。普段直接読む必要はありません。
+    </p>
+    <p>
+      もしレシピの scaffold だけを行いたい場合 (完全な fix-and-PR ループ不要) は{' '}
+      <a href="/vivarium/ja/guide/getting-started">はじめての 5 分</a>{' '}
+      ガイドを使ってください。
+    </p>
+    <Callout>
+      <strong>このガイドはまだ反復中です。</strong>{' '}
+      メンテナが実際に上流 issue で 1 回ずつ回した結果をフィードバックしながら肉付けしていきます。具体例は今後増えていく想定です。
+    </Callout>
+  </Section>
+
+  <Section
+    eyebrow="// 1 · 前提条件"
+    heading="インストールと設定が必要なもの。"
+  >
+    <NumberedList
+      items={[
+        {
+          lead: 'gh CLI が repo スコープで authenticated。',
+          body: (
+            <>
+              まだなら <code>gh auth login</code> を実行。スキル内部では{' '}
+              <code>gh issue view</code>、<code>gh pr create</code>、<code>gh workflow run</code>、<code>gh run download</code> を呼ぶので、最低限 <code>repo</code> スコープが必要です。
+            </>
+          ),
+        },
+        {
+          lead: 'MCP サーバーをクライアントに登録済み。',
+          body: (
+            <>
+              <a href="/vivarium/ja/guide/use-from-ai-agent">AI エージェントから使う</a>{' '}
+              を参照。round-trip スキルは内部で{' '}
+              <code>search_upstream_issues</code>、<code>prepare_new_recipe</code>、<code>verify_and_report_fix</code>、(Layer 2 のみ) <code>create_fork_pr</code>{' '}
+              を呼びます。
+            </>
+          ),
+        },
+        {
+          lead: 'Sapling (sl) がインストール済み。',
+          body: (
+            <>
+              Vivarium は SCM として Git ではなく{' '}
+              <a href="https://sapling-scm.com">Sapling</a>{' '}
+              を使います。スキルは Vivarium 側 PR のために{' '}
+              <code>sl addremove</code> / <code>sl commit</code> / <code>sl amend</code> / <code>sl pr submit</code>{' '}
+              を駆動します。
+            </>
+          ),
+        },
+        {
+          lead: 'Layer 2 のみ: GHCR PAT。',
+          body: (
+            <>
+              <code>write:packages</code> スコープを持つ classic PAT を{' '}
+              <code>mise run ghcr:login</code> がドキュメント化している場所に配置。Stage 5.5 の{' '}
+              <code>mise run branch-fix:publish</code> で使います。
+            </>
+          ),
+        },
+      ]}
+    />
+  </Section>
+
+  <Section
+    eyebrow="// 2 · 全体の流れ"
+    heading="10 stage、verdict 経路は Layer 依存。"
+  >
+    <p>
+      Stage 0〜5 は Layer 非依存で共通、Stage 6 で Layer 1 (WASM in-browser) と Layer 2 (Docker) に分岐します。Layer 3 (record-replay) は現状 fixed-verdict 取得の対象外 — 詳細は下の cheat sheet を参照。
+    </p>
+    <pre>
+      <code>{`Stage 0    Pre-flight (project 活動度、issue 存在、関連 PR なし)
+Stage 1    Scaffold (prepare_new_recipe + mise run recipes:new)
+Stage 2    再現実装 (人間 + AI)
+Stage 3    unfixed verdict 取得 (verify_and_report_fix)
+Stage 4    Vivarium PR open (sl pr submit、ai: generated ラベル付与)
+Stage 5    Upstream fork + fix branch push (人間)
+Stage 5.5  Layer 2 のみ: branch-fix image を build & push
+             (mise run branch-fix:publish)
+Stage 6    fixed verdict 取得
+             - Layer 1: prepare_fix_candidate → CI wheel build →
+                        live recipe page (人間が visual confirm)
+             - Layer 2: verify_and_report_fix に branch_image を渡す →
+                        branch-fix-verdict.yml + artefact
+Stage 7    Vivarium PR を fixed verdict で更新
+             (Layer 2 のみ; sl amend + sl pr submit)
+Stage 8    Upstream draft PR open
+             - Layer 1: prepare_fix_candidate が返したコマンドを実行
+             - Layer 2: create_fork_pr (dry_run: false)
+Stage 9    最終 Vivarium 側 commit
+             (Layer 2 のみ; sl amend + sl pr submit)`}</code>
+    </pre>
+  </Section>
+
+  <Section
+    eyebrow="// 3 · スキルの起動"
+    heading="一文で投げれば、後はエージェントが進める。"
+  >
+    <p>AI エージェント (Claude Code / Cursor / Cline) に以下のように依頼:</p>
+    <blockquote>
+      <em>
+        https://github.com/owner/repo/issues/N の round-trip を回して。Layer 2、タイトルは「short title」、base image は{' '}
+        <code>node:26-slim</code>。
+      </em>
+    </blockquote>
+    <p>
+      エージェントは <code>round-trip</code> スキル (トリガー一致で自動 load) を選び、各 stage を案内します。人間に渡される箇所 (Stage 2、5、Layer 1 の場合は Stage 6 も) では確認後にエージェントが続行します。失敗時はスキルが{' '}
+      <code>roundtrip.json#/status</code> を{' '}
+      <code>&quot;blocked&quot;</code> に書き換えて停止 — 下の Troubleshooting を参照。
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 4 · LAYER 1 vs LAYER 2 cheat sheet"
+    heading="fixed verdict 経路だけが異なる、他は揃う。"
+  >
+    <table>
+      <thead>
+        <tr>
+          <th></th>
+          <th>Layer 1 (WASM)</th>
+          <th>Layer 2 (Docker)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Unfixed verdict ソース</td>
+          <td>
+            In-browser の Pyodide / Ruby.wasm / php-wasm を Playwright が{' '}
+            <code>src/layer1_wasm/&lt;slug&gt;/</code> に対して実行
+          </td>
+          <td>
+            recipe merge 時に CI が capture した deployed{' '}
+            <code>verdict.json</code> スナップショット
+          </td>
+        </tr>
+        <tr>
+          <td>Fix の届け方</td>
+          <td>
+            Fork branch → CI で wheel build (Vivarium PR merge 時に{' '}
+            <code>deploy-docs.yml</code> が発火)
+          </td>
+          <td>
+            Fork branch → コントリビュータがローカルで Docker image を build → GHCR に push
+          </td>
+        </tr>
+        <tr>
+          <td>Fixed verdict ソース</td>
+          <td>
+            Live recipe page が baseline + fix-candidate を side-by-side で描画、人間が visual に確認
+          </td>
+          <td>
+            <code>branch-fix-verdict.yml</code> workflow の artefact (Contract v1 形式の{' '}
+            <code>branch-fix-verdict.json</code>)
+          </td>
+        </tr>
+        <tr>
+          <td>Upstream PR の open</td>
+          <td>
+            <code>prepare_fix_candidate</code> が返したコマンドを Vivarium PR merge 後に手動実行
+          </td>
+          <td>
+            <code>create_fork_pr</code> MCP ツールに{' '}
+            <code>dry_run: false</code> を渡して draft PR を open (本文に AI 開示 footer を自動付与)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <p>
+      Layer 3 (record-replay) は{' '}
+      <code>verify_and_report_fix</code> 側で{' '}
+      <code>verify_fixed</code> が明示的に拒否されます — 現状{' '}
+      <code>branch-fix-verdict.yml</code> が{' '}
+      <code>src/layer2_docker/&lt;slug&gt;/</code> しか扱えないためです。{' '}
+      <code>src/layer3_thirdway/&lt;slug&gt;/</code> をサポートする workflow 拡張は別 issue で追跡しています。
+    </p>
+  </Section>
+
+  <Section
+    eyebrow="// 5 · TROUBLESHOOTING"
+    heading="スキルが status: blocked で停止したとき。"
+  >
+    <p>
+      どの stage でも失敗時は{' '}
+      <code>roundtrip.json#/status</code> が{' '}
+      <code>&quot;blocked&quot;</code> に書き換わり、スキルは停止します。同じ slug に対する{' '}
+      <code>/round-trip</code> 再起動は、人間が解除するまで再開を拒否します。
+    </p>
+    <p>解除手順:</p>
+    <ol>
+      <li>
+        <code>roundtrip.json#/notes[]</code> を読んで失敗理由と stage 番号を確認。
+      </li>
+      <li>
+        失敗の根本を修正 (典型的には: 失敗したコマンドを verbose フラグ付きで手動再実行し、何が起きたか掴む)。
+      </li>
+      <li>
+        <code>roundtrip.json</code> を編集 — <code>status</code> を期待値に戻し (進捗具合に応じて{' '}
+        <code>&quot;verifying&quot;</code> か{' '}
+        <code>&quot;verified&quot;</code>)、<code>updated_at</code> を更新。
+      </li>
+      <li>
+        <code>/round-trip</code> を再起動。スキルが{' '}
+        <code>roundtrip.json</code> を再読込し、{' '}
+        <code>verify_and_report_fix</code> の{' '}
+        <code>computeNextAction</code> ステートマシンが適切な stage を選んで再開します。
+      </li>
+    </ol>
+  </Section>
+
+  <Callout>
+    このガイドで触れていない事象に遭遇したら、{' '}
+    <a href="https://github.com/aletheia-works/vivarium/issues">
+      aletheia-works/vivarium
+    </a>{' '}
+    に issue を立ててください。穴を埋めてこのページに反映します。
+  </Callout>
+</Page>
+
+<NextCta
+  eyebrow="// NEXT"
+  heading={
+    <>
+      branch-fix verdict を比較する{' '}
+      <span className="v-next-cta__heading-arrow">→</span>
+    </>
+  }
+  sub="round-trip スキルが branch-fix 検証を内部で回しますが、単発の fix 検証なら手動でも実行できます。"
+  primary={{
+    label: 'ブランチ修正検証ガイド →',
+    href: '/vivarium/ja/guide/compare-branch-fix',
+  }}
+  ghost={{ label: '用語集', href: '/vivarium/ja/guide/glossary' }}
+/>
+
+<BottomNote
+  text="VIVARIUM IS PART OF ALETHEIA-WORKS · SEE SOURCE ON GITHUB →"
+  href="https://github.com/aletheia-works/vivarium"
+/>


### PR DESCRIPTION

The new round-trip guide (en + ja) is the human-readable companion
to the `round-trip` Claude Code skill ([#258]). While adding it,
reviewer flagged that the en docs use `/vivarium/en/guide/...` for
internal links — but rspress configures English as the default
locale (no locale segment in the URL), so those links 404 at
runtime even though the build's dead-link check did not catch them.
Same pattern was already present on three existing en pages, so
the fix is applied to all of them in this PR.

New:

- docs/site/en/guide/round-trip.mdx
- docs/site/ja/guide/round-trip.mdx

Modified:

- docs/site/en/guide/_meta.json — insert round-trip between
  compare-branch-fix and fork-your-own.
- docs/site/ja/guide/_meta.json — same insertion point.
- docs/site/en/guide/use-from-ai-agent.mdx (7 occurrences)
- docs/site/en/guide/integrate-with-your-repo.mdx (13 occurrences)
- docs/site/en/guide/write-your-first-reproduction.mdx (9 occurrences)
  — all dropping the `/en/` segment from internal links.

The Japanese pages (\`/vivarium/ja/guide/...\`) are correct as-is —
`ja` is a non-default locale and DOES carry its segment in the
URL.

Review fixes (now applied repo-wide for en):

- [P2] All internal links in en pages drop the `/en/` prefix.
  `/vivarium/guide/...` is the canonical English path; legacy
  `/vivarium/en/guide/...` was 404'ing at runtime.
- [P3] Missing space between \"(Layer 2)\" and a `<code>` element
  in the new round-trip page (would render as \"(Layer 2)create_fork_pr\").
  Inserted \`{' '}\` to keep the literal space.

Intent of the new page: short v1 — concrete examples grow as the
maintainer exercises the round-trip on real upstream issues and
folds findings back. The §0 Callout says this explicitly.

Verification:

- mise run docs:check → biome clean (54 files).
- mise run markdown:check → rumdl clean (42 files).
- mise run docs:build → rspress build green, dead-link check
  passed. Built site has zero `/vivarium/en/` references left.

No MCP server changes, no version bump. Phase 5 release (mcp-server-
v0.2.1 + v0.1.3) shipped earlier and is unaffected.
