### PR TITLE
feat(wasm): register fix-candidate for dateutil-1478

### DIFF
--- a/docs/site/public/api/recipes.json
+++ b/docs/site/public/api/recipes.json
@@ -46,10 +46,19 @@
         "schema_version": 1,
         "slug": "dateutil-1478",
         "upstream_issue": "https://github.com/dateutil/dateutil/issues/1478",
-        "status": "draft",
-        "updated_at": "2026-05-17T00:00:00Z",
+        "vivarium_pr": "https://github.com/aletheia-works/vivarium/pull/266",
+        "fork": {
+          "owner": "JamBalaya56562",
+          "repo": "dateutil",
+          "branch": "fix-issue-1478"
+        },
+        "upstream_pr": "https://github.com/dateutil/dateutil/pull/1500",
+        "status": "verifying",
+        "updated_at": "2026-05-19T02:54:07Z",
         "notes": [
-          "scaffolded from upstream issue dateutil/dateutil#1478 (sign of UTC±N offset inverted when the literal UTC prefix precedes a numeric offset). Native repro.py confirms reproduction against python-dateutil 2.9.0.post0; in-browser repro pinned to the same version via micropip."
+          "scaffolded from upstream issue dateutil/dateutil#1478 (sign of UTC±N offset inverted when the literal UTC prefix precedes a numeric offset). Native repro.py confirms reproduction against python-dateutil 2.9.0.post0; in-browser repro pinned to the same version via micropip.",
+          "fix-candidate registered (Stage 6): JamBalaya56562/dateutil@fix-issue-1478 (commit 9a5355c — \"Fix sign inversion when parsing literal UTC/GMT offsets\"). Wheel is built by CI on Vivarium PR merge so the live recipe page renders baseline + fix-candidate side-by-side; expected fixed verdict: unreproduced.",
+          "upstream PR opened: dateutil/dateutil#1500 (\"Fix UTC/GMT offset sign parsing\")."
         ]
       }
     },

--- a/src/layer1_wasm/dateutil-1478/fix-candidate.json
+++ b/src/layer1_wasm/dateutil-1478/fix-candidate.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "package": "python-dateutil",
+  "purpose": "fix-candidate verification for dateutil/dateutil#1478",
+  "source": {
+    "type": "git",
+    "url": "https://github.com/JamBalaya56562/dateutil",
+    "ref": "fix-issue-1478"
+  },
+  "upstream_pr": "https://github.com/dateutil/dateutil/pull/1500"
+}

--- a/src/layer1_wasm/dateutil-1478/roundtrip.json
+++ b/src/layer1_wasm/dateutil-1478/roundtrip.json
@@ -2,9 +2,18 @@
   "schema_version": 1,
   "slug": "dateutil-1478",
   "upstream_issue": "https://github.com/dateutil/dateutil/issues/1478",
-  "status": "draft",
-  "updated_at": "2026-05-17T00:00:00Z",
+  "vivarium_pr": "https://github.com/aletheia-works/vivarium/pull/266",
+  "fork": {
+    "owner": "JamBalaya56562",
+    "repo": "dateutil",
+    "branch": "fix-issue-1478"
+  },
+  "upstream_pr": "https://github.com/dateutil/dateutil/pull/1500",
+  "status": "verifying",
+  "updated_at": "2026-05-19T02:54:07Z",
   "notes": [
-    "scaffolded from upstream issue dateutil/dateutil#1478 (sign of UTC±N offset inverted when the literal UTC prefix precedes a numeric offset). Native repro.py confirms reproduction against python-dateutil 2.9.0.post0; in-browser repro pinned to the same version via micropip."
+    "scaffolded from upstream issue dateutil/dateutil#1478 (sign of UTC±N offset inverted when the literal UTC prefix precedes a numeric offset). Native repro.py confirms reproduction against python-dateutil 2.9.0.post0; in-browser repro pinned to the same version via micropip.",
+    "fix-candidate registered (Stage 6): JamBalaya56562/dateutil@fix-issue-1478 (commit 9a5355c — \"Fix sign inversion when parsing literal UTC/GMT offsets\"). Wheel is built by CI on Vivarium PR merge so the live recipe page renders baseline + fix-candidate side-by-side; expected fixed verdict: unreproduced.",
+    "upstream PR opened: dateutil/dateutil#1500 (\"Fix UTC/GMT offset sign parsing\")."
   ]
 }


### PR DESCRIPTION

Register JamBalaya56562/dateutil@fix-issue-1478 (commit 9a5355c —
"Fix sign inversion when parsing literal UTC/GMT offsets") as the
fix-candidate for dateutil/dateutil#1478. On Vivarium PR merge,
deploy-docs' scripts/build-layer1-wheels.sh builds a wheel from the
fork branch so the recipe page renders the baseline (PyPI
python-dateutil==2.9.0.post0) and fix-candidate verdicts side-by-side.

Locally confirmed:
- Baseline: repro.py against python-dateutil==2.9.0.post0 -> all four
  UTC±N cases invert (inverted_count: 4/4, verdict=reproduced).
- Fix-candidate: same probe against the fork-branch wheel -> all four
  cases parse with the correct sign (inverted_count: 0/4,
  verdict=unreproduced).
- mise run repro:build:wheels emits a pure-Python wheel
  (python_dateutil-0.1.dev1615+g9a5355c-py2.py3-none-any.whl).

Updates roundtrip.json: status draft -> verifying; records fork +
vivarium_pr (#266, the original recipe PR).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
