### PR TITLE
fix(wasm): correct dateutil-1478 fix-candidate ref to match PR #1500

### DIFF
--- a/docs/site/public/api/recipes.json
+++ b/docs/site/public/api/recipes.json
@@ -50,14 +50,14 @@
         "fork": {
           "owner": "JamBalaya56562",
           "repo": "dateutil",
-          "branch": "fix-issue-1478"
+          "branch": "fix-1478-utc-gmt-offset-sign"
         },
         "upstream_pr": "https://github.com/dateutil/dateutil/pull/1500",
         "status": "verifying",
         "updated_at": "2026-05-19T02:54:07Z",
         "notes": [
           "scaffolded from upstream issue dateutil/dateutil#1478 (sign of UTC±N offset inverted when the literal UTC prefix precedes a numeric offset). Native repro.py confirms reproduction against python-dateutil 2.9.0.post0; in-browser repro pinned to the same version via micropip.",
-          "fix-candidate registered (Stage 6): JamBalaya56562/dateutil@fix-issue-1478 (commit 9a5355c — \"Fix sign inversion when parsing literal UTC/GMT offsets\"). Wheel is built by CI on Vivarium PR merge so the live recipe page renders baseline + fix-candidate side-by-side; expected fixed verdict: unreproduced.",
+          "fix-candidate registered (Stage 6): JamBalaya56562/dateutil@fix-1478-utc-gmt-offset-sign (commit 63e0611 — \"Fix sign inversion when parsing literal UTC/GMT offsets\"). Wheel is built by CI on Vivarium PR merge so the live recipe page renders baseline + fix-candidate side-by-side; expected fixed verdict: unreproduced.",
           "upstream PR opened: dateutil/dateutil#1500 (\"Fix UTC/GMT offset sign parsing\")."
         ]
       }

--- a/src/layer1_wasm/dateutil-1478/fix-candidate.json
+++ b/src/layer1_wasm/dateutil-1478/fix-candidate.json
@@ -5,7 +5,7 @@
   "source": {
     "type": "git",
     "url": "https://github.com/JamBalaya56562/dateutil",
-    "ref": "fix-issue-1478"
+    "ref": "fix-1478-utc-gmt-offset-sign"
   },
   "upstream_pr": "https://github.com/dateutil/dateutil/pull/1500"
 }

--- a/src/layer1_wasm/dateutil-1478/roundtrip.json
+++ b/src/layer1_wasm/dateutil-1478/roundtrip.json
@@ -6,14 +6,14 @@
   "fork": {
     "owner": "JamBalaya56562",
     "repo": "dateutil",
-    "branch": "fix-issue-1478"
+    "branch": "fix-1478-utc-gmt-offset-sign"
   },
   "upstream_pr": "https://github.com/dateutil/dateutil/pull/1500",
   "status": "verifying",
   "updated_at": "2026-05-19T02:54:07Z",
   "notes": [
     "scaffolded from upstream issue dateutil/dateutil#1478 (sign of UTC±N offset inverted when the literal UTC prefix precedes a numeric offset). Native repro.py confirms reproduction against python-dateutil 2.9.0.post0; in-browser repro pinned to the same version via micropip.",
-    "fix-candidate registered (Stage 6): JamBalaya56562/dateutil@fix-issue-1478 (commit 9a5355c — \"Fix sign inversion when parsing literal UTC/GMT offsets\"). Wheel is built by CI on Vivarium PR merge so the live recipe page renders baseline + fix-candidate side-by-side; expected fixed verdict: unreproduced.",
+    "fix-candidate registered (Stage 6): JamBalaya56562/dateutil@fix-1478-utc-gmt-offset-sign (commit 63e0611 — \"Fix sign inversion when parsing literal UTC/GMT offsets\"). Wheel is built by CI on Vivarium PR merge so the live recipe page renders baseline + fix-candidate side-by-side; expected fixed verdict: unreproduced.",
     "upstream PR opened: dateutil/dateutil#1500 (\"Fix UTC/GMT offset sign parsing\")."
   ]
 }


### PR DESCRIPTION
## Summary

- Upstream PR [dateutil/dateutil#1500](https://github.com/dateutil/dateutil/pull/1500) was force-pushed onto a renamed branch (`fix-issue-1478` → `fix-1478-utc-gmt-offset-sign`), and its HEAD now diverges from the previous reference (`9a5355c` → `63e0611`; same commit message, different parent — `git compare` reports `status: diverged, ahead 1, behind 1`).
- Update `src/layer1_wasm/dateutil-1478/fix-candidate.json` and `roundtrip.json` (and the regenerated `docs/site/public/api/recipes.json`) so the Layer 1 wheel-build pipeline (`scripts/build-layer1-wheels.sh`) targets the ref that actually backs the upstream PR.
- Local wheel rebuild against the new HEAD succeeds (`python_dateutil-0.1.dev1615+g63e0611-py2.py3-none-any.whl`); CI will rebuild on merge per the Stage 6 contract.

## Test plan

- [x] `mise run recipes:index` — regenerates `recipes.json` / `projects.json` / project landing pages / site stats with the new ref.
- [x] `mise run repro:build:wheels` — locally rebuilds the dateutil-1478 wheel from the new ref (commit `63e0611`); manifest emitted with matching `commit` / `spec` / `fetched_at`.
- [x] `jq empty` on the three tracked JSON files.
- [x] CI: `repro-regression.yml` should keep showing baseline = reproduced, fix-candidate = unreproduced on the live recipe page once the wheel rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)