### PR TITLE
feat(wasm): sympy-29413 reproduction + round-trip walkthrough target

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,7 +3,7 @@
   "configurations": [
     {
       "name": "vivarium-docs",
-      "runtimeExecutable": "C:\\Users\\Jam\\AppData\\Local\\mise\\installs\\bun\\1.3.13\\bin\\bun.exe",
+      "runtimeExecutable": "C:\\Users\\Jam\\AppData\\Local\\mise\\installs\\bun\\1.3.14\\bin\\bun.exe",
       "runtimeArgs": ["--cwd=docs", "run", "dev"],
       "port": 3000
     },

--- a/docs/site/_data/projects.json
+++ b/docs/site/_data/projects.json
@@ -50,6 +50,13 @@
       "homepage": "https://mpmath.org/",
       "github": "https://github.com/mpmath/mpmath"
     },
+    "sympy": {
+      "display_name": "SymPy",
+      "tagline": "Pure-Python symbolic mathematics.",
+      "description": "Assumption-system and symbolic-evaluation bugs that survive when SymPy is installed into Pyodide via micropip. The browser page and the host-Python repro.py share the exact same script and the same pinned wheel.",
+      "homepage": "https://www.sympy.org/",
+      "github": "https://github.com/sympy/sympy"
+    },
     "bash": {
       "display_name": "bash",
       "tagline": "GNU bash and POSIX shell semantics.",

--- a/docs/site/_data/recipe-facets.json
+++ b/docs/site/_data/recipe-facets.json
@@ -54,6 +54,12 @@
         "arbitrary-precision"
       ]
     },
+    "sympy-29413": {
+      "language": "python",
+      "symptom": "assumption-blind-spot-at-infinity",
+      "severity": "spec-violation",
+      "tags": ["sympy", "ask", "Q.extended_real", "core.relational", "infinity"]
+    },
     "find-xargs-whitespace": {
       "language": "shell",
       "symptom": "whitespace-unsafe-pipeline",

--- a/docs/site/public/api/projects.json
+++ b/docs/site/public/api/projects.json
@@ -169,6 +169,19 @@
       "description": "Reproductions run on ruby.wasm (CRuby compiled to WASI). Host parity is provided by mise-pinned ruby for the repro.rb script.",
       "homepage": "https://www.ruby-lang.org/",
       "github": "https://github.com/ruby/ruby"
+    },
+    {
+      "project": "sympy",
+      "display_name": "SymPy",
+      "recipe_count": 1,
+      "layers": [
+        1
+      ],
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/sympy/",
+      "tagline": "Pure-Python symbolic mathematics.",
+      "description": "Assumption-system and symbolic-evaluation bugs that survive when SymPy is installed into Pyodide via micropip. The browser page and the host-Python repro.py share the exact same script and the same pinned wheel.",
+      "homepage": "https://www.sympy.org/",
+      "github": "https://github.com/sympy/sympy"
     }
   ]
 }

