### PR TITLE
feat(wasm): lark-1585 reproduction — LALR/CYK infinite loop

### DIFF
--- a/docs/site/_data/projects.json
+++ b/docs/site/_data/projects.json
@@ -57,6 +57,13 @@
       "homepage": "https://www.sympy.org/",
       "github": "https://github.com/sympy/sympy"
     },
+    "lark": {
+      "display_name": "Lark",
+      "tagline": "Pure-Python parsing toolkit (LALR / Earley / CYK).",
+      "description": "Grammar-engine bugs that survive when lark is installed into Pyodide via micropip. Layer 1 recipes that involve hangs (e.g. LALR-construction infinite loops) run inside a Web Worker so the page can hard-terminate the worker on budget overrun without freezing the visitor's tab.",
+      "homepage": "https://lark-parser.readthedocs.io/",
+      "github": "https://github.com/lark-parser/lark"
+    },
     "bash": {
       "display_name": "bash",
       "tagline": "GNU bash and POSIX shell semantics.",

--- a/docs/site/_data/recipe-facets.json
+++ b/docs/site/_data/recipe-facets.json
@@ -60,6 +60,12 @@
       "severity": "spec-violation",
       "tags": ["sympy", "ask", "Q.extended_real", "core.relational", "infinity"]
     },
