### PR TITLE
fix(wasm): render fix-candidate pane on dateutil-1478 recipe page

### DIFF
--- a/.claude/skills/round-trip/SKILL.md
+++ b/.claude/skills/round-trip/SKILL.md
@@ -270,9 +270,44 @@ the fix-candidate verdict side-by-side.
 ```
 
 Write the returned `fix_candidate_json` content to
-`src/layer1_wasm/<slug>/fix-candidate.json`. Amend the Stage-4
-Vivarium commit (`sl addremove && sl amend && sl pr submit`) so
-the same PR now also carries the fix-candidate registration.
+`src/layer1_wasm/<slug>/fix-candidate.json`.
+
+**Wire the recipe page to render the fix-candidate variant.** The
+wheel pipeline only builds the artefact — it does **not** modify
+`index.html` / `repro.ts`. Before amending, verify the recipe page
+renders both variants side-by-side:
+
+- `index.html` output section uses
+  `class="vh-main__col vh-main__col--output vh-output-multi"` and
+  contains both `<pre id="output">` (baseline) and
+  `<pre id="output-fix">` (fix-candidate), with
+  `<header class="vh-variant-head" data-variant="baseline">` /
+  `data-variant="fix-candidate"` labels. The shared CSS in
+  `src/layer1_wasm/_shared/style.css` styles these classes;
+  per-recipe CSS is not needed.
+- `repro.ts` fetches `./wheels/manifest.json`, installs the wheel
+  via `micropip.install(<wheel URL>)` after running
+  `micropip.uninstall(...)` + `del sys.modules[...]` for every
+  in-memory module of the target package (Pyodide caches imports
+  in `sys.modules`; `del` is the only reliable way to force
+  re-resolution). It runs the same reproduction source against the
+  fix-candidate, restores the baseline package (so `enableRunner`
+  still operates against the buggy build), and publishes the
+  Contract v1 envelope with additive `result.baseline` and
+  `result.fix_candidate` sub-objects.
+
+If wiring is absent, copy the dual-variant pattern from
+`src/layer1_wasm/sympy-29413/` (silent wrong-result, main-thread
+Pyodide, single-instance + uninstall/reinstall) or
+`src/layer1_wasm/lark-1585/` (hang-class bug requiring per-variant
+Web Worker isolation) and adapt the package name / install spec.
+Without this step the live page will display only the baseline
+pane after merge and Stage 8's visual confirmation will fail.
+
+Then amend the Stage-4 Vivarium commit
+(`sl addremove && sl amend && sl pr submit`) so the same PR now
+carries the fix-candidate registration **and** the recipe-page
+dual-variant wiring.
 
 **Layer 1 stops here for now.** The skill hands back to the
 human. The remaining flow:

--- a/src/layer1_wasm/dateutil-1478/README.md
+++ b/src/layer1_wasm/dateutil-1478/README.md
@@ -38,10 +38,13 @@ signed-offset code path. Both the short (`-4`) and the long
 
 | File         | Role                                                              |
 | ------------ | ----------------------------------------------------------------- |
-| `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
-| `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. Renders baseline + fix-candidate output panes side-by-side. |
+| `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. Drives the two-variant run (baseline `micropip` install → fix-candidate wheel install via `./wheels/manifest.json` → baseline restore for `enableRunner`). |
 | `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
 | `repro.py`   | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. See "Native verification" below. |
+| `fix-candidate.json` | **Tracked.** Single source of truth for the fix branch the page renders alongside the baseline (fork repo URL + branch ref). Read by `scripts/build-layer1-wheels.sh`. |
+| `wheels/`    | Generated; gitignored. `mise run repro:build:wheels` (`scripts/build-layer1-wheels.sh`) builds `python_dateutil-<version>-py2.py3-none-any.whl` from `fix-candidate.json` plus a `manifest.json` (filename + version + resolved commit + spec). `repro.ts` fetches the manifest at page load to install the fix candidate in the same Pyodide tab. |
+| `roundtrip.json` | Tracked workflow state (round-trip schema_version 1). Updated as the recipe moves through verify → Vivarium PR → fork+fix → upstream PR. |
 
 Shared visual presentation lives in [`../_shared/style.css`](../_shared/style.css).
 
@@ -56,8 +59,12 @@ The page conforms to the contract canonicalised in
 - `globalThis.__VIVARIUM_VERDICT__` — mirror of the DOM verdict.
 - `globalThis.__VIVARIUM_RESULT__` — a `VivariumResultV1` envelope:
   `{ contract: "v1", bug: { project: "dateutil", issue: 1478, upstream_url },
-  runtime: { name: "pyodide", version, extras: { python, "python-dateutil" } },
-  result: { cases, inverted_count, case_count, reproduced }, timing }`.
+  runtime: { name: "pyodide", version, extras: { python, "python-dateutil", "python-dateutil_fix_candidate"? } },
+  result: { cases, inverted_count, case_count, reproduced, baseline: {...},
+  fix_candidate: {...} | null }, timing }`. The top-level `cases` /
+  `inverted_count` / `reproduced` mirror the **baseline** variant
+  (Contract v1 single-verdict surface preserved); the additive
+  `baseline` / `fix_candidate` sub-objects describe each variant.
 - Visible verdict text starts with `bug reproduced` or
   `bug not reproduced`.
 

