### PR TITLE
docs(guide): add §6 worked-example section to round-trip guide

### DIFF
--- a/docs/site/en/guide/round-trip.mdx
+++ b/docs/site/en/guide/round-trip.mdx
@@ -271,6 +271,129 @@ Stage 9    Final Vivarium-side commit
     </ol>
   </Section>
 
+  <Section
+    eyebrow="// 6 · WORKED EXAMPLE — sympy-29413"
+    heading="A Layer 1 round-trip on a SymPy assumption blind spot."
+  >
+    <p>
+      First end-to-end exercise of the loop after Phases 1 – 5 merged.
+      The recipe lives at{' '}
+      <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/sympy-29413">
+        <code>src/layer1_wasm/sympy-29413/</code>
+      </a>{' '}
+      and reproduces{' '}
+      <a href="https://github.com/sympy/sympy/issues/29413">
+        sympy/sympy#29413
+      </a>
+      : <code>ask(a + 1 &gt; a, Q.extended_real(a))</code> returns{' '}
+      <code>True</code> against sympy 1.14.0, but{' '}
+      <code>Q.extended_real</code> admits <code>a = ±∞</code> where the
+      comparison is undefined, so the correct answer is{' '}
+      <code>None</code>.
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Stage</th>
+          <th>Result</th>
+          <th>Sticking point</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>0 · Pre-flight</td>
+          <td>
+            OK — SymPy had 49 human-merged PRs in the 90 days prior,
+            issue OPEN, no linked PR.
+          </td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td>1 · Scaffold</td>
+          <td>Copy-from-existing.</td>
+          <td>
+            Layer 1 has no <code>recipes:new</code> scaffolder yet — the
+            agent copied <code>src/layer1_wasm/pandas-56679/</code> and
+            adapted the slug + bug-specific files.
+          </td>
+        </tr>
+        <tr>
+          <td>2 · Implement</td>
+          <td>
+            <code>repro.ts</code> bootstraps Pyodide, runs SymPy under
+            it, and emits the contract-v1 verdict envelope.
+          </td>
+          <td>
+            SymPy is not in Pyodide's bundled package set; resolved by
+            installing it via <code>micropip</code> at runtime
+            (<code>await micropip.install("sympy==1.14.0")</code>). Pure
+            Python + mpmath only, so two PyPI wheel pulls instead of a
+            recompile.
+          </td>
+        </tr>
+        <tr>
+          <td>3 · Unfixed verdict</td>
+          <td>
+            <code>verify_and_report_fix</code> returned{' '}
+            <code>verdicts.unfixed.verdict === &quot;reproduced&quot;</code>.
+          </td>
+          <td>
+            Smoke confirmed: the targeted Playwright run on Vivarium's
+            own Layer 1 server captured the same envelope the deployed
+            page would emit, with no flakiness on Pyodide cold start.
+          </td>
+        </tr>
+        <tr>
+          <td>4 · Vivarium PR</td>
+          <td>
+            <a href="https://github.com/aletheia-works/vivarium/pull/260">
+              #260
+            </a>{' '}
+            opened, <code>ai: generated</code> label applied,{' '}
+            <code>roundtrip.json#/vivarium_pr</code> recorded.
+          </td>
+          <td>
+            Pre PR{' '}
+            <a href="https://github.com/aletheia-works/vivarium/pull/264">
+              #264
+            </a>
+            , the recipe still required four out-of-recipe edits —{' '}
+            <code>recipe-facets.json</code> /{' '}
+            <code>projects.json</code> overlays plus{' '}
+            <code>highlight-repros.ts</code> /{' '}
+            <code>repro.spec.ts</code> entries. Those manual touches
+            drove the recipe-metadata cleanup that landed as PRs{' '}
+            <a href="https://github.com/aletheia-works/vivarium/pull/264">
+              #264
+            </a>{' '}
+            /{' '}
+            <a href="https://github.com/aletheia-works/vivarium/pull/265">
+              #265
+            </a>{' '}
+            /{' '}
+            <a href="https://github.com/aletheia-works/vivarium/pull/268">
+              #268
+            </a>
+            , so new recipes from here on are a single-directory change.
+          </td>
+        </tr>
+        <tr>
+          <td>5+ · Fork &amp; fix</td>
+          <td>In progress.</td>
+          <td>
+            Fork on the contributor's personal GitHub account,
+            candidate fix branched, and{' '}
+            <code>prepare_fix_candidate</code> wired to the fork URL.
+            Stage 5 onward is captured in{' '}
+            <code>src/layer1_wasm/sympy-29413/roundtrip.json</code> for
+            the live state; this section will fold in lessons from the
+            upstream PR once the loop closes.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Section>
+
   <Callout>
     Found something this guide didn't cover? File an issue against{' '}
     <a href="https://github.com/aletheia-works/vivarium/issues">

--- a/docs/site/ja/guide/round-trip.mdx
+++ b/docs/site/ja/guide/round-trip.mdx
@@ -239,6 +239,128 @@ Stage 9    最終 Vivarium 側 commit
     </ol>
   </Section>
 