+    "lark-1585": {
+      "language": "python",
+      "symptom": "lalr-construction-infinite-loop",
+      "severity": "bug",
+      "tags": ["lark", "lalr", "cyk", "grammar-priority", "infinite-loop"]
+    },
     "find-xargs-whitespace": {
       "language": "shell",
       "symptom": "whitespace-unsafe-pipeline",

--- a/docs/site/public/api/projects.json
+++ b/docs/site/public/api/projects.json
@@ -54,6 +54,19 @@
       "github": "https://github.com/util-linux/util-linux"
     },
     {
+      "project": "lark",
+      "display_name": "Lark",
+      "recipe_count": 1,
+      "layers": [
+        1
+      ],
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/lark/",
+      "tagline": "Pure-Python parsing toolkit (LALR / Earley / CYK).",
+      "description": "Grammar-engine bugs that survive when lark is installed into Pyodide via micropip. Layer 1 recipes that involve hangs (e.g. LALR-construction infinite loops) run inside a Web Worker so the page can hard-terminate the worker on budget overrun without freezing the visitor's tab.",
+      "homepage": "https://lark-parser.readthedocs.io/",
+      "github": "https://github.com/lark-parser/lark"
+    },
+    {
       "project": "mpmath",
       "display_name": "mpmath",
       "recipe_count": 1,

--- a/docs/site/public/api/recipes.json
+++ b/docs/site/public/api/recipes.json
@@ -21,6 +21,37 @@
       "severity": "spec-violation"
     },
     {
+      "slug": "lark-1585",
+      "layer": 1,
+      "project": "lark",
+      "issue": 1585,
+      "title": "lark-parser/lark#1585",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/lark/1585/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/lark-1585",
+      "language": "python",
+      "tags": [
+        "lark",
+        "lalr",
+        "cyk",
+        "grammar-priority",
+        "infinite-loop"
+      ],
+      "symptom": "lalr-construction-infinite-loop",
+      "severity": "bug",
+      "roundtrip": {
+        "schema_version": 1,
+        "slug": "lark-1585",
+        "upstream_issue": "https://github.com/lark-parser/lark/issues/1585",
+        "vivarium_pr": null,
+        "status": "draft",
+        "updated_at": "2026-05-17T00:00:00Z",
+        "notes": [
+          "scaffolded from upstream issue lark-parser/lark#1585 — infinite loop in lark's LALR/CYK back-ends on the grammar `start.1: \"a\" | start start*`",
+          "Layer 1 recipe runs Pyodide + lark in a Web Worker so the hang does not freeze the page; main thread terminates the worker after an 8-second budget and that termination is the verdict signal"
+        ]
+      }
+    },
+    {
       "slug": "mpmath-983",
       "layer": 1,
       "project": "mpmath",

--- a/src/layer1_wasm/lark-1585/README.md
+++ b/src/layer1_wasm/lark-1585/README.md
@@ -1,0 +1,142 @@
+# Reproduction — lark-parser/lark#1585
+
+> **Status**: Layer 1 reproduction page. Uses the shared
+> [`_shared/`](../_shared/) verdict helper and TypeScript toolchain,
+> and emits the canonical `vivarium-contract: v1` surface.
+
+## The bug
+
+[lark-parser/lark#1585](https://github.com/lark-parser/lark/issues/1585) —
+the grammar `start.1: "a" | start start*` puts lark's LALR back-end
+(and the CYK back-end) into an infinite loop when
+`parser='lalr'`. Earley terminates normally. Without the `.1`
+priority on `start`, lark raises `GrammarError` instead — only the
+priority-plus-recursive-alt combination triggers the hang.
+
+Upstream label: `bug`. Reporter:
+[`acornlaw-skwilinski`](https://github.com/lark-parser/lark/issues/1585)
+(filed 2026-03-24).
+
+## Why this bug fits Layer 1
+
+- Lark is pure Python, no C extensions; micropip installs the
+  `lark-1.3.1` wheel into Pyodide directly.
+- The reproduction is two lines and pinpoints the exact grammar
+  shape — easy to render and easy to verify visually.
+- Verdict is a simple wall-clock decision: "did the parse return
+  within the budget?". A mechanically distinguishable boolean.
+
+The bug is a **hang**, not a wrong result. Running it on the main
+thread would freeze the visitor's tab, so the page runs Pyodide +
+lark inside a `Worker(..., { type: 'module' })` and the main thread
+imposes a wall-clock budget. If the worker does not message back a
+result within the budget, the page calls `worker.terminate()` and
+sets the verdict to `reproduced`.
+
+## Files
+
+| File              | Role                                                          |
+| ----------------- | ------------------------------------------------------------- |
+| `index.html`      | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
+| `repro.ts`        | Main-thread driver. Spawns the worker, races its `result` message against an 8-second budget, updates the verdict + envelope. |
+| `repro.worker.ts` | Worker source. Loads Pyodide, installs `lark==1.3.1` via micropip, then executes the reproduction inside a `try/except` + timing harness. |
+| `repro.js` /      | Generated from the TS sources; gitignored.                    |
+| `repro.worker.js` |                                                               |
+| `repro.py`        | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. Uses `subprocess` + `TimeoutExpired` so the timeout works on Windows as well as POSIX. |
+| `roundtrip.json`  | Tracked workflow state (round-trip schema_version 1).         |
+
+Shared visual presentation lives in [`../_shared/style.css`](../_shared/style.css);
+this directory does not carry its own copy.
+
+## Verdict contract — `vivarium-contract: v1`
+
+The page conforms to the contract canonicalised in
+[`../_shared/verdict.ts`](../_shared/verdict.ts):
+
+- `<meta name="vivarium-contract" content="v1">` declared in `<head>`.
+- `document.querySelector('#verdict').dataset.verdict` ∈
+  `{"pending", "reproduced", "unreproduced"}`.
+- `globalThis.__VIVARIUM_VERDICT__` — mirror of the DOM verdict.
+- `globalThis.__VIVARIUM_RESULT__` — a `VivariumResultV1` envelope:
+  `{ contract: "v1", bug: { project: "lark", issue: 1585, upstream_url },
+  runtime: { name: "pyodide", version, extras: { python, lark } },
+  result: { outcome, error, elapsed_ms, timeout_ms, reproduced },
+  timing }`.
+
+A `reproduced` verdict means the worker did not return a result
+within 8 seconds — the infinite loop is confirmed.
+An `unreproduced` verdict means the parse returned (bug fixed
+upstream) or raised an exception (bug behaviour changed; the
+specific hang did not trigger) before the budget elapsed.
+
+## Running locally — in-browser
+
+```bash
+# 1. From src/layer1_wasm/, build the TypeScript sources once.
+cd src/layer1_wasm
+bun install        # one-time per machine / lockfile change
+bun run build      # emits repro.js + repro.worker.js next to the .ts sources
+
+# 2. Serve this directory.
+python -m http.server -d lark-1585 8765
+# then open http://localhost:8765/
+```
+
+Pyodide does not require COOP/COEP headers for this page (no
+`SharedArrayBuffer`, no shared-memory threading — the Web Worker
+runs an entirely independent Pyodide instance).
+
+## Native verification — same reproduction under a real CPython + lark
+
+The companion `repro.py` script reproduces the bug without any
+WASM layer, so a contributor can confirm the page is catching a
+*real* upstream behaviour rather than a Pyodide / micropip quirk.
+PEP 723 inline metadata pins **`lark==1.3.1`** and the `mise.toml`
+at the repo root pins Python to 3.13:
+
+```bash
+# One-time per machine / mise.toml change.
+mise install
+
+# Reproduces the bug; exits 0 on `reproduced`. The script forks a
+# subprocess to run the parse and waits up to 8s before declaring
+# the bug reproduced.
+mise exec uv -- uv run src/layer1_wasm/lark-1585/repro.py
+
+# Expected output (lark 1.3.1):
+# {
+#   "lark_version": "1.3.1",
+#   "python_version": "3.13.x",
+#   "outcome": "timeout",
+#   "exit_code": null,
+#   "stderr_tail": [...],
+#   "elapsed_ms": 8000.x,
+#   "timeout_ms": 8000.0,
+#   "reproduced": true
+# }
+# verdict=reproduced — Lark(...).parse('aa') hung past 8s; the LALR back-end exhibits the infinite loop reported upstream.
+```
+
+## Round-trip state
+
+`roundtrip.json` tracks the recipe's progress through the round-
+trip loop (see
+[the round-trip guide](https://aletheia-works.github.io/vivarium/guide/round-trip)
+for the stage breakdown). Stages reflect:
+
+- `status: "draft"` — recipe just scaffolded.
+- `status: "verifying"` — `verdicts.unfixed` captured.
+- `status: "verified"` — both verdicts captured, the fix actually
+  flips the page.
+- `status: "upstream_open"` — upstream draft PR opened.
+- `status: "merged"` — upstream merged. (Terminal.)
+- `status: "blocked"` — any stage failure; reason in `notes[]`.
+
+## Deployment
+
+Published to GitHub Pages at
+`https://aletheia-works.github.io/vivarium/repro/lark/1585/` by
+the `deploy-docs` workflow. The workflow runs `bun install` +
+`bun run build` in `src/layer1_wasm/` first so the compiled
+`repro.js` + `repro.worker.js` exist when the bundling step
+copies the directory into the Pages artefact.

--- a/src/layer1_wasm/lark-1585/index.html
+++ b/src/layer1_wasm/lark-1585/index.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="vivarium-contract" content="v1" />
+    <title>Vivarium · Reproducing lark-parser/lark#1585</title>
+    <!-- vivarium-chrome-injected -->
+    <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.asm.wasm" as="fetch" type="application/wasm" crossorigin />
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/python_stdlib.zip" as="fetch" crossorigin />
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide-lock.json" as="fetch" type="application/json" crossorigin />
+    <!-- Warm the TLS/HTTP3 handshake to jsDelivr in parallel with HTML parse. -->
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <!-- Keep the version below in sync with DEFAULT_PYODIDE_VERSION in
+         ../_shared/loader.ts. -->
+    <link
+      rel="modulepreload"
+      href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.mjs"
+      crossorigin
+    />
+    <link rel="stylesheet" href="../_shared/style.css" />
+    <template id="bug-context">
+      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <div class="vh-drawer__body" id="vh-drawer-body">
+        <p>
+          The lark grammar <code>start.1: "a" | start start*</code>
+          causes lark's LALR back-end (and CYK) to enter an infinite
+          loop when <code>parser='lalr'</code> is requested. Earley
+          terminates normally. Without the <code>.1</code> priority
+          on <code>start</code>, lark raises <code>GrammarError</code>
+          instead — only the priority-plus-recursive-alt combination
+          triggers the hang.
+        </p>
+        <p>
+          Because the bug is a hang rather than a wrong result,
+          this page runs Pyodide + lark inside a Web Worker and the
+          main thread imposes a wall-clock budget. If the worker
+          does not return a result in time, the verdict is
+          <code>reproduced</code> and the worker is terminated; if
+          the parse returns or raises before the budget elapses,
+          the verdict is <code>unreproduced</code>.
+        </p>
+        <p>
+          The full discussion lives in the GitHub issue thread
+          linked below.
+        </p>
+      </div>
+      <hr class="vh-drawer__divider" />
+      <div class="vh-drawer__meta-grid">
+        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-val">lark-parser/lark</span>
+        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-val">#1585</span>
+        <span class="vh-drawer__meta-key">Layer</span>
+        <span class="vh-drawer__meta-val">L1 · WASM</span>
+        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-val">Pyodide v0.29.3 + lark 1.3.1 (micropip, inside a Web Worker)</span>
+      </div>
+    </template>
+  </head>
+  <body>
+    <main class="vh-main">
+      <header class="vh-main__header">
+        <div class="vh-main__header-text">
+          <p class="kicker">L1 · Pyodide</p>
+          <h1>Reproducing <a href="https://github.com/lark-parser/lark/issues/1585">lark-parser/lark#1585</a></h1>
+          <div class="vh-main__header-actions">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+              Bug context
+            </button>
+            <a class="vh-chip" href="https://github.com/lark-parser/lark/issues/1585" target="_blank" rel="noreferrer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              Upstream issue
+            </a>
+          </div>
+        </div>
+        <div class="vh-main__header-aside">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+            Loading Pyodide runtime…
+          </div>
+          <p class="meta" id="meta"></p>
+        </div>
+      </header>
+
+      <div class="vh-main__cols">
+        <section class="vh-main__col vh-main__col--script">
+          <h2>Reproduction script</h2>
+          <pre><code id="repro-code"><span class="line"><span style="color:#E1E4E8">Lark(</span><span style="color:#9ECBFF">'start.1: "a" | start start*'</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">parser</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">'lalr'</span><span style="color:#E1E4E8">).parse(</span><span style="color:#9ECBFF">'aa'</span><span style="color:#E1E4E8">)</span></span></code></pre>
+        </section>
+
+        <section class="vh-main__col vh-main__col--output">
+          <h2>Output</h2>
+          <pre id="output">(running)</pre>
+        </section>
+      </div>
+
+    </main>
+
+    <script type="module" src="./repro.js"></script>
+  </body>
+</html>

--- a/src/layer1_wasm/lark-1585/repro.py
+++ b/src/layer1_wasm/lark-1585/repro.py
@@ -1,0 +1,102 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#   "lark==1.3.1",
+# ]
+# ///
+"""Vivarium Layer 1 reproduction — lark-parser/lark#1585, native variant.
+
+The browser page runs the same grammar inside a Web Worker so the
+infinite loop does not freeze the tab; the native variant uses a
+subprocess + ``subprocess.TimeoutExpired`` so the parent process can
+walk away from the hung child without depending on ``signal.alarm``
+(Windows-friendly).
+
+Bug: ``Lark('start.1: "a" | start start*', parser='lalr').parse('aa')``
+hangs indefinitely under the LALR and CYK back-ends. Without the
+``.1`` priority lark raises ``GrammarError`` instead, and the Earley
+back-end terminates normally — both are documented in the upstream
+issue thread.
+
+Verdict semantics:
+- ``reproduced``   — the child process did not return within the
+  budget (default 8 s).
+- ``unreproduced`` — the child returned (bug fixed) or raised
+  before the budget elapsed (bug behaviour changed; the specific
+  hang reported upstream did not trigger).
+"""
+
+import json
+import subprocess
+import sys
+import time
+
+TIMEOUT_S = 8.0
+
+CHILD_SCRIPT = r"""
+import sys
+import lark
+from lark import Lark
+
+print(lark.__version__, sys.version.split()[0], flush=True, file=sys.stderr)
+Lark('start.1: "a" | start start*', parser='lalr').parse('aa')
+"""
+
+
+def main() -> int:
+    started = time.perf_counter()
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", CHILD_SCRIPT],
+            timeout=TIMEOUT_S,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        child_meta = completed.stderr.strip().splitlines()[-1] if completed.stderr.strip() else ""
+        lark_version, _, python_version = child_meta.partition(" ")
+        result = {
+            "lark_version": lark_version or "unknown",
+            "python_version": python_version or sys.version.split()[0],
+            "outcome": "returned" if completed.returncode == 0 else "raised",
+            "exit_code": completed.returncode,
+            "stderr_tail": (completed.stderr or "").splitlines()[-5:],
+            "elapsed_ms": elapsed_ms,
+            "timeout_ms": TIMEOUT_S * 1000,
+            "reproduced": False,
+        }
+        print(json.dumps(result, indent=2))
+        if completed.returncode == 0:
+            msg = "verdict=unreproduced — Lark(...).parse('aa') returned cleanly within the budget."
+        else:
+            msg = (
+                "verdict=unreproduced — child raised before timeout "
+                f"(exit {completed.returncode}); the infinite loop reported "
+                "upstream did not trigger."
+            )
+        print(msg, file=sys.stderr)
+        return 1
+    except subprocess.TimeoutExpired as exc:
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        result = {
+            "lark_version": "1.3.1",
+            "python_version": sys.version.split()[0],
+            "outcome": "timeout",
+            "exit_code": None,
+            "stderr_tail": (exc.stderr.decode(errors="replace") if exc.stderr else "").splitlines()[-5:],
+            "elapsed_ms": elapsed_ms,
+            "timeout_ms": TIMEOUT_S * 1000,
+            "reproduced": True,
+        }
+        print(json.dumps(result, indent=2))
+        print(
+            f"verdict=reproduced — Lark(...).parse('aa') hung past {TIMEOUT_S:.0f}s; "
+            "the LALR back-end exhibits the infinite loop reported upstream.",
+            file=sys.stderr,
+        )
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/layer1_wasm/lark-1585/repro.py
+++ b/src/layer1_wasm/lark-1585/repro.py
@@ -84,7 +84,9 @@ def main() -> int:
             "python_version": sys.version.split()[0],
             "outcome": "timeout",
             "exit_code": None,
-            "stderr_tail": (exc.stderr.decode(errors="replace") if exc.stderr else "").splitlines()[-5:],
+            "stderr_tail": (exc.stderr.decode(errors="replace") if exc.stderr else "").splitlines()[
+                -5:
+            ],
             "elapsed_ms": elapsed_ms,
             "timeout_ms": TIMEOUT_S * 1000,
             "reproduced": True,

--- a/src/layer1_wasm/lark-1585/repro.ts
+++ b/src/layer1_wasm/lark-1585/repro.ts
@@ -1,0 +1,275 @@
+// Vivarium Layer 1 reproduction — lark-parser/lark#1585.
+//
+// The grammar `start.1: "a" | start start*` causes an infinite
+// loop in lark's LALR back-end when `parser='lalr'` is supplied.
+// CYK exhibits the same hang; Earley terminates normally.
+//
+// Because the bug is a hang rather than a wrong result, the repro
+// runs Pyodide + lark inside a Web Worker. The main thread races
+// the worker's result message against a wall-clock budget and
+// terminates the worker if it does not return within the budget —
+// that termination is the verdict signal.
+//
+// Verdict semantics (per Contract v1):
+//   - "reproduced"   — the worker did not return within TIMEOUT_MS;
+//                      the infinite loop is confirmed.
+//   - "unreproduced" — the worker returned (parse completed; bug
+//                      fixed upstream) or raised an exception (bug
+//                      behaviour changed; the specific hang did
+//                      not trigger) before the budget elapsed.
+
+import {
+  setResult,
+  setVerdict,
+  type VivariumResultV1,
+} from '../_shared/verdict.js';
+
+const TIMEOUT_MS = 8000;
+const PYODIDE_VERSION = '0.29.3';
+
+// Canonical reproduction source. The worker wraps it in a
+// `try/except` + timing harness, but this is the part the recipe
+// page surfaces in `<pre id="repro-code">` and the highlight-repros
+// build step extracts. Editing this constant changes both the
+// rendered source and the parse the worker actually runs.
+const REPRO_CODE = `
+Lark('start.1: "a" | start start*', parser='lalr').parse('aa')
+`.trim();
+
+interface ReproOutput {
+  lark_version: string;
+  python_version: string;
+  outcome: 'returned' | 'raised';
+  error: string | null;
+  elapsed_ms: number;
+}
+
+interface WorkerReady {
+  type: 'ready';
+  pyodide_version: string;
+  lark_version: string;
+  python_version: string;
+}
+
+interface WorkerProgress {
+  type: 'progress';
+  stage: string;
+}
+
+interface WorkerResult {
+  type: 'result';
+  data: ReproOutput;
+}
+
+interface WorkerError {
+  type: 'error';
+  message: string;
+}
+
+type WorkerMessage = WorkerReady | WorkerProgress | WorkerResult | WorkerError;
+
+const outputEl = document.getElementById('output');
+const metaEl = document.getElementById('meta');
+const reproCodeEl = document.getElementById('repro-code');
+
+if (!outputEl || !metaEl || !reproCodeEl) {
+  throw new Error(
+    'lark-1585: missing required DOM elements (#output, #meta, #repro-code).',
+  );
+}
+
+if (!reproCodeEl.firstChild) {
+  reproCodeEl.textContent = REPRO_CODE;
+  fetch('./repro.highlighted.html')
+    .then((r) => (r.ok ? r.text() : null))
+    .then((html) => {
+      if (html) reproCodeEl.innerHTML = html;
+    })
+    .catch(() => {});
+}
+
+const startedAt = new Date();
+
+function publishEnvelope(args: {
+  pyodideVersion: string;
+  larkVersion: string;
+  pythonVersion: string;
+  reproduced: boolean;
+  outcome: 'timeout' | ReproOutput['outcome'];
+  error: string | null;
+  elapsedMs: number;
+  timeoutMs: number;
+}): void {
+  const finishedAt = new Date();
+  const envelope: VivariumResultV1 = {
+    contract: 'v1',
+    bug: {
+      project: 'lark',
+      issue: 1585,
+      upstream_url: 'https://github.com/lark-parser/lark/issues/1585',
+    },
+    runtime: {
+      name: 'pyodide',
+      version: args.pyodideVersion,
+      extras: {
+        python: args.pythonVersion,
+        lark: args.larkVersion,
+      },
+    },
+    result: {
+      outcome: args.outcome,
+      error: args.error,
+      elapsed_ms: args.elapsedMs,
+      timeout_ms: args.timeoutMs,
+      reproduced: args.reproduced,
+    },
+    timing: {
+      started_at: startedAt.toISOString(),
+      finished_at: finishedAt.toISOString(),
+      duration_ms: finishedAt.getTime() - startedAt.getTime(),
+    },
+  };
+  setResult(envelope);
+}
+
+try {
+  setVerdict('pending', 'Spawning Pyodide worker…');
+
+  const worker = new Worker(new URL('./repro.worker.js', import.meta.url), {
+    type: 'module',
+  });
+
+  const ready = await new Promise<WorkerReady>((resolve, reject) => {
+    const onMessage = (ev: MessageEvent<WorkerMessage>): void => {
+      const msg = ev.data;
+      if (msg.type === 'progress') {
+        setVerdict('pending', `Worker: ${msg.stage}…`);
+      } else if (msg.type === 'ready') {
+        worker.removeEventListener('message', onMessage);
+        resolve(msg);
+      } else if (msg.type === 'error') {
+        worker.removeEventListener('message', onMessage);
+        reject(new Error(msg.message));
+      }
+    };
+    worker.addEventListener('message', onMessage);
+    worker.addEventListener('error', (ev) => reject(new Error(ev.message)));
+  });
+
+  metaEl.textContent =
+    `lark ${ready.lark_version} on Python ${ready.python_version} ` +
+    `via Pyodide v${ready.pyodide_version}; budget ${TIMEOUT_MS} ms.`;
+
+  setVerdict(
+    'pending',
+    `Running Lark(...).parse('aa') with a ${TIMEOUT_MS / 1000}s budget…`,
+  );
+
+  const resultPromise = new Promise<WorkerResult | WorkerError>(
+    (resolve, reject) => {
+      const onMessage = (ev: MessageEvent<WorkerMessage>): void => {
+        if (ev.data.type === 'result' || ev.data.type === 'error') {
+          worker.removeEventListener('message', onMessage);
+          resolve(ev.data);
+        }
+      };
+      worker.addEventListener('message', onMessage);
+      worker.addEventListener('error', (ev) =>
+        reject(new Error(`worker errored: ${ev.message}`)),
+      );
+    },
+  );
+
+  const timeoutPromise = new Promise<'timeout'>((resolve) => {
+    setTimeout(() => resolve('timeout'), TIMEOUT_MS);
+  });
+
+  worker.postMessage({ type: 'go', source: REPRO_CODE });
+
+  const outcome = await Promise.race([resultPromise, timeoutPromise]);
+
+  if (outcome === 'timeout') {
+    worker.terminate();
+    const message =
+      `bug reproduced — Lark('start.1: "a" | start start*', parser='lalr')` +
+      `.parse('aa') did not return within ${TIMEOUT_MS / 1000}s; ` +
+      `the LALR back-end is in an infinite loop.`;
+    outputEl.textContent = JSON.stringify(
+      {
+        lark_version: ready.lark_version,
+        python_version: ready.python_version,
+        outcome: 'timeout',
+        timeout_ms: TIMEOUT_MS,
+        reproduced: true,
+      },
+      null,
+      2,
+    );
+    setVerdict('reproduced', message);
+    publishEnvelope({
+      pyodideVersion: ready.pyodide_version,
+      larkVersion: ready.lark_version,
+      pythonVersion: ready.python_version,
+      reproduced: true,
+      outcome: 'timeout',
+      error: null,
+      elapsedMs: TIMEOUT_MS,
+      timeoutMs: TIMEOUT_MS,
+    });
+  } else if (outcome.type === 'error') {
+    outputEl.textContent = outcome.message;
+    setVerdict(
+      'unreproduced',
+      `bug not reproduced — worker errored before timeout: ${outcome.message}.`,
+    );
+    publishEnvelope({
+      pyodideVersion: ready.pyodide_version,
+      larkVersion: ready.lark_version,
+      pythonVersion: ready.python_version,
+      reproduced: false,
+      outcome: 'raised',
+      error: outcome.message,
+      elapsedMs: 0,
+      timeoutMs: TIMEOUT_MS,
+    });
+  } else {
+    const data = outcome.data;
+    outputEl.textContent = JSON.stringify(data, null, 2);
+    const message =
+      data.outcome === 'returned'
+        ? `bug not reproduced — parse returned in ${data.elapsed_ms.toFixed(0)} ms (likely fixed upstream).`
+        : `bug not reproduced — parse raised ${data.error ?? '<unknown>'} in ${data.elapsed_ms.toFixed(0)} ms; the specific infinite loop did not trigger.`;
+    setVerdict('unreproduced', message);
+    publishEnvelope({
+      pyodideVersion: ready.pyodide_version,
+      larkVersion: data.lark_version,
+      pythonVersion: data.python_version,
+      reproduced: false,
+      outcome: data.outcome,
+      error: data.error,
+      elapsedMs: data.elapsed_ms,
+      timeoutMs: TIMEOUT_MS,
+    });
+  }
+} catch (err: unknown) {
+  console.error(err);
+  const errAny = err as { stack?: string; message?: string } | null;
+  outputEl.textContent =
+    (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
+  if (globalThis.__VIVARIUM_VERDICT__ !== 'unreproduced') {
+    setVerdict(
+      'unreproduced',
+      `bug not reproduced — runtime error: ${errAny?.message ?? String(err)}`,
+    );
+  }
+  publishEnvelope({
+    pyodideVersion: PYODIDE_VERSION,
+    larkVersion: 'unknown',
+    pythonVersion: 'unknown',
+    reproduced: false,
+    outcome: 'raised',
+    error: errAny?.message ?? String(err),
+    elapsedMs: 0,
+    timeoutMs: TIMEOUT_MS,
+  });
+}

--- a/src/layer1_wasm/lark-1585/repro.worker.ts
+++ b/src/layer1_wasm/lark-1585/repro.worker.ts
@@ -1,0 +1,173 @@
+// Web Worker for lark-1585. Runs Pyodide + lark in a separate
+// thread so the main page can `worker.terminate()` if the parse hangs
+// (the bug being reproduced is an infinite loop in lark's LALR
+// back-end, which would otherwise freeze the tab).
+//
+// Protocol (all messages are JSON):
+//   worker → main:
+//     { type: 'progress', stage: string }
+//     { type: 'ready', pyodide_version, lark_version, python_version }
+//     { type: 'result', data: ReproOutput }
+//     { type: 'error', message: string }
+//   main → worker:
+//     { type: 'go', source: string }
+//
+// The worker loads Pyodide and installs lark up-front, then waits
+// for a `go` message before invoking the grammar. The main thread
+// races the `result` message against a wall-clock timeout — if the
+// timeout fires first, the worker is terminated and the verdict is
+// "reproduced".
+
+// The project tsconfig pulls in `lib: DOM`, so we cannot `declare const
+// self: DedicatedWorkerGlobalScope` here — that would collide with the
+// DOM lib's `self: Window`. Cast at point of use instead: both `Window`
+// and `DedicatedWorkerGlobalScope` expose `postMessage` /
+// `addEventListener`, so the runtime call shape is the same.
+const workerScope = self as unknown as {
+  postMessage: (msg: unknown) => void;
+  addEventListener: (
+    type: 'message',
+    listener: (ev: MessageEvent<{ type: string; source?: string }>) => void,
+  ) => void;
+};
+
+const PYODIDE_VERSION = '0.29.3';
+const LARK_VERSION = '1.3.1';
+
+interface ReproOutput {
+  lark_version: string;
+  python_version: string;
+  outcome: 'returned' | 'raised';
+  error: string | null;
+  elapsed_ms: number;
+}
+
+interface PyodideModule {
+  loadPyodide(opts: {
+    indexURL: string;
+    packages?: string[];
+  }): Promise<PyodideRuntime>;
+}
+
+interface PyodideRuntime {
+  runPythonAsync(code: string): Promise<unknown>;
+  runPython(code: string): unknown;
+}
+
+// The actual reproduction source is shipped from the main thread
+// via the `go` message — that keeps a single canonical declaration
+// of REPRO_CODE in repro.ts where the highlight-repros build step
+// can extract it for the recipe page.
+const HARNESS_PROLOGUE = `
+import json
+import sys
+import time
+import lark
+from lark import Lark
+
+t0 = time.perf_counter()
+outcome = "returned"
+error_repr = None
+try:
+`.trim();
+
+const HARNESS_EPILOGUE = `
+except BaseException as e:
+    outcome = "raised"
+    error_repr = f"{type(e).__name__}: {e}"
+elapsed_ms = (time.perf_counter() - t0) * 1000
+
+json.dumps({
+    "lark_version": lark.__version__,
+    "python_version": sys.version.split()[0],
+    "outcome": outcome,
+    "error": error_repr,
+    "elapsed_ms": elapsed_ms,
+})
+`.trim();
+
+function indent(text: string, spaces: number): string {
+  const pad = ' '.repeat(spaces);
+  return text
+    .split('\n')
+    .map((line) => (line.length > 0 ? pad + line : line))
+    .join('\n');
+}
+
+function progress(stage: string): void {
+  workerScope.postMessage({ type: 'progress', stage });
+}
+
+async function bootstrap(): Promise<{
+  runtime: PyodideRuntime;
+  larkVersion: string;
+  pythonVersion: string;
+}> {
+  progress('downloading Pyodide runtime');
+  const mod = (await import(
+    /* @vite-ignore */ `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/pyodide.mjs`
+  )) as PyodideModule;
+
+  const runtime = await mod.loadPyodide({
+    indexURL: `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/`,
+    packages: ['micropip'],
+  });
+  progress(`installing lark==${LARK_VERSION} via micropip`);
+  await runtime.runPythonAsync(`
+import micropip
+await micropip.install("lark==${LARK_VERSION}")
+`);
+
+  const versionInfo = runtime.runPython(`
+import json, sys, lark
+json.dumps({"lark": lark.__version__, "python": sys.version.split()[0]})
+`) as string;
+  const parsed = JSON.parse(versionInfo) as { lark: string; python: string };
+  return {
+    runtime,
+    larkVersion: parsed.lark,
+    pythonVersion: parsed.python,
+  };
+}
+
+async function runRepro(
+  runtime: PyodideRuntime,
+  source: string,
+): Promise<ReproOutput> {
+  const wrapped = `${HARNESS_PROLOGUE}\n${indent(source, 4)}\n${HARNESS_EPILOGUE}`;
+  const raw = (await runtime.runPythonAsync(wrapped)) as string;
+  return JSON.parse(raw) as ReproOutput;
+}
+
+let runtimeRef: PyodideRuntime | null = null;
+
+workerScope.addEventListener(
+  'message',
+  (ev: MessageEvent<{ type: string; source?: string }>) => {
+    if (ev.data?.type === 'go' && runtimeRef !== null && ev.data.source) {
+      runRepro(runtimeRef, ev.data.source)
+        .then((data) => {
+          workerScope.postMessage({ type: 'result', data });
+        })
+        .catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          workerScope.postMessage({ type: 'error', message });
+        });
+    }
+  },
+);
+
+bootstrap()
+  .then(({ runtime, larkVersion, pythonVersion }) => {
+    runtimeRef = runtime;
+    workerScope.postMessage({
+      type: 'ready',
+      pyodide_version: PYODIDE_VERSION,
+      lark_version: larkVersion,
+      python_version: pythonVersion,
+    });
+  })
+  .catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    workerScope.postMessage({ type: 'error', message: `bootstrap failed: ${message}` });
+  });

--- a/src/layer1_wasm/lark-1585/roundtrip.json
+++ b/src/layer1_wasm/lark-1585/roundtrip.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "slug": "lark-1585",
+  "upstream_issue": "https://github.com/lark-parser/lark/issues/1585",
+  "vivarium_pr": null,
+  "status": "draft",
+  "updated_at": "2026-05-17T00:00:00Z",
+  "notes": [
+    "scaffolded from upstream issue lark-parser/lark#1585 — infinite loop in lark's LALR/CYK back-ends on the grammar `start.1: \"a\" | start start*`",
+    "Layer 1 recipe runs Pyodide + lark in a Web Worker so the hang does not freeze the page; main thread terminates the worker after an 8-second budget and that termination is the verdict signal"
+  ]
+}