--- a/src/layer1_wasm/dateutil-1478/index.html
+++ b/src/layer1_wasm/dateutil-1478/index.html
@@ -50,6 +50,14 @@
           The full discussion (motivation, history, fix progress)
           lives in the GitHub issue thread linked below.
         </p>
+        <p>
+          A fix-candidate branch
+          (<code>JamBalaya56562/dateutil@fix-1478-utc-gmt-offset-sign</code>)
+          is built into a pure-Python wheel under <code>./wheels/</code>
+          and installed into the same Pyodide tab after the baseline
+          run completes, so visitors can compare the before/after
+          verdict in one page load.
+        </p>
       </div>
       <hr class="vh-drawer__divider" />
       <div class="vh-drawer__meta-grid">
@@ -60,7 +68,7 @@
         <span class="vh-drawer__meta-key">Layer</span>
         <span class="vh-drawer__meta-val">L1 · WASM</span>
         <span class="vh-drawer__meta-key">Runtime</span>
-        <span class="vh-drawer__meta-val">Pyodide v0.29.3</span>
+        <span class="vh-drawer__meta-val">Pyodide v0.29.3 + python-dateutil 2.9.0.post0 (micropip)</span>
       </div>
     </template>
   </head>
@@ -75,6 +83,10 @@
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
               Bug context
             </button>
+            <a class="vh-chip" href="https://github.com/JamBalaya56562/dateutil/tree/fix-1478-utc-gmt-offset-sign" target="_blank" rel="noreferrer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><line x1="6" y1="9" x2="6" y2="21"/></svg>
+              Fix candidate branch
+            </a>
           </div>
         </div>
         <div class="vh-main__header-aside">
@@ -122,9 +134,22 @@
 <span class="line"><span style="color:#E1E4E8">}</span></span></code></pre>
         </section>
 
-        <section class="vh-main__col vh-main__col--output">
-          <h2>Output</h2>
-          <pre id="output">(running)</pre>
+        <section class="vh-main__col vh-main__col--output vh-output-multi">
+          <header class="vh-variant-head" data-variant="baseline">
+            <h2 class="vh-variant-head__title">Baseline output</h2>
+          </header>
+          <div class="vh-variant-stage" data-variant="baseline">
+            <!-- chrome.js inserts <div class="vh-progress"> before #output;
+                 the stage stacks both children in one grid cell so the
+                 overlay covers the pre during loading without taking
+                 extra column height. -->
+            <pre id="output" class="vh-variant-output">(pending)</pre>
+          </div>
+
+          <header class="vh-variant-head vh-variant-head--secondary" data-variant="fix-candidate">
+            <h2 class="vh-variant-head__title">Fix-candidate output</h2>
+          </header>
+          <pre id="output-fix" class="vh-variant-output">(waiting for baseline)</pre>
         </section>
       </div>
 

--- a/src/layer1_wasm/dateutil-1478/repro.ts
+++ b/src/layer1_wasm/dateutil-1478/repro.ts
@@ -14,12 +14,20 @@
 // Pyodide's bundled package set; the page installs the pinned
 // version via micropip.
 //
-// Verdict semantics (per ADR-0008 / contract v1):
+// Verdict semantics (per ADR-0008 / contract v1) — applied to each
+// variant card individually; the top-level `#verdict` pill mirrors
+// the **baseline** variant so the existing Contract v1 single-verdict
+// surface (`__VIVARIUM_VERDICT__`, `data-verdict`) keeps its prior
+// meaning and downstream consumers do not need to branch.
 //   - "reproduced"   — every UTC±N case lands on the negated offset
 //                      (signed inversion present).
 //   - "unreproduced" — at least one UTC±N case parsed with the
 //                      correct sign (likely fixed upstream), or the
 //                      runtime errored before producing a result.