--- a/docs/site/public/api/recipes.json
+++ b/docs/site/public/api/recipes.json
@@ -122,6 +122,35 @@
       "severity": "bug"
     },
     {
+      "slug": "sympy-29413",
+      "layer": 1,
+      "project": "sympy",
+      "issue": 29413,
+      "title": "sympy/sympy#29413",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/sympy/29413/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/sympy-29413",
+      "language": "python",
+      "tags": [
+        "sympy",
+        "ask",
+        "Q.extended_real",
+        "core.relational",
+        "infinity"
+      ],
+      "symptom": "assumption-blind-spot-at-infinity",
+      "severity": "spec-violation",
+      "roundtrip": {
+        "schema_version": 1,
+        "slug": "sympy-29413",
+        "upstream_issue": "https://github.com/sympy/sympy/issues/29413",
+        "status": "draft",
+        "updated_at": "2026-05-17T09:30:00Z",
+        "notes": [
+          "scaffolded from upstream issue via the round-trip skill walkthrough (sympy-29413 first end-to-end smoke)"
+        ]
+      }
+    },
+    {
       "slug": "bash-local-shadows-exit",
       "layer": 2,
       "project": "bash",

--- a/src/layer1_wasm/scripts/highlight-repros.ts
+++ b/src/layer1_wasm/scripts/highlight-repros.ts
@@ -57,6 +57,7 @@ const LANG_BY_PROJECT: Record<string, BundledLanguage> = {
   mpmath: 'python',
   numpy: 'python',
   pandas: 'python',
+  sympy: 'python',
   ruby: 'ruby',
   php: 'php',
   regex: 'rust',

--- a/src/layer1_wasm/sympy-29413/README.md
+++ b/src/layer1_wasm/sympy-29413/README.md
@@ -1,0 +1,135 @@
+# Reproduction — sympy/sympy#29413
+
+> **Status**: Layer 1 reproduction page. Uses the shared
+> [`_shared/`](../_shared/) helpers and TypeScript toolchain, and emits
+> the canonical `vivarium-contract: v1` surface.
+
+## The bug
+
+[sympy/sympy#29413](https://github.com/sympy/sympy/issues/29413) —
+`ask(a + 1 > a, Q.extended_real(a))` returns `True`. The correct
+answer is `None`: `Q.extended_real(a)` admits `a = ±∞`, and at
+either infinity the predicate `a + 1 > a` is undefined (the
+left-hand side equals the right-hand side as both reduce to the
+same `∞`). The assumption system's blind spot lives in
+`core.relational`.
+
+Labels on the upstream issue: `Wrong Result`, `assumptions`,
+`core.relational`.
+
+## Why this bug
+
+- Five-line reproduction, zero non-sympy dependencies beyond the
+  Python stdlib.
+- Verdict is a strict identity check (`result is True`) — a single
+  boolean — so the page emits a mechanically-distinguishable
+  `reproduced` / `unreproduced` value.
+- Reported against sympy 1.14.0 (latest at issue filing time).
+  This page pins `sympy==1.14.0` via micropip so the verdict flips
+  from `reproduced` to `unreproduced` only when the wheel Pyodide
+  installs reflects an upstream fix.
+- Pure sympy core — no plotting, no codegen, no external solvers.
+  Nothing in the repro path touches a browser-restricted surface.
+
+## Files
+
+| File         | Role                                                              |
+| ------------ | ----------------------------------------------------------------- |
+| `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
+| `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
+| `repro.py`   | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. See "Native verification" below. |
+| `roundtrip.json` | Tracked workflow state (round-trip schema_version 1). Updated as the recipe moves through verify → Vivarium PR → fork+fix → upstream PR. |
+
+Shared visual presentation lives in [`../_shared/style.css`](../_shared/style.css);
+this directory does not carry its own copy.
+
+## Verdict contract — `vivarium-contract: v1`
+
+The page conforms to the contract canonicalised in
+[`../_shared/verdict.ts`](../_shared/verdict.ts):
+
+- `<meta name="vivarium-contract" content="v1">` declared in `<head>`.
+- `document.querySelector('#verdict').dataset.verdict` ∈
+  `{"pending", "reproduced", "unreproduced"}`.
+- `globalThis.__VIVARIUM_VERDICT__` — mirror of the DOM verdict.
+- `globalThis.__VIVARIUM_RESULT__` — a `VivariumResultV1` envelope:
+  `{ contract: "v1", bug: { project: "sympy", issue: 29413, upstream_url },
+  runtime: { name: "pyodide", version, extras: { python, sympy } },
+  result: { ask_result, reproduced }, timing }`.
+- Visible verdict text starts with `bug reproduced` or
+  `bug not reproduced`.
+
+A `reproduced` verdict means **the bug reproduced** (sympy's
+assumption system still claims `True` for `a + 1 > a` under
+`Q.extended_real(a)`). An `unreproduced` verdict means either the
+bug was fixed in the sympy wheel micropip currently resolves, or
+the runtime itself errored before producing a result.
+
+## Running locally — in-browser
+
+```bash
+# 1. From src/layer1_wasm/, build the TypeScript sources once.
+cd src/layer1_wasm
+bun install        # one-time per machine / lockfile change
+bun run build      # emits repro.js next to repro.ts (gitignored)
+
+# 2. Serve this directory.
+python -m http.server -d sympy-29413 8765
+# then open http://localhost:8765/
+```
+
+Pyodide does **not** require COOP/COEP headers for this page (no
+`SharedArrayBuffer`, no threading), so a plain server is enough.
+
+## Native verification — same reproduction under a real CPython + sympy
+
+The companion `repro.py` script reproduces the bug without any
+WASM layer, so a contributor can confirm the gallery page is
+catching a *real* upstream behaviour rather than a Pyodide /
+micropip quirk. PEP 723 inline metadata pins
+**`sympy==1.14.0`** and the `mise.toml` at the repo root pins
+Python to 3.13:
+
+```bash
+# One-time per machine / mise.toml change.
+mise install
+
+# Reproduces the bug; exits 0 on `reproduced`. uv reads the inline
+# metadata, builds an ephemeral venv, and runs the script.
+mise exec uv -- uv run src/layer1_wasm/sympy-29413/repro.py
+
+# Expected output (sympy 1.14.0):
+# {
+#   "sympy_version": "1.14.0",
+#   "python_version": "3.13.x",
+#   "ask_result": "True",
+#   "expected": "None (undefined when a = ±oo)",
+#   "reproduced": true
+# }
+# verdict=reproduced — ask(a+1>a, Q.extended_real(a)) returned True, but a=±oo would make this undefined.
+```
+
+## Round-trip state
+
+`roundtrip.json` tracks the recipe's progress through the round-
+trip loop (see
+[the round-trip guide](https://aletheia-works.github.io/vivarium/guide/round-trip)
+for the stage breakdown). Stages reflect:
+
+- `status: "draft"` — recipe just scaffolded.
+- `status: "verifying"` — `verdicts.unfixed` captured.
+- `status: "verified"` — both verdicts captured, the fix actually
+  flips the page.
+- `status: "upstream_open"` — upstream draft PR opened.
+- `status: "merged"` — upstream merged. (Terminal.)
+- `status: "blocked"` — any stage failure; reason in `notes[]`.
+
+## Deployment
+
+Published to GitHub Pages at
+`https://aletheia-works.github.io/vivarium/repro/sympy/29413/` by
+the `deploy-docs` workflow. The workflow runs `bun install` +
+`bun run build` in `src/layer1_wasm/` first so the compiled
+`repro.js` exists when the bundling step copies the directory
+into the Pages artefact.

--- a/src/layer1_wasm/sympy-29413/index.html
+++ b/src/layer1_wasm/sympy-29413/index.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="vivarium-contract" content="v1" />
+    <title>Vivarium · Reproducing sympy/sympy#29413</title>
+    <!-- vivarium-chrome-injected -->
+    <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.asm.wasm" as="fetch" type="application/wasm" crossorigin />
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/python_stdlib.zip" as="fetch" crossorigin />
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide-lock.json" as="fetch" type="application/json" crossorigin />
+    <!-- Warm the TLS/HTTP3 handshake to jsDelivr in parallel with HTML parse. -->
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <!-- Keep the version below in sync with DEFAULT_PYODIDE_VERSION in
+         ../_shared/loader.ts. -->
+    <link
+      rel="modulepreload"
+      href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.mjs"
+      crossorigin
+    />
+    <link rel="stylesheet" href="../_shared/style.css" />
+    <template id="bug-context">
+      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <div class="vh-drawer__body" id="vh-drawer-body">
+        <p>
+          <code>ask(a + 1 &gt; a, Q.extended_real(a))</code> returns
+          <code>True</code> under sympy 1.14.0. The correct answer is
+          <code>None</code> — the predicate is undefined when
+          <code>a = ±∞</code>, which <code>Q.extended_real</code>
+          admits (extended reals include both infinities).
+        </p>
+        <p>
+          The script on this page sets up the assumption and asks
+          the question. If sympy returns <code>True</code>, the bug
+          reproduces; if it returns <code>None</code> (or
+          <code>False</code>), the upstream blind spot has been
+          fixed in the wheel Pyodide installed via micropip.
+        </p>
+        <p>
+          The full discussion (motivation, history, fix progress)
+          lives in the GitHub issue thread linked below.
+        </p>
+      </div>
+      <hr class="vh-drawer__divider" />
+      <div class="vh-drawer__meta-grid">
+        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-val">sympy/sympy</span>
+        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-val">#29413</span>
+        <span class="vh-drawer__meta-key">Layer</span>
+        <span class="vh-drawer__meta-val">L1 · WASM</span>
+        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-val">Pyodide v0.29.3 + sympy 1.14.0 (micropip)</span>
+      </div>
+    </template>
+  </head>
+  <body>
+    <main class="vh-main">
+      <header class="vh-main__header">
+        <div class="vh-main__header-text">
+          <p class="kicker">L1 · Pyodide</p>
+          <h1>Reproducing <a href="https://github.com/sympy/sympy/issues/29413">sympy/sympy#29413</a></h1>
+          <div class="vh-main__header-actions">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+              Bug context
+            </button>
+            <a class="vh-chip" href="https://github.com/sympy/sympy/issues/29413" target="_blank" rel="noreferrer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              Upstream issue
+            </a>
+          </div>
+        </div>
+        <div class="vh-main__header-aside">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+            Loading Pyodide runtime…
+          </div>
+          <p class="meta" id="meta"></p>
+        </div>
+      </header>
+
+      <div class="vh-main__cols">
+        <section class="vh-main__col vh-main__col--script">
+          <h2>Reproduction script</h2>
+          <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sympy</span></span>
+<span class="line"><span style="color:#F97583">from</span><span style="color:#E1E4E8"> sympy </span><span style="color:#F97583">import</span><span style="color:#E1E4E8"> ask, Q, Symbol</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">a </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> Symbol(</span><span style="color:#9ECBFF">'a'</span><span style="color:#E1E4E8">)</span></span>
+<span class="line"><span style="color:#E1E4E8">result_value </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> ask(a </span><span style="color:#F97583">+</span><span style="color:#79B8FF"> 1</span><span style="color:#F97583"> ></span><span style="color:#E1E4E8"> a, Q.extended_real(a))</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">{</span></span>
+<span class="line"><span style="color:#9ECBFF">    "sympy_version"</span><span style="color:#E1E4E8">: sympy.</span><span style="color:#79B8FF">__version__</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "python_version"</span><span style="color:#E1E4E8">: sys.version.split()[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
+<span class="line"><span style="color:#9ECBFF">    "ask_result"</span><span style="color:#E1E4E8">: </span><span style="color:#79B8FF">repr</span><span style="color:#E1E4E8">(result_value),</span></span>
+<span class="line"><span style="color:#9ECBFF">    "reproduced"</span><span style="color:#E1E4E8">: result_value </span><span style="color:#F97583">is</span><span style="color:#79B8FF"> True</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span></code></pre>
+        </section>
+
+        <section class="vh-main__col vh-main__col--output">
+          <h2>Output</h2>
+          <pre id="output">(running)</pre>
+        </section>
+      </div>
+
+    </main>
+
+    <script type="module" src="./repro.js"></script>
+  </body>
+</html>

--- a/src/layer1_wasm/sympy-29413/repro.py
+++ b/src/layer1_wasm/sympy-29413/repro.py
@@ -1,0 +1,65 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#   "sympy==1.14.0",
+# ]
+# ///
+"""Vivarium Layer 1 reproduction — sympy/sympy#29413, native variant.
+
+Mirrors the script that runs in ``repro.ts`` (under Pyodide) so a
+contributor can re-verify the bug against a real CPython interpreter
++ a real sympy install:
+
+    mise install                                                    # one-time
+    mise exec uv -- uv run src/layer1_wasm/sympy-29413/repro.py
+
+PEP 723 inline metadata pins sympy to **1.14.0** — the version
+reported as exhibiting the bug in the upstream issue thread.
+
+``ask(a + 1 > a, Q.extended_real(a))`` should be ``None`` (the
+predicate is undefined when ``a = ±oo``, which ``extended_real``
+admits). sympy 1.14.0 returns ``True``. Verdict is "reproduced"
+when the returned value is literally ``True``.
+
+Prints ``reproduced=true`` to JSON output. Exit code: 0 on
+``reproduced``, 1 on ``unreproduced`` so CI can shell-script around
+it without parsing stdout.
+"""
+
+import json
+import sys
+
+import sympy
+from sympy import Q, Symbol, ask
+
+a = Symbol("a")
+result_value = ask(a + 1 > a, Q.extended_real(a))
+
+# Bug: sympy 1.14.0 returns True. Correct answer is None (a = ±oo
+# is within extended_real and makes a + 1 > a undefined).
+reproduced = result_value is True
+
+result = {
+    "sympy_version": sympy.__version__,
+    "python_version": sys.version.split()[0],
+    "ask_result": repr(result_value),
+    "expected": "None (undefined when a = ±oo)",
+    "reproduced": reproduced,
+}
+
+print(json.dumps(result, indent=2))
+
+if reproduced:
+    print(
+        "verdict=reproduced — ask(a+1>a, Q.extended_real(a)) returned True, "
+        "but a=±oo would make this undefined.",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+else:
+    print(
+        "verdict=unreproduced — assumption no longer claims True for "
+        "(a+1)>a under extended_real (likely fixed upstream).",
+        file=sys.stderr,
+    )
+    sys.exit(1)

--- a/src/layer1_wasm/sympy-29413/repro.ts
+++ b/src/layer1_wasm/sympy-29413/repro.ts
@@ -1,0 +1,199 @@
+// Vivarium Layer 1 reproduction — sympy/sympy#29413.
+//
+// `ask(a + 1 > a, Q.extended_real(a))` returns True under sympy
+// 1.14.0, but the correct answer is None: `a + 1 > a` is undefined
+// when `a = ±oo` (which `Q.extended_real` admits). Assumption-system
+// blind spot in `core.relational`.
+//
+// Verdict semantics (per ADR-0008 / contract v1):
+//   - "reproduced"   — `ask()` returned `True` (the bug).
+//   - "unreproduced" — `ask()` returned `None` or `False` (likely
+//                      fixed upstream), or the runtime errored before
+//                      producing a result.
+//
+// sympy is **not** in Pyodide's bundled package set, so we install
+// it via `micropip` after the Pyodide bootstrap. sympy has only
+// pure-Python dependencies (mpmath), so the install is a couple of
+// PyPI wheels — slower than `pandas` but still cold-loads in well
+// under the Playwright timeout.
+
+import { loadVivariumPyodide } from '../_shared/loader.js';
+import type { PathACapturedRun } from '../_shared/path_a.js';
+import { enableRunner } from '../_shared/runner.js';
+import {
+  setResult,
+  setVerdict,
+  type VivariumResultV1,
+} from '../_shared/verdict.js';
+
+const REPRO_CODE = `
+import sys
+import sympy
+from sympy import ask, Q, Symbol
+
+a = Symbol('a')
+result_value = ask(a + 1 > a, Q.extended_real(a))
+
+{
+    "sympy_version": sympy.__version__,
+    "python_version": sys.version.split()[0],
+    "ask_result": repr(result_value),
+    "reproduced": result_value is True,
+}
+`.trim();
+
+interface ReproOutput {
+  sympy_version: string;
+  python_version: string;
+  ask_result: string;
+  reproduced: boolean;
+}
+
+interface PyodideRuntime {
+  runPythonAsync(code: string): Promise<{
+    toJs(opts: { dict_converter: typeof Object.fromEntries }): ReproOutput;
+    destroy?(): void;
+  }>;
+}
+
+const outputEl = document.getElementById('output');
+const metaEl = document.getElementById('meta');
+const reproCodeEl = document.getElementById('repro-code');
+
+if (!outputEl || !metaEl || !reproCodeEl) {
+  throw new Error(
+    'sympy-29413: missing required DOM elements (#output, #meta, #repro-code).',
+  );
+}
+
+if (!reproCodeEl.firstChild) {
+  reproCodeEl.textContent = REPRO_CODE;
+  fetch('./repro.highlighted.html')
+    .then((r) => (r.ok ? r.text() : null))
+    .then((html) => {
+      if (html) reproCodeEl.innerHTML = html;
+    })
+    .catch(() => {});
+}
+
+function evaluate(result: ReproOutput): {
+  verdict: 'reproduced' | 'unreproduced';
+  message: string;
+} {
+  if (result.reproduced) {
+    return {
+      verdict: 'reproduced',
+      message:
+        'bug reproduced — ask((a+1)>a, Q.extended_real(a)) returned True, but a=±oo would make this undefined.',
+    };
+  }
+  return {
+    verdict: 'unreproduced',
+    message: `bug not reproduced — ask returned ${result.ask_result} (expected None for the bug; True signals the blind spot).`,
+  };
+}
+
+async function captureRun(
+  runtime: PyodideRuntime,
+  source: string,
+): Promise<PathACapturedRun> {
+  try {
+    const proxy = await runtime.runPythonAsync(source);
+    const result = proxy.toJs({ dict_converter: Object.fromEntries });
+    proxy.destroy?.();
+    const ev = evaluate(result);
+    return {
+      exitCode: 0,
+      verdict: ev.verdict,
+      message: ev.message,
+      stdout: JSON.stringify(result, null, 2),
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      exitCode: 1,
+      verdict: 'unreproduced',
+      message: `runtime error: ${message}`,
+      stdout: message,
+    };
+  }
+}
+
+const startedAt = new Date();
+
+try {
+  const { pyodide, version } = await loadVivariumPyodide({
+    packages: ['micropip'],
+    pendingText: 'Loading Pyodide runtime and micropip…',
+  });
+
+  setVerdict('pending', 'Installing sympy from PyPI…');
+  const runtime = pyodide as PyodideRuntime;
+  await runtime.runPythonAsync(`
+import micropip
+await micropip.install("sympy==1.14.0")
+`);
+
+  setVerdict('pending', 'Running reproduction script…');
+  const baseline = await captureRun(runtime, REPRO_CODE);
+
+  let baselineResult: ReproOutput | null = null;
+  try {
+    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
+  } catch {
+    outputEl.textContent = baseline.stdout;
+    setVerdict(baseline.verdict, baseline.message);
+    throw new Error(baseline.message);
+  }
+
+  metaEl.textContent =
+    `sympy ${baselineResult.sympy_version} on Python ${baselineResult.python_version} ` +
+    `via Pyodide v${version}.`;
+  outputEl.textContent = baseline.stdout;
+  setVerdict(baseline.verdict, baseline.message);
+
+  const finishedAt = new Date();
+  const envelope: VivariumResultV1 = {
+    contract: 'v1',
+    bug: {
+      project: 'sympy',
+      issue: 29413,
+      upstream_url: 'https://github.com/sympy/sympy/issues/29413',
+    },
+    runtime: {
+      name: 'pyodide',
+      version,
+      extras: {
+        python: baselineResult.python_version,
+        sympy: baselineResult.sympy_version,
+      },
+    },
+    result: {
+      ask_result: baselineResult.ask_result,
+      reproduced: baselineResult.reproduced,
+    },
+    timing: {
+      started_at: startedAt.toISOString(),
+      finished_at: finishedAt.toISOString(),
+      duration_ms: finishedAt.getTime() - startedAt.getTime(),
+    },
+  };
+  setResult(envelope);
+
+  enableRunner({
+    slug: 'sympy-29413',
+    baselineSource: REPRO_CODE,
+    runFix: (source) => captureRun(runtime, source),
+  });
+} catch (err: unknown) {
+  console.error(err);
+  const errAny = err as { stack?: string; message?: string } | null;
+  outputEl.textContent =
+    (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
+  if (globalThis.__VIVARIUM_VERDICT__ !== 'unreproduced') {
+    setVerdict(
+      'unreproduced',
+      `bug not reproduced — runtime error: ${errAny?.message ?? String(err)}`,
+    );
+  }
+}

--- a/src/layer1_wasm/sympy-29413/roundtrip.json
+++ b/src/layer1_wasm/sympy-29413/roundtrip.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "slug": "sympy-29413",
+  "upstream_issue": "https://github.com/sympy/sympy/issues/29413",
+  "vivarium_pr": "https://github.com/aletheia-works/vivarium/pull/260",
+  "status": "draft",
+  "updated_at": "2026-05-17T10:00:00Z",
+  "notes": [
+    "scaffolded from upstream issue via the round-trip skill walkthrough (sympy-29413 first end-to-end smoke)",
+    "Vivarium PR opened (Stage 4); unfixed verdict will be captured by the CI Playwright suite on this PR's push"
+  ]
+}

--- a/src/layer1_wasm/tests/repro.spec.ts
+++ b/src/layer1_wasm/tests/repro.spec.ts
@@ -117,6 +117,14 @@ const cases: ReproCase[] = [
     expectedBugIssue: 779,
     expectedRuntimeName: "rust-wasi",
   },
+  {
+    name: "sympy-29413 reproduction",
+    url: `${LAYER1}/sympy-29413/`,
+    expectedVerdict: "reproduced",
+    expectedBugProject: "sympy",
+    expectedBugIssue: 29413,
+    expectedRuntimeName: "pyodide",
+  },
   // Layer 2 — Docker catalogue, verdict snapshot fetched from
   // `verdict.json` next to the page. CI generates `verdict.json` in
   // both `repro-regression.yml` (build + run + write) and


### PR DESCRIPTION

First end-to-end exercise of the Phase 1-5 round-trip automation
on a real upstream issue: sympy/sympy#29413.

The bug: `ask(a + 1 > a, Q.extended_real(a))` returns `True` in
sympy 1.14.0, but the correct answer is `None` — `Q.extended_real`
admits `a = ±∞`, and at infinity the predicate is undefined (both
sides reduce to the same `∞`). Single-line assumption-system blind
spot in `core.relational`; upstream labels: Wrong Result,
assumptions, core.relational.

Pre-flight passed (per `.claude/rules/upstream-issue-selection.md`):
- sympy 90-day human merge count: 49 (≥5).
- Issue OPEN; `closedByPullRequestsReferences` empty; no
  conflicting in-flight work.
- Bug reproducible against the latest released sympy.

New (recipe directory):

- `src/layer1_wasm/sympy-29413/index.html`
- `src/layer1_wasm/sympy-29413/repro.ts` — Pyodide driver; installs
  `sympy==1.14.0` via micropip, runs the `ask` invocation,
  publishes the Contract v1 surface.
- `src/layer1_wasm/sympy-29413/repro.py` — host-CPython companion
  pinned to the same sympy version via PEP 723 inline metadata.
- `src/layer1_wasm/sympy-29413/README.md`
- `src/layer1_wasm/sympy-29413/roundtrip.json` — initial state
  (`status: draft`); the Phase 5 skill will advance through
  verifying → verified → upstream_open as the round-trip
  progresses.

Modified:

- `src/layer1_wasm/scripts/highlight-repros.ts` — added `sympy`
  → `python` to the `LANG_BY_PROJECT` map so the new recipe's
  reproduction script renders with Shiki tokens at HTML-parse
  time, same as the other Python recipes.
- `src/layer1_wasm/tests/repro.spec.ts` — added a `sympy-29413`
  case to the Playwright regression suite. CI now exercises the
  Pyodide load + micropip install + `ask` evaluation path and
  asserts `verdict=reproduced` on every push.
- `docs/site/_data/recipe-facets.json` — overlay row for
  `sympy-29413` (language=python, symptom=
  assumption-blind-spot-at-infinity, severity=spec-violation, tags
  cover assumption / `Q.extended_real` / `core.relational`).
- `docs/site/_data/projects.json` — new `sympy` project entry
  (SymPy is a first appearance in the catalogue).
- `docs/site/public/api/{recipes,projects}.json` — regenerated by
  `mise run recipes:index`. Recipe count 13 → 14, projects 13 →
  14, mcpTools surface unchanged.
- `.claude/launch.json` — bumped the local `bun` path from 1.3.13
  to 1.3.14 (the version `mise install` resolves today) so
  `preview_start` does not ENOENT on the stale path. Per the
  project's "launch.json path bumps ride along with the same PR
  as the work that uncovered them" convention.

Verification (Stage 0-2):

- `mise run repro:typecheck` clean.
- `mise run repro:build:ts` green; `repro.highlighted.html` and
  the inlined `<code id="repro-code">` block in `index.html`
  generated (intentional, idempotent for re-runs of the
  highlighter).
- `mise run docs:check` (biome) clean (54 files).
- `mise run markdown:check` (rumdl) clean (43 files).
- `mise run recipes:index` regenerated derived artefacts and
  reports recipes=14.

Round-trip stages tracked by `roundtrip.json` (Phase 5 skill):

- Stage 0 (pre-flight): done above.
- Stage 1-2 (scaffold + reproduce): this PR.
- Stage 3 (unfixed verdict capture): the CI Playwright suite runs
  the `sympy-29413` case on every push to this PR; green CI
  = unfixed verdict captured. `roundtrip.json` will move to
  `status: verifying` once verified locally; for now it stays at
  `status: draft` so the state machine recognises this PR as the
  unfixed-only step.
- Stage 4 (Vivarium PR open): this PR itself.
- Stages 5-9 (fork + fix + upstream PR): out of scope for this PR;
  follow-up after the contributor pushes a sympy fix branch.

Local browser-preview verification on the page was inconclusive
(Pyodide cold start + micropip sympy install exceeds the
preview_eval timeout window); the CI Playwright suite is the
proper verification gate and runs on this PR.