--- a/src/layer1_wasm/scripts/highlight-repros.ts
+++ b/src/layer1_wasm/scripts/highlight-repros.ts
@@ -54,6 +54,7 @@ const LAYER1_DIR = dirname(SCRIPT_DIR);
 // the source language for Layer 1 recipes.
 const LANG_BY_PROJECT: Record<string, BundledLanguage> = {
   cpython: 'python',
+  lark: 'python',
   mpmath: 'python',
   numpy: 'python',
   pandas: 'python',

--- a/src/layer1_wasm/tests/repro.spec.ts
+++ b/src/layer1_wasm/tests/repro.spec.ts
@@ -125,6 +125,14 @@ const cases: ReproCase[] = [
     expectedBugIssue: 29413,
     expectedRuntimeName: "pyodide",
   },
+  {
+    name: "lark-1585 reproduction",
+    url: `${LAYER1}/lark-1585/`,
+    expectedVerdict: "reproduced",
+    expectedBugProject: "lark",
+    expectedBugIssue: 1585,
+    expectedRuntimeName: "pyodide",
+  },
   // Layer 2 — Docker catalogue, verdict snapshot fetched from
   // `verdict.json` next to the page. CI generates `verdict.json` in
   // both `repro-regression.yml` (build + run + write) and


### PR DESCRIPTION
## Summary

Vivarium-side reproduction recipe for [lark-parser/lark#1585](https://github.com/lark-parser/lark/issues/1585) — the grammar `start.1: "a" | start start*` puts lark's LALR back-end (and CYK) into an infinite loop when `parser='lalr'` is requested. Earley terminates normally; without the `.1` priority lark raises `GrammarError` instead — only the priority-plus-recursive-alt combination triggers the hang.

## Design — Web Worker + hard timeout

Because the bug is a **hang** rather than a wrong result, running it on the main thread would freeze the visitor's tab. The recipe runs Pyodide + `lark==1.3.1` inside a `Worker(..., { type: 'module' })` and the main thread races the worker's `result` message against an 8-second wall-clock budget. The verdict signal is the budget overrun itself:

- `reproduced` — worker did not return within the budget; the LALR construction/parse hung.
- `unreproduced` — parse returned (bug fixed) or raised an exception (bug behaviour changed) before the budget elapsed.

The companion native `repro.py` uses `subprocess.run(..., timeout=8.0)` for the same semantics under a real CPython 3.13 + lark 1.3.1 — verified locally, parse hangs past 8s and exits with `outcome=timeout`.

## What landed

```text
src/layer1_wasm/lark-1585/
├── index.html         ← Contract v1 entry point
├── repro.ts           ← main-thread driver (worker + timeout race)
├── repro.worker.ts    ← Pyodide + lark inside the worker
├── repro.py           ← native CLI variant (subprocess + TimeoutExpired)
├── README.md
└── roundtrip.json     ← status: draft, schema_version 1
```

Plus the data-file plumbing:

- `docs/site/_data/recipe-facets.json` — new `lark-1585` facet row.
- `docs/site/_data/projects.json` — new `lark` project entry (first lark recipe).
- `docs/site/public/api/{recipes,projects}.json` — regenerated via `mise run recipes:index`.
- `src/layer1_wasm/scripts/highlight-repros.ts` — `lark → python` Shiki lang map.
- `src/layer1_wasm/tests/repro.spec.ts` — Playwright case (`expectedVerdict: reproduced`).

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run build` — Shiki highlight + tsc emit `repro.js` / `repro.worker.js`; placeholder block inlined into `index.html`.
- [x] `bun run generate` (docs) — recipes.json: 9 Layer 1 entries; projects.json: 15 projects.
- [x] `bun run test:unit` (docs) — 20 passed.
- [x] `bun x --bun biome check .` (docs) — clean.
- [x] `uv run src/layer1_wasm/lark-1585/repro.py` — `outcome=timeout`, `reproduced=true` (verified locally on lark 1.3.1 + Python 3.13.12, parse hung 8.1s past the budget).
- [x] `bun run build` (docs/rspress) — full site builds.
- [x] Playwright `repro.spec.ts` `lark-1585 reproduction` case — browser download blocked in this sandbox; CI's `repro-regression.yml` will exercise it on Chromium / Firefox / WebKit.

## Round-trip status

`roundtrip.json` is at `status: "draft"` with `vivarium_pr: null` — the next stage (the round-trip skill's verify step) will capture the unfixed verdict and bump the status.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MpBU6MqJkgwZaqYyXfoGj3)_