+//
+// The fix-candidate this page renders side-by-side is a pure-Python
+// wheel under `./wheels/` built from the fork+branch
+// `JamBalaya56562/dateutil@fix-1478-utc-gmt-offset-sign`.
 
 import { loadVivariumPyodide } from '../_shared/loader.js';
 import type { PathACapturedRun } from '../_shared/path_a.js';
@@ -88,13 +96,33 @@ interface PyodideRuntime {
   }>;
 }
 
-const outputEl = document.getElementById('output');
+interface WheelManifest {
+  schema_version: number;
+  package: string;
+  filename: string;
+  version: string;
+  source: {
+    type: string;
+    url: string;
+    ref: string;
+    commit?: string;
+    spec?: string;
+    subdirectory?: string;
+  };
+  upstream_pr?: string;
+  fetched_at?: string;
+}
+
+const BASELINE_SPEC = 'python-dateutil==2.9.0.post0';
+
+const outputBaselineEl = document.getElementById('output');
+const outputFixEl = document.getElementById('output-fix');
 const metaEl = document.getElementById('meta');
 const reproCodeEl = document.getElementById('repro-code');
 
-if (!outputEl || !metaEl || !reproCodeEl) {
+if (!outputBaselineEl || !outputFixEl || !metaEl || !reproCodeEl) {
   throw new Error(
-    'dateutil-1478: missing required DOM elements (#output, #meta, #repro-code).',
+    'dateutil-1478: missing required DOM elements (#output, #output-fix, #meta, #repro-code).',
   );
 }
 
@@ -152,7 +180,34 @@ async function captureRun(
   }
 }
 
+// Drop the in-memory dateutil module tree so the next `import
+// dateutil` resolves the freshly-installed wheel rather than the
+// previously-loaded version. Pyodide caches imports in
+// `sys.modules`; `del` is the only reliable way to force a
+// re-resolution after `micropip.uninstall`.
+async function reinstallDateutil(
+  runtime: PyodideRuntime,
+  installSpec: string,
+): Promise<void> {
+  await runtime.runPythonAsync(`
+import micropip, sys
+try:
+    await micropip.uninstall("python-dateutil")
+except Exception:
+    pass
+for _name in [n for n in list(sys.modules) if n == "dateutil" or n.startswith("dateutil.")]:
+    del sys.modules[_name]
+await micropip.install(${JSON.stringify(installSpec)})
+`);
+}
+
 const startedAt = new Date();