+  <Section
+    eyebrow="// 6 · 実例 — sympy-29413"
+    heading="SymPy の assumption blind spot を Layer 1 で 1 周。"
+  >
+    <p>
+      Phase 1 – 5 merge 後の最初のエンドツーエンド試行。レシピは{' '}
+      <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/sympy-29413">
+        <code>src/layer1_wasm/sympy-29413/</code>
+      </a>{' '}
+      にあり、{' '}
+      <a href="https://github.com/sympy/sympy/issues/29413">
+        sympy/sympy#29413
+      </a>{' '}
+      ——{' '}
+      <code>ask(a + 1 &gt; a, Q.extended_real(a))</code> が sympy 1.14.0
+      で <code>True</code> を返す不具合を再現します。{' '}
+      <code>Q.extended_real</code> は <code>a = ±∞</code> を含み、
+      その時 <code>a + 1 &gt; a</code> は未定義なので正解は{' '}
+      <code>None</code>。
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Stage</th>
+          <th>結果</th>
+          <th>詰まったポイント</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>0 · Pre-flight</td>
+          <td>
+            OK — SymPy は直近 90 日で 49 件の人手 merge、issue OPEN、
+            linked PR なし。
+          </td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td>1 · Scaffold</td>
+          <td>既存レシピからコピー。</td>
+          <td>
+            Layer 1 には <code>recipes:new</code> スキャフォルダが未整備
+            のため、エージェントが <code>src/layer1_wasm/pandas-56679/</code>{' '}
+            をコピーして slug と bug 固有ファイルを差し替え。
+          </td>
+        </tr>
+        <tr>
+          <td>2 · 再現実装</td>
+          <td>
+            <code>repro.ts</code> が Pyodide を起動し、SymPy を読んで
+            contract-v1 verdict envelope を返す。
+          </td>
+          <td>
+            SymPy は Pyodide bundle に含まれないため、ランタイムで{' '}
+            <code>micropip</code> 経由インストール
+            (<code>await micropip.install("sympy==1.14.0")</code>)。pure
+            Python + mpmath のみで完結するので PyPI wheel 2 本の取得で済む。
+          </td>
+        </tr>
+        <tr>
+          <td>3 · unfixed verdict 取得</td>
+          <td>
+            <code>verify_and_report_fix</code> が{' '}
+            <code>verdicts.unfixed.verdict === &quot;reproduced&quot;</code>{' '}
+            を返した。
+          </td>
+          <td>
+            Smoke 確認: targeted Playwright が Vivarium 側 Layer 1 サーバ
+            に対し、デプロイ後ページと同じ envelope を取得。Pyodide cold
+            start の flakiness なし。
+          </td>
+        </tr>
+        <tr>
+          <td>4 · Vivarium PR open</td>
+          <td>
+            <a href="https://github.com/aletheia-works/vivarium/pull/260">
+              #260
+            </a>{' '}
+            open、<code>ai: generated</code> label 付与、{' '}
+            <code>roundtrip.json#/vivarium_pr</code> 反映。
+          </td>
+          <td>
+            PR{' '}
+            <a href="https://github.com/aletheia-works/vivarium/pull/264">
+              #264
+            </a>{' '}
+            以前はレシピ外の 4 ファイル変更が必要だった ——{' '}
+            <code>recipe-facets.json</code> /{' '}
+            <code>projects.json</code> overlay と{' '}
+            <code>highlight-repros.ts</code> /{' '}
+            <code>repro.spec.ts</code> の登録。この煩雑さがレシピ metadata
+            整理を駆動し、PR{' '}
+            <a href="https://github.com/aletheia-works/vivarium/pull/264">
+              #264
+            </a>{' '}
+            /{' '}
+            <a href="https://github.com/aletheia-works/vivarium/pull/265">
+              #265
+            </a>{' '}
+            /{' '}
+            <a href="https://github.com/aletheia-works/vivarium/pull/268">
+              #268
+            </a>{' '}
+            として merge。以降の新規レシピは 1 ディレクトリの変更で済む。
+          </td>
+        </tr>
+        <tr>
+          <td>5+ · fork & fix</td>
+          <td>進行中。</td>
+          <td>
+            contributor 個人 GitHub アカウントに fork、候補修正ブランチ作成、
+            <code>prepare_fix_candidate</code> を fork URL に紐付け。Stage 5
+            以降の live 状態は{' '}
+            <code>src/layer1_wasm/sympy-29413/roundtrip.json</code> を参照。
+            このセクションは upstream PR まで一周した時点で得られた学びを
+            追記していく。
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Section>
+
   <Callout>
     このガイドで触れていない事象に遭遇したら、{' '}
     <a href="https://github.com/aletheia-works/vivarium/issues">


### PR DESCRIPTION

The §0 callout in round-trip.mdx promised "examples grow over time"
once the maintainer exercises the loop on real upstream issues. The
first full exercise — sympy/sympy#29413 reproduced as the Layer 1
recipe at src/layer1_wasm/sympy-29413/ — has run through Stages 0–4
and is now in Stage 5+ (cloud-Claude session for fork-and-fix), so
the guide now carries the first walkthrough.

Section §6 lays out each stage as a row: what happened, and what
stuck. Notable sticking points captured:

- Stage 1: Layer 1 has no recipes:new scaffolder; agent copy-from-
  existing (src/layer1_wasm/pandas-56679/).
- Stage 2: SymPy not in Pyodide's bundled set; resolved via
  micropip.install("sympy==1.14.0") at runtime — works because
  SymPy is pure Python + mpmath.
- Stage 4: the recipe still required four out-of-recipe edits at
  PR open time. Those manual touches drove the recipe-metadata
  cleanup that landed as PRs #264 / #265 / #268, so new recipes
  from here on are a single-directory change. The section links
  to all three retrospectively so a reader landing on this page
  later can see the rationale chain.

Stage 5+ is intentionally a stub ("in progress; see roundtrip.json
for the live state") because the upstream loop has not closed yet.
Once the upstream PR lands the section will be amended with the
lessons that come back from there.

Mirrored verbatim in docs/site/ja/guide/round-trip.mdx so the
Japanese locale stays in lockstep with the English one (no
recipe-authoring.md path-rule for docs/site/ja, but the en/ja
parity convention applies).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
