### PR TITLE
refactor(wasm): dynamise repro.spec.ts cases from recipes.json

### DIFF
--- a/docs/site/public/spec/recipe.schema.json
+++ b/docs/site/public/spec/recipe.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://aletheia-works.github.io/vivarium/spec/recipe.schema.json",
   "title": "Vivarium per-recipe metadata (schema_version 1)",
-  "description": "Per-recipe metadata sibling of a recipe's tracked sources (README.md / repro.* / index.html / Dockerfile) under src/layer{1,2,3}_*/<slug>/recipe.json. Single source of truth for the facets the gallery filters on (language / symptom / severity / tags) and the expectations the regression suite will assert (expected_verdict / expected_runtime). Replaces the hand-curated overlay at docs/site/_data/recipe-facets.json (retired 2026-05-18). Consumed by docs/scripts/generate-recipes-index.ts (merges the fields into the public docs/site/public/api/recipes.json catalogue) and by src/layer1_wasm/scripts/highlight-repros.ts (reads language to pick the Shiki bundle). The static case list in src/layer1_wasm/tests/repro.spec.ts will be retired by a follow-up PR in favour of reading this file directly; until that lands, the Playwright suite keeps its own duplicate source of truth. Adding a new recipe = creating its directory + this file plus (for now) a matching entry in repro.spec.ts; the projects.json overlay remains the only out-of-recipe edit, and only when a new project debuts.",
+  "description": "Per-recipe metadata sibling of a recipe's tracked sources (README.md / repro.* / index.html / Dockerfile) under src/layer{1,2,3}_*/<slug>/recipe.json. Single source of truth for the facets the gallery filters on (language / symptom / severity / tags) and the expectations the regression suite will assert (expected_verdict / expected_runtime). Replaces the hand-curated overlay at docs/site/_data/recipe-facets.json (retired 2026-05-18). Consumed by docs/scripts/generate-recipes-index.ts (merges the fields into the public docs/site/public/api/recipes.json catalogue), by src/layer1_wasm/scripts/highlight-repros.ts (reads language to pick the Shiki bundle), and by src/layer1_wasm/tests/repro.spec.ts via the generated catalogue (reads expected_verdict / expected_runtime for the regression suite). Adding a new recipe = creating its directory + this file; the projects.json overlay remains the only out-of-recipe edit, and only when a new project debuts.",
   "type": "object",
   "required": ["schema_version", "language"],
   "additionalProperties": false,