+
+let baselineCapture: PathACapturedRun | null = null;
+let baselineParsed: ReproOutput | null = null;
+let fixCapture: PathACapturedRun | null = null;
+let fixParsed: ReproOutput | null = null;
+let manifest: WheelManifest | null = null;
 
 try {
   const { pyodide, version } = await loadVivariumPyodide({
@@ -161,59 +216,168 @@ try {
   });
   const runtime = pyodide as PyodideRuntime;
 
-  setVerdict('pending', 'Installing python-dateutil==2.9.0.post0 from PyPI…');
-  await runtime.runPythonAsync(`
-import micropip
-await micropip.install("python-dateutil==2.9.0.post0")
-`);
+  // Baseline variant: PyPI python-dateutil==2.9.0.post0.
+  setVerdict('pending', `Installing ${BASELINE_SPEC} from PyPI…`);
+  await reinstallDateutil(runtime, BASELINE_SPEC);
 
-  setVerdict('pending', 'Running reproduction script…');
-  const baseline = await captureRun(runtime, REPRO_CODE);
-
-  let baselineResult: ReproOutput | null = null;
+  setVerdict('pending', 'Running reproduction script (baseline)…');
+  baselineCapture = await captureRun(runtime, REPRO_CODE);
   try {
-    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
+    baselineParsed = JSON.parse(baselineCapture.stdout) as ReproOutput;
   } catch {
-    outputEl.textContent = baseline.stdout;
-    setVerdict(baseline.verdict, baseline.message);
-    throw new Error(baseline.message);
+    baselineParsed = null;
   }
+  outputBaselineEl.textContent = baselineCapture.stdout;
+
+  // Build the Contract v1 envelope as a closure that reflects whatever
+  // variant data is currently captured. Called once after baseline (so
+  // `__VIVARIUM_RESULT__` is populated by the time the top-level
+  // `#verdict` pill flips to "reproduced" — Playwright reads the
+  // envelope at that moment and would otherwise see `undefined`), and
+  // again after the fix-candidate run completes so the envelope picks
+  // up the second variant.
+  const buildEnvelope = (): VivariumResultV1 | null => {
+    if (!baselineParsed || !baselineCapture) return null;
+    const finishedAt = new Date();
+    return {
+      contract: 'v1',
+      bug: {
+        project: 'dateutil',
+        issue: 1478,
+        upstream_url: 'https://github.com/dateutil/dateutil/issues/1478',
+      },
+      runtime: {
+        name: 'pyodide',
+        version,
+        extras: {
+          python: baselineParsed.python_version,
+          'python-dateutil': baselineParsed.dateutil_version,
+          ...(fixParsed
+            ? { 'python-dateutil_fix_candidate': fixParsed.dateutil_version }
+            : {}),
+        },
+      },
+      result: {
+        cases: baselineParsed.cases,
+        inverted_count: baselineParsed.inverted_count,
+        case_count: baselineParsed.case_count,
+        reproduced: baselineParsed.reproduced,
+        baseline: {
+          spec: BASELINE_SPEC,
+          verdict: baselineCapture.verdict,
+          dateutil_version: baselineParsed.dateutil_version,
+          cases: baselineParsed.cases,
+          inverted_count: baselineParsed.inverted_count,
+          case_count: baselineParsed.case_count,
+          reproduced: baselineParsed.reproduced,
+        },
+        fix_candidate:
+          fixParsed && fixCapture && manifest
+            ? {
+                spec:
+                  manifest.source.spec ??
+                  `python-dateutil @ git+${manifest.source.url}@${manifest.source.ref}` +
+                    (manifest.source.subdirectory
+                      ? `#subdirectory=${manifest.source.subdirectory}`
+                      : ''),
+                verdict: fixCapture.verdict,
+                dateutil_version: fixParsed.dateutil_version,
+                cases: fixParsed.cases,
+                inverted_count: fixParsed.inverted_count,
+                case_count: fixParsed.case_count,
+                reproduced: fixParsed.reproduced,
+                upstream_pr: manifest.upstream_pr || null,
+              }
+            : null,
+      },
+      timing: {
+        started_at: startedAt.toISOString(),
+        finished_at: finishedAt.toISOString(),
+        duration_ms: finishedAt.getTime() - startedAt.getTime(),
+      },
+    };
+  };
+
+  // Publish the baseline-only envelope BEFORE flipping the verdict
+  // pill — Playwright's regression suite reads `__VIVARIUM_RESULT__`
+  // the moment `data-verdict` leaves `pending`.
+  const initialEnvelope = buildEnvelope();
+  if (initialEnvelope) setResult(initialEnvelope);
+
+  // Top-level verdict pill mirrors baseline — preserves the
+  // single-verdict Contract v1 surface for downstream consumers.
+  setVerdict(baselineCapture.verdict, baselineCapture.message);
 
   metaEl.textContent =
-    `python-dateutil ${baselineResult.dateutil_version} on Python ` +
-    `${baselineResult.python_version} via Pyodide v${version}.`;
-  outputEl.textContent = baseline.stdout;
-  setVerdict(baseline.verdict, baseline.message);
+    `Baseline python-dateutil ${baselineParsed?.dateutil_version ?? '?'} on Python ` +
+    `${baselineParsed?.python_version ?? '?'} via Pyodide v${version}.`;
 
-  const finishedAt = new Date();
-  const envelope: VivariumResultV1 = {
-    contract: 'v1',
-    bug: {
-      project: 'dateutil',
-      issue: 1478,
-      upstream_url: 'https://github.com/dateutil/dateutil/issues/1478',
-    },
-    runtime: {
-      name: 'pyodide',
-      version,
-      extras: {
-        python: baselineResult.python_version,
-        'python-dateutil': baselineResult.dateutil_version,
-      },
-    },
-    result: {
-      cases: baselineResult.cases,
-      inverted_count: baselineResult.inverted_count,
-      case_count: baselineResult.case_count,
-      reproduced: baselineResult.reproduced,
-    },
-    timing: {
-      started_at: startedAt.toISOString(),
-      finished_at: finishedAt.toISOString(),
-      duration_ms: finishedAt.getTime() - startedAt.getTime(),
-    },
-  };
-  setResult(envelope);
+  // Fix-candidate variant: committed wheel.
+  outputFixEl.textContent = 'Fetching wheel manifest…';
+  let manifestRes: Response | null = null;
+  try {
+    manifestRes = await fetch('./wheels/manifest.json', { cache: 'no-store' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    outputFixEl.textContent = `Could not fetch wheel manifest: ${message}`;
+  }
+
+  if (manifestRes && manifestRes.ok) {
+    manifest = (await manifestRes.json()) as WheelManifest;
+    const wheelUrl = new URL(
+      `./wheels/${manifest.filename}`,
+      window.location.href,
+    ).toString();
+    outputFixEl.textContent =
+      `Installing ${manifest.filename} (${manifest.version})…\n` +
+      `from ${manifest.source.url}@${manifest.source.ref}` +
+      (manifest.source.subdirectory
+        ? ` (subdir: ${manifest.source.subdirectory})`
+        : '');
+    try {
+      await reinstallDateutil(runtime, wheelUrl);
+      fixCapture = await captureRun(runtime, REPRO_CODE);
+      try {
+        fixParsed = JSON.parse(fixCapture.stdout) as ReproOutput;
+      } catch {
+        fixParsed = null;
+      }
+      outputFixEl.textContent = fixCapture.stdout;
+    } catch (err) {
+      const errAny = err as { stack?: string; message?: string } | null;
+      const message =
+        (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
+      outputFixEl.textContent = `Fix-candidate install/run failed: ${message}`;
+    }
+  } else if (manifestRes && !manifestRes.ok) {
+    outputFixEl.textContent = `Wheel manifest unavailable (HTTP ${manifestRes.status}).`;
+  }
+
+  // Restore baseline python-dateutil so the visitor-facing runner
+  // (Edit + Run) operates against the buggy build — the runner's
+  // documented mental model is "test your script change against the
+  // same broken interpreter the recipe loaded". Without this,
+  // runner.runFix would execute against the fix-candidate dateutil,
+  // which is semantically surprising for visitors paste-editing the
+  // script.
+  try {
+    await reinstallDateutil(runtime, BASELINE_SPEC);
+  } catch {
+    console.warn(
+      'dateutil-1478: failed to restore baseline for the runner; runner.runFix will run against the fix-candidate.',
+    );
+  }
+
+  // ---- Contract v1 envelope (final) ---------------------------------
+  // Re-publish the envelope now that the fix-candidate variant has
+  // also captured (or definitively failed). `result` keeps the
+  // historical baseline-only fields (`cases`, `inverted_count`,
+  // `reproduced`) so consumers reading
+  // `__VIVARIUM_RESULT__.result.reproduced` continue to work, and the
+  // additive `baseline` / `fix_candidate` sub-objects describe each
+  // variant separately. Additive change — no `contract` version bump.
+  const finalEnvelope = buildEnvelope();
+  if (finalEnvelope) setResult(finalEnvelope);
 
   enableRunner({
     slug: 'dateutil-1478',
@@ -223,7 +387,7 @@ await micropip.install("python-dateutil==2.9.0.post0")
 } catch (err: unknown) {
   console.error(err);
   const errAny = err as { stack?: string; message?: string } | null;
-  outputEl.textContent =
+  outputBaselineEl.textContent =
     (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
   if (globalThis.__VIVARIUM_VERDICT__ !== 'unreproduced') {
     setVerdict(


### PR DESCRIPTION

The page at /repro/dateutil/1478/ shipped with the fix-candidate
registration (`fix-candidate.json` + CI-built wheel under `./wheels/`)
but the recipe page itself had only a single `#output` element and no
JS to install the wheel and run the fix-candidate variant. The
"Fix-candidate output" pane therefore never appeared on the live page.

Adopt the sympy-29413 dual-variant pattern (silent wrong-result +
main-thread Pyodide + `enableRunner` coexistence):

- `index.html`: output column → `vh-output-multi` with baseline +
  fix-candidate `<pre>` panes and `data-variant` headers, plus a
  "Fix candidate branch" header chip and a drawer paragraph.
- `repro.ts`: add a `reinstallDateutil()` helper (uninstall +
  `del sys.modules[dateutil.*]` + reinstall to defeat Pyodide's
  import cache), fetch `./wheels/manifest.json`, run the fix-candidate
  variant in the same Pyodide instance, restore the baseline package
  for `enableRunner`, and publish a Contract v1 envelope with
  additive `result.baseline` / `result.fix_candidate` sub-objects.
  Top-level `cases` / `inverted_count` / `reproduced` keep mirroring
  the baseline so single-verdict consumers do not need to branch.
- `README.md`: extend the Files table with `fix-candidate.json` /
  `wheels/` / `roundtrip.json` rows and update the envelope
  description to mention the new sub-objects.

Also close the documentation gap that allowed the regression to ship:
SKILL.md Stage 6 (Layer 1) now spells out — between `fix-candidate.json`
write and the Stage-4 amend — that the recipe page itself must carry
the dual-variant wiring, referencing sympy-29413 / lark-1585 as
copy-from templates and noting that the wheel pipeline only builds the
artefact.