@@ -33,12 +33,12 @@
     },
     "expected_verdict": {
       "enum": ["reproduced", "unreproduced"],
-      "description": "Verdict the regression suite (src/layer1_wasm/tests/repro.spec.ts and equivalents) expects the recipe page to produce. Currently 'reproduced' for every shipped recipe — when an upstream fix lands and the runtime picks it up, the suite turns the flip into a CI failure so a maintainer can decide whether to update / retire the recipe."
+      "description": "Verdict the regression suite (src/layer1_wasm/tests/repro.spec.ts and equivalents) expects the recipe page to produce. Currently 'reproduced' for every shipped recipe — when an upstream fix lands and the runtime picks it up, the suite turns the flip into a CI failure so a maintainer can decide whether to update / retire the recipe. Required in practice for Layer 1 / Layer 2 recipes: src/layer1_wasm/tests/repro.spec.ts refuses to start when the field is missing or off-enum. Schema keeps it optional so external_examples and future layers can ship recipe.json without owning this field; ADR-0018 spec evolution policy reserves required-promotion for v2."
     },
     "expected_runtime": {
       "type": "string",
       "minLength": 1,
-      "description": "Runtime identifier the recipe's verdict envelope reports in `__VIVARIUM_RESULT__.runtime.name`. For Layer 1: 'pyodide' / 'ruby.wasm' / 'php-wasm' / 'rust-wasi' / 'browser' (the smoke test). For Layer 2: 'docker-snapshot'. For Layer 3: 'rr-replay'. Asserted by the regression suite alongside expected_verdict."
+      "description": "Runtime identifier the recipe's verdict envelope reports in `__VIVARIUM_RESULT__.runtime.name`. For Layer 1: 'pyodide' / 'ruby.wasm' / 'php-wasm' / 'rust-wasi' / 'browser' (the smoke test). For Layer 2: 'docker-snapshot'. For Layer 3: 'rr-replay'. Asserted by the regression suite alongside expected_verdict, and required in practice on the same terms: src/layer1_wasm/tests/repro.spec.ts refuses to start when the value is missing or unrecognised."
     }
   },
   "examples": [

--- a/src/layer1_wasm/tests/repro.spec.ts
+++ b/src/layer1_wasm/tests/repro.spec.ts
@@ -20,10 +20,26 @@
 // Either way, this suite turns that into a CI failure so a human can
 // decide whether to update / retire the page.
 
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { expect, test, type Page } from "@playwright/test";
 
 const LAYER1 = "http://localhost:8767";
 const LAYER2 = "http://localhost:8768";
+
+const SUPPORTED_VERDICTS = ["reproduced", "unreproduced"] as const;
+const SUPPORTED_RUNTIMES = [
+  "browser",
+  "pyodide",
+  "ruby.wasm",
+  "php-wasm",
+  "rust-wasi",
+  "docker-snapshot",
+] as const;
+
+type ExpectedVerdict = (typeof SUPPORTED_VERDICTS)[number];
+type ExpectedRuntimeName = (typeof SUPPORTED_RUNTIMES)[number];
 
 interface ReproCase {
   /** Display name used in the test title. */
@@ -31,7 +47,7 @@ interface ReproCase {
   /** Absolute URL — pick the Layer 1 or Layer 2 host as appropriate. */
   url: string;
   /** Expected verdict — currently "reproduced" for every case. */
-  expectedVerdict: "reproduced" | "unreproduced";
+  expectedVerdict: ExpectedVerdict;
   /** Envelope `bug.project` field. */
   expectedBugProject: string;
   /** Envelope `bug.issue` field. */
@@ -42,144 +58,100 @@ interface ReproCase {
    * for Layer 1 pages; `"docker-snapshot"` for Layer 2 pages
    * rendering a CI-captured verdict.
    */
-  expectedRuntimeName:
-    | "browser"
-    | "pyodide"
-    | "ruby.wasm"
-    | "php-wasm"
-    | "rust-wasi"
-    | "docker-snapshot";
+  expectedRuntimeName: ExpectedRuntimeName;
 }
 
-const cases: ReproCase[] = [
-  // Layer 1 — WASM in-page runtime.
-  {
+interface RecipeEntry {
+  slug: string;
+  layer: 1 | 2 | 3;
+  project: string;
+  issue: number;
+  expected_verdict?: string;
+  expected_runtime?: string;
+}
+
+interface RecipesIndex {
+  recipes: RecipeEntry[];
+}
+
+function isExpectedVerdict(value: unknown): value is ExpectedVerdict {
+  return SUPPORTED_VERDICTS.some((v) => v === value);
+}
+
+function isExpectedRuntimeName(value: unknown): value is ExpectedRuntimeName {
+  return SUPPORTED_RUNTIMES.some((v) => v === value);
+}
+
+function loadRecipeEntries(): RecipeEntry[] {
+  // Resolved from the spec file's own location rather than
+  // `process.cwd()` so the suite stays robust against being invoked
+  // from a non-default working directory (e.g. `playwright test
+  // --config=src/layer1_wasm/playwright.config.ts` from the repo root).
+  // `tests/` → `..` is `src/layer1_wasm/`, `..` again is `src/`, `..`
+  // one more is the repo root.
+  const indexPath = resolve(
+    import.meta.dirname,
+    "../../..",
+    "docs/site/public/api/recipes.json",
+  );
+  const raw = readFileSync(indexPath, "utf-8");
+  const parsed = JSON.parse(raw) as RecipesIndex;
+  return parsed.recipes;
+}
+
+function recipeCaseName(recipe: RecipeEntry): string {
+  if (recipe.layer === 1) return `${recipe.slug} reproduction`;
+  return `${recipe.slug} Layer 2 snapshot`;
+}
+
+function recipeUrl(recipe: RecipeEntry): string {
+  const base = recipe.layer === 1 ? LAYER1 : LAYER2;
+  return `${base}/${recipe.slug}/`;
+}
+
+function caseFromRecipe(recipe: RecipeEntry): ReproCase {
+  if (!isExpectedVerdict(recipe.expected_verdict)) {
+    throw new Error(
+      `${recipe.slug}: expected_verdict must be one of ${SUPPORTED_VERDICTS.join(", ")}`,
+    );
+  }
+  if (!isExpectedRuntimeName(recipe.expected_runtime)) {
+    throw new Error(
+      `${recipe.slug}: expected_runtime must be one of ${SUPPORTED_RUNTIMES.join(", ")}`,
+    );
+  }
+  return {
+    name: recipeCaseName(recipe),
+    url: recipeUrl(recipe),
+    expectedVerdict: recipe.expected_verdict,
+    expectedBugProject: recipe.project,
+    expectedBugIssue: recipe.issue,
+    expectedRuntimeName: recipe.expected_runtime,
+  };
+}
+
+function loadRegressionCases(): ReproCase[] {
+  const smoke: ReproCase = {
     name: "_shared/_test smoke test",
     url: `${LAYER1}/_shared/_test/`,
     expectedVerdict: "reproduced",
     expectedBugProject: "vivarium",
     expectedBugIssue: 0,
     expectedRuntimeName: "browser",
-  },
-  {
-    name: "pandas-56679 reproduction",
-    url: `${LAYER1}/pandas-56679/`,
-    expectedVerdict: "reproduced",
-    expectedBugProject: "pandas",
-    expectedBugIssue: 56679,
-    expectedRuntimeName: "pyodide",
-  },
-  {
-    name: "mpmath-983 reproduction",
-    url: `${LAYER1}/mpmath-983/`,
-    expectedVerdict: "reproduced",
-    expectedBugProject: "mpmath",
-    expectedBugIssue: 983,
-    expectedRuntimeName: "pyodide",
-  },
-  {
-    name: "numpy-28287 reproduction",
-    url: `${LAYER1}/numpy-28287/`,
-    expectedVerdict: "reproduced",
-    expectedBugProject: "numpy",
-    expectedBugIssue: 28287,
-    expectedRuntimeName: "pyodide",
-  },
-  {
-    name: "ruby-21709 reproduction",
-    url: `${LAYER1}/ruby-21709/`,
-    expectedVerdict: "reproduced",
-    expectedBugProject: "ruby",
-    expectedBugIssue: 21709,
-    expectedRuntimeName: "ruby.wasm",
-  },
-  {
-    name: "cpython-137205 reproduction",
-    url: `${LAYER1}/cpython-137205/`,
-    expectedVerdict: "reproduced",
-    expectedBugProject: "cpython",
-    expectedBugIssue: 137205,
-    expectedRuntimeName: "pyodide",
-  },
-  {
-    name: "php-12167 reproduction",
-    url: `${LAYER1}/php-12167/`,
-    expectedVerdict: "reproduced",
-    expectedBugProject: "php",
-    expectedBugIssue: 12167,
-    expectedRuntimeName: "php-wasm",
-  },
-  {
-    name: "regex-779 reproduction",
-    url: `${LAYER1}/regex-779/`,
-    expectedVerdict: "reproduced",
-    expectedBugProject: "regex",
-    expectedBugIssue: 779,
-    expectedRuntimeName: "rust-wasi",
-  },
-  {
-    name: "sympy-29413 reproduction",
-    url: `${LAYER1}/sympy-29413/`,
-    expectedVerdict: "reproduced",
-    expectedBugProject: "sympy",
-    expectedBugIssue: 29413,
-    expectedRuntimeName: "pyodide",
-  },
-  {
-    name: "lark-1585 reproduction",
-    url: `${LAYER1}/lark-1585/`,
-    expectedVerdict: "reproduced",
-    expectedBugProject: "lark",
-    expectedBugIssue: 1585,
-    expectedRuntimeName: "pyodide",
-  },
-  {
-    name: "dateutil-1478 reproduction",
-    url: `${LAYER1}/dateutil-1478/`,
-    expectedVerdict: "reproduced",
-    expectedBugProject: "dateutil",
-    expectedBugIssue: 1478,
-    expectedRuntimeName: "pyodide",
-  },
-  // Layer 2 — Docker catalogue, verdict snapshot fetched from
-  // `verdict.json` next to the page. CI generates `verdict.json` in
-  // both `repro-regression.yml` (build + run + write) and
-  // `deploy-docs.yml` (build + push + write); locally Playwright sees
-  // the regression-flow output. All current entries are
-  // expected `reproduced` snapshots.
-  {
-    name: "postgres-lost-update Layer 2 snapshot",
-    url: `${LAYER2}/postgres-lost-update/`,
-    expectedVerdict: "reproduced",
-    expectedBugProject: "postgres",
-    expectedBugIssue: 0,
-    expectedRuntimeName: "docker-snapshot",
-  },
-  {
-    name: "bash-local-shadows-exit Layer 2 snapshot",
-    url: `${LAYER2}/bash-local-shadows-exit/`,
-    expectedVerdict: "reproduced",
-    expectedBugProject: "bash",
-    expectedBugIssue: 0,
-    expectedRuntimeName: "docker-snapshot",
-  },
-  {
-    name: "flock-is-advisory Layer 2 snapshot",
-    url: `${LAYER2}/flock-is-advisory/`,
-    expectedVerdict: "reproduced",
-    expectedBugProject: "flock",
-    expectedBugIssue: 0,
-    expectedRuntimeName: "docker-snapshot",
-  },
-  {
-    name: "find-xargs-whitespace Layer 2 snapshot",
-    url: `${LAYER2}/find-xargs-whitespace/`,
-    expectedVerdict: "reproduced",
-    expectedBugProject: "find-xargs",
-    expectedBugIssue: 0,
-    expectedRuntimeName: "docker-snapshot",
-  },
-];
+  };
+  const recipes = loadRecipeEntries()
+    .filter((recipe) => recipe.layer === 1 || recipe.layer === 2)
+    .map(caseFromRecipe);
+  return [smoke, ...recipes];
+}
+
+const cases: ReproCase[] = loadRegressionCases();
+
+// Layer 1 — WASM in-page runtime. Layer 2 — Docker catalogue, verdict
+// snapshot fetched from `verdict.json` next to the page. CI generates
+// `verdict.json` in both `repro-regression.yml` (build + run + write)
+// and `deploy-docs.yml` (build + push + write); locally Playwright sees
+// the regression-flow output.
 
 interface VivariumPageState {
   verdict: string | undefined;
@@ -212,13 +184,17 @@ async function readVivariumState(page: Page): Promise<VivariumPageState> {
 
 function timeoutForRuntime(name: ReproCase["expectedRuntimeName"]): number {
   // Smoke test and Layer 2 verdict-snapshot fetch resolve in milliseconds;
-  // WASM-runtime pages download a multi-MB CDN bundle and instantiate it.
+  // Pyodide pages download and import large wheels, with SymPy on
+  // Firefox sitting near the old 75s ceiling on cold local runs.
   if (name === "browser" || name === "docker-snapshot") return 10_000;
+  if (name === "pyodide") return 120_000;
   return 75_000;
 }
 
 for (const c of cases) {
   test(`${c.name} produces ${c.expectedVerdict}`, async ({ page }) => {
+    test.setTimeout(timeoutForRuntime(c.expectedRuntimeName) + 15_000);
+
     await page.goto(c.url);
 
     // Wait for the verdict to settle. Pages start at `pending` and

--- a/src/layer1_wasm/tests/verdict-capture.spec.ts
+++ b/src/layer1_wasm/tests/verdict-capture.spec.ts
@@ -26,34 +26,73 @@ import { expect, test } from "@playwright/test";
 
 const LAYER1 = "http://localhost:8767";
 
+const SUPPORTED_RUNTIMES = [
+  "browser",
+  "pyodide",
+  "ruby.wasm",
+  "php-wasm",
+  "rust-wasi",
+] as const;
+
+type ExpectedRuntimeName = (typeof SUPPORTED_RUNTIMES)[number];
+
 interface RecipeEntry {
   slug: string;
   layer: 1 | 2 | 3;
+  expected_runtime?: string;
 }
 
 interface RecipesIndex {
   recipes: RecipeEntry[];
 }
 
-function loadLayer1Slugs(): string[] {
+interface Layer1Recipe {
+  slug: string;
+  expectedRuntimeName: ExpectedRuntimeName;
+}
+
+function isExpectedRuntimeName(value: unknown): value is ExpectedRuntimeName {
+  return SUPPORTED_RUNTIMES.some((v) => v === value);
+}
+
+function loadLayer1Recipes(): Layer1Recipe[] {
+  // Resolved from the spec file's own location so the suite stays
+  // robust against being invoked from a non-default working directory.
+  // See the matching comment in `repro.spec.ts:loadRecipeEntries`.
   const indexPath = resolve(
-    process.cwd(),
-    "../../docs/site/public/api/recipes.json",
+    import.meta.dirname,
+    "../../..",
+    "docs/site/public/api/recipes.json",
   );
   const raw = readFileSync(indexPath, "utf-8");
   const parsed = JSON.parse(raw) as RecipesIndex;
   return parsed.recipes
     .filter((r) => r.layer === 1)
-    .map((r) => r.slug)
-    .sort();
+    .map((r) => {
+      if (!isExpectedRuntimeName(r.expected_runtime)) {
+        throw new Error(
+          `${r.slug}: expected_runtime must be one of ${SUPPORTED_RUNTIMES.join(", ")}`,
+        );
+      }
+      return { slug: r.slug, expectedRuntimeName: r.expected_runtime };
+    })
+    .sort((a, b) => a.slug.localeCompare(b.slug));
 }
 
-const SLUGS = loadLayer1Slugs();
+function timeoutForRuntime(name: ExpectedRuntimeName): number {
+  if (name === "browser") return 10_000;
+  if (name === "pyodide") return 120_000;
+  return 75_000;
+}
+
+const RECIPES = loadLayer1Recipes();
 const FIX_URL = process.env["PLAYWRIGHT_FIX_URL"];
 const OUTPUT_PATH = process.env["VERDICT_CAPTURE_OUTPUT"];
 
-for (const slug of SLUGS) {
+for (const { slug, expectedRuntimeName } of RECIPES) {
   test(`verdict-capture: ${slug}`, async ({ page }) => {
+    test.setTimeout(timeoutForRuntime(expectedRuntimeName) + 15_000);
+
     let url = `${LAYER1}/${slug}/`;
     if (FIX_URL) {
       const sep = url.includes("?") ? "&" : "?";
@@ -69,7 +108,7 @@ for (const slug of SLUGS) {
         return v === "reproduced" || v === "unreproduced";
       },
       undefined,
-      { timeout: 75_000 },
+      { timeout: timeoutForRuntime(expectedRuntimeName) },
     );
 
     const verdict = await page.evaluate(

--- a/src/layer2_docker/find-xargs-whitespace/index.html
+++ b/src/layer2_docker/find-xargs-whitespace/index.html
@@ -65,7 +65,7 @@
       import { renderVerdictSnapshot } from "../_layer2-shared/layer2.js";
       renderVerdictSnapshot({
         bug: {
-          project: "find-xargs",
+          project: "find",
           issue: 0,
           upstream_url: "https://mywiki.wooledge.org/BashFAQ/020",
         },


### PR DESCRIPTION

Final piece of the recipe-facets.json retirement triplet (after PR
#264 introducing per-recipe recipe.json and PR #265 dropping
LANG_BY_PROJECT in highlight-repros.ts). Until now,
src/layer1_wasm/tests/repro.spec.ts still carried a hand-curated
`cases: ReproCase[]` array that grew by one entry per recipe — so
adding a new Layer 1 / Layer 2 recipe meant touching this file
even though every input it needed (project / issue / expected
verdict / expected runtime) already lives in
docs/site/public/api/recipes.json after `mise run recipes:index`.

This PR makes the cases catalogue-driven:

- `loadRecipeEntries()` reads docs/site/public/api/recipes.json
  from a path resolved relative to the spec file itself
  (import.meta.dirname-based) so the suite stays robust against
  being invoked from a non-default working directory.
- `caseFromRecipe()` builds a ReproCase from a recipes.json entry,
  using SUPPORTED_VERDICTS / SUPPORTED_RUNTIMES type guards to
  fail-fast at suite startup if a recipe.json ships an off-enum
  expected_verdict / expected_runtime.
- Layer 3 is filtered out (the lone Layer 3 recipe ships a static
  verdict.json captured maintainer-side, not probed by Playwright).
- The `_shared/_test` smoke test stays hardcoded — it is not a
  recipe and carries no recipe.json.

src/layer1_wasm/tests/verdict-capture.spec.ts gets the same
catalogue-driven + import.meta.dirname treatment so the two spec
files stay in sync, and both gain a per-runtime
`timeoutForRuntime()` (browser=10s, pyodide=120s, others=75s).
The Pyodide bump from the previous 75s ceiling is driven by SymPy
on Firefox sitting right at the old limit during cold local runs;
GHA hosted Ubuntu runners had headroom at 75s so CI was not
flaky, but giving local cold starts the same ceiling avoids
divergent local-vs-CI test outcomes.

Catalogue-driven cases also surface a latent page-vs-catalogue
inconsistency: src/layer2_docker/find-xargs-whitespace/index.html
declared `bug.project: "find-xargs"` while the slug parser in
docs/scripts/generate-recipes-index.ts derives `project: "find"`
from `find-xargs-whitespace`. The hardcoded test array masked the
divergence by mirroring the page side. Now that the test sources
the expected project from recipes.json, the page is brought into
line with the catalogue (`"find-xargs"` → `"find"`).

After this lands, adding a new Layer 1 / Layer 2 recipe is a
single-directory change: create `src/layer{1,2}_*/<slug>/` with
its recipe.json, run `mise run recipes:index`, and the regression
suite picks the new case up automatically.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
