### PR TITLE
feat(wasm): share dual-variant helpers + CI guard against missing wiring

### DIFF
--- a/src/layer1_wasm/_shared/README.md
+++ b/src/layer1_wasm/_shared/README.md
@@ -27,6 +27,9 @@ and runner — `bun install`, `bun run build`, `bun run typecheck`.
 | --- | --- | --- |
 | `verdict.ts` | `verdict.js` | `setVerdict()` / `setResult()` + `VivariumResultV1` interface. |
 | `loader.ts` | `loader.js` | `loadVivariumPyodide()` — Pyodide bootstrap with version pin and package preload. |
+| `fix-candidate.ts` | `fix-candidate.js` | `reinstallPyodidePackage()` / `fetchWheelManifest()` / `resolveFixCandidateSpec()` + `WheelManifest` interface — shared plumbing for recipes that render baseline + fix-candidate side-by-side on a single Pyodide instance (sympy-29413, dateutil-1478). Worker-based recipes (lark-1585) keep their own per-variant flow. |
+| `runner.ts` | `runner.js` | `enableRunner()` — Edit/Run/Reset buttons that hand the (possibly edited) source back to the recipe's `captureRun`. |
+| `path_a.ts` | `path_a.js` | `PathACapturedRun` type + the Path A "fix URL?" UI panel. |
 | `_test/repro.ts` | `_test/repro.js` | Smoke test validating the contract-v1 surface (no Pyodide). |
 | `style.css` | — | Shared CSS for the gallery's visual presentation. |
 | `_test/index.html` | — | Smoke test entrypoint. References `./repro.js`. |

--- a/src/layer1_wasm/_shared/fix-candidate.ts
+++ b/src/layer1_wasm/_shared/fix-candidate.ts
@@ -1,0 +1,194 @@
+// Shared helpers for Layer 1 recipes that render a baseline + fix-candidate
+// side-by-side comparison on a single Pyodide instance.
+//
+// Two pieces are duplicated across every "main-thread Pyodide" recipe
+// that adopts the dual-variant pattern (sympy-29413, dateutil-1478,
+// future analogues):
+//
+//   1. `reinstallPyodidePackage` — `micropip.uninstall` followed by
+//      a `sys.modules` purge (to defeat Pyodide's import cache) and
+//      then `micropip.install` of either the baseline pin or the
+//      `./wheels/<filename>` fix-candidate wheel. The Python template
+//      is invariant across recipes; only the pip package name, the
+//      Python module root, and the install spec differ.
+//
+//   2. `fetchWheelManifest` — the small dance that fetches
+//      `./wheels/manifest.json` next to the recipe page, validates the
+//      shape, and resolves the wheel URL the runtime is going to pass
+//      to `micropip.install`. CI builds the wheel via
+//      `scripts/build-layer1-wheels.sh` from each recipe's tracked
+//      `fix-candidate.json`; the manifest is the contract between
+//      that build step and the in-page loader.
+//
+// Worker-based dual-variant recipes (lark-1585) bypass this helper —
+// they spawn an independent Pyodide instance per variant and do not
+// need the uninstall/reinstall dance, so the worker pattern lives in
+// the recipe itself rather than here.
+//
+// The validator under `scripts/validate-fix-candidates.ts` enforces
+// that any recipe with `fix-candidate.json` also ships the matching
+// HTML + JS wiring (vh-output-multi pane, `#output-fix` element,
+// `./wheels/manifest.json` reference). That guard is independent of
+// whether the recipe uses this helper — both worker-pattern and
+// main-thread-pattern recipes pass the same validator.
+
+/**
+ * The minimal slice of the Pyodide runtime this helper depends on.
+ * Recipes typically declare a richer interface locally (with a
+ * `toJs()`-capable proxy return type for `runPythonAsync`); this is
+ * just the surface this module needs.
+ */
+export interface PyodideRuntime {
+  runPythonAsync(code: string): Promise<unknown>;
+}
+
+/**
+ * Shape of `wheels/manifest.json` produced by
+ * `scripts/build-layer1-wheels.sh`. Mirrors the structure that
+ * shell script writes via `jq -n` — keep the two in sync.
+ */
+export interface WheelManifest {
+  schema_version: number;
+  package: string;
+  filename: string;
+  version: string;
+  purpose?: string;
+  source: {
+    type: string;
+    url: string;
+    ref: string;
+    commit?: string;
+    spec?: string;
+    subdirectory?: string;
+  };
+  upstream_pr?: string;
+  fetched_at?: string;
+}
+
+/**
+ * Reinstall a Python package inside a running Pyodide instance,
+ * defeating the in-process import cache so the next `import` resolves
+ * the freshly-installed version.
+ *
+ * - `pipPackageName` is what `micropip` knows the project as
+ *   (e.g. `"python-dateutil"`, `"sympy"`).
+ * - `pythonRootModule` is the top-level package name as Python sees
+ *   it after import (e.g. `"dateutil"`, `"sympy"`). Often equal to
+ *   `pipPackageName`, but not always — `python-dateutil` exposes
+ *   `dateutil`.
+ * - `installSpec` is the argument handed to `micropip.install(...)`
+ *   — a PyPI pin like `"sympy==1.14.0"` or an absolute wheel URL like
+ *   `"http://localhost:.../wheels/<file>.whl"`.
+ *
+ * The function is best-effort on uninstall: a project that was never
+ * installed in this session raises a `ValueError` inside micropip,
+ * which we swallow so the helper is also callable as a plain "install"
+ * on the first variant.
+ */
+export async function reinstallPyodidePackage(
+  runtime: PyodideRuntime,
+  args: {
+    pipPackageName: string;
+    pythonRootModule: string;
+    installSpec: string;
+  },
+): Promise<void> {
+  await runtime.runPythonAsync(`
+import micropip, sys
+try:
+    await micropip.uninstall(${JSON.stringify(args.pipPackageName)})
+except Exception:
+    pass
+for _name in [n for n in list(sys.modules) if n == ${JSON.stringify(args.pythonRootModule)} or n.startswith(${JSON.stringify(`${args.pythonRootModule}.`)})]:
+    del sys.modules[_name]
+await micropip.install(${JSON.stringify(args.installSpec)})
+`);
+}
+
+export type FetchWheelManifestOutcome =
+  | { ok: true; manifest: WheelManifest; wheelUrl: string }
+  | { ok: false; reason: string };
+
+/**
+ * Fetch `./wheels/manifest.json` next to the recipe page, parse it,
+ * and resolve the absolute URL of the wheel file the recipe should
+ * hand to `micropip.install`.
+ *
+ * The wheel itself lives at `./wheels/<manifest.filename>` (sibling
+ * of the manifest). Returning the resolved URL here keeps the URL
+ * construction logic in one place so future tweaks (e.g. a CDN
+ * prefix) only need to land here.
+ *
+ * Returns a tagged result instead of throwing: any failure (HTTP
+ * error, network drop, JSON parse error) yields `{ ok: false }` with
+ * a human-readable reason the recipe can surface in the
+ * fix-candidate pane. The recipe stays responsible for verdict
+ * polarity — the helper never flips it.
+ */
+export async function fetchWheelManifest(opts?: {
+  /** Override the default `./wheels/manifest.json` location. Useful in tests. */
+  manifestUrl?: string;
+}): Promise<FetchWheelManifestOutcome> {
+  const manifestUrl = opts?.manifestUrl ?? './wheels/manifest.json';
+  let res: Response;
+  try {
+    res = await fetch(manifestUrl, { cache: 'no-store' });
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `could not fetch wheel manifest: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+  if (!res.ok) {
+    return {
+      ok: false,
+      reason: `wheel manifest unavailable (HTTP ${res.status}).`,
+    };
+  }
+  let manifest: WheelManifest;
+  try {
+    manifest = (await res.json()) as WheelManifest;
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `wheel manifest is not valid JSON: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+  if (!manifest.filename) {
+    return {
+      ok: false,
+      reason: 'wheel manifest is missing `filename` field.',
+    };
+  }
+  const wheelUrl = new URL(
+    `./wheels/${manifest.filename}`,
+    window.location.href,
+  ).toString();
+  return { ok: true, manifest, wheelUrl };
+}
+
+/**
+ * Resolve the spec string that should appear in
+ * `result.fix_candidate.spec` of the Contract v1 envelope.
+ *
+ * Prefers `manifest.source.spec` (the exact `pip` spec the wheel
+ * build resolved); falls back to reconstructing
+ * `<package> @ git+<url>@<ref>[#subdirectory=<dir>]` so the spec is
+ * never `undefined`. The fallback matches the shape
+ * `scripts/build-layer1-wheels.sh` writes, so the two paths are
+ * indistinguishable to envelope consumers.
+ */
+export function resolveFixCandidateSpec(
+  manifest: WheelManifest,
+  pipPackageName: string,
+): string {
+  if (manifest.source.spec) return manifest.source.spec;
+  const base = `${pipPackageName} @ git+${manifest.source.url}@${manifest.source.ref}`;
+  return manifest.source.subdirectory
+    ? `${base}#subdirectory=${manifest.source.subdirectory}`
+    : base;
+}

--- a/src/layer1_wasm/dateutil-1478/repro.ts
+++ b/src/layer1_wasm/dateutil-1478/repro.ts
@@ -29,6 +29,12 @@
 // wheel under `./wheels/` built from the fork+branch
 // `JamBalaya56562/dateutil@fix-1478-utc-gmt-offset-sign`.
 
+import {
+  fetchWheelManifest,
+  reinstallPyodidePackage,
+  resolveFixCandidateSpec,
+  type WheelManifest,
+} from '../_shared/fix-candidate.js';
 import { loadVivariumPyodide } from '../_shared/loader.js';
 import type { PathACapturedRun } from '../_shared/path_a.js';
 import { enableRunner } from '../_shared/runner.js';
@@ -94,23 +100,6 @@ interface PyodideRuntime {
     toJs(opts: { dict_converter: typeof Object.fromEntries }): ReproOutput;
     destroy?(): void;
   }>;
-}
-
-interface WheelManifest {
-  schema_version: number;
-  package: string;
-  filename: string;
-  version: string;
-  source: {
-    type: string;
-    url: string;
-    ref: string;
-    commit?: string;
-    spec?: string;
-    subdirectory?: string;
-  };
-  upstream_pr?: string;
-  fetched_at?: string;
 }
 
 const BASELINE_SPEC = 'python-dateutil==2.9.0.post0';
@@ -180,26 +169,15 @@ async function captureRun(
   }
 }
 
-// Drop the in-memory dateutil module tree so the next `import
-// dateutil` resolves the freshly-installed wheel rather than the
-// previously-loaded version. Pyodide caches imports in
-// `sys.modules`; `del` is the only reliable way to force a
-// re-resolution after `micropip.uninstall`.
-async function reinstallDateutil(
+const reinstallDateutil = (
   runtime: PyodideRuntime,
   installSpec: string,
-): Promise<void> {
-  await runtime.runPythonAsync(`
-import micropip, sys
-try:
-    await micropip.uninstall("python-dateutil")
-except Exception:
-    pass
-for _name in [n for n in list(sys.modules) if n == "dateutil" or n.startswith("dateutil.")]:
-    del sys.modules[_name]
-await micropip.install(${JSON.stringify(installSpec)})
-`);
-}
+): Promise<void> =>
+  reinstallPyodidePackage(runtime, {
+    pipPackageName: 'python-dateutil',
+    pythonRootModule: 'dateutil',
+    installSpec,
+  });
 
 const startedAt = new Date();
 
@@ -274,12 +252,7 @@ try {
         fix_candidate:
           fixParsed && fixCapture && manifest
             ? {
-                spec:
-                  manifest.source.spec ??
-                  `python-dateutil @ git+${manifest.source.url}@${manifest.source.ref}` +
-                    (manifest.source.subdirectory
-                      ? `#subdirectory=${manifest.source.subdirectory}`
-                      : ''),
+                spec: resolveFixCandidateSpec(manifest, 'python-dateutil'),
                 verdict: fixCapture.verdict,
                 dateutil_version: fixParsed.dateutil_version,
                 cases: fixParsed.cases,
@@ -314,20 +287,10 @@ try {
 
   // Fix-candidate variant: committed wheel.
   outputFixEl.textContent = 'Fetching wheel manifest…';
-  let manifestRes: Response | null = null;
-  try {
-    manifestRes = await fetch('./wheels/manifest.json', { cache: 'no-store' });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    outputFixEl.textContent = `Could not fetch wheel manifest: ${message}`;
-  }
+  const manifestResult = await fetchWheelManifest();
 
-  if (manifestRes && manifestRes.ok) {
-    manifest = (await manifestRes.json()) as WheelManifest;
-    const wheelUrl = new URL(
-      `./wheels/${manifest.filename}`,
-      window.location.href,
-    ).toString();
+  if (manifestResult.ok) {
+    manifest = manifestResult.manifest;
     outputFixEl.textContent =
       `Installing ${manifest.filename} (${manifest.version})…\n` +
       `from ${manifest.source.url}@${manifest.source.ref}` +
@@ -335,7 +298,7 @@ try {
         ? ` (subdir: ${manifest.source.subdirectory})`
         : '');
     try {
-      await reinstallDateutil(runtime, wheelUrl);
+      await reinstallDateutil(runtime, manifestResult.wheelUrl);
       fixCapture = await captureRun(runtime, REPRO_CODE);
       try {
         fixParsed = JSON.parse(fixCapture.stdout) as ReproOutput;
@@ -349,8 +312,8 @@ try {
         (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
       outputFixEl.textContent = `Fix-candidate install/run failed: ${message}`;
     }
-  } else if (manifestRes && !manifestRes.ok) {
-    outputFixEl.textContent = `Wheel manifest unavailable (HTTP ${manifestRes.status}).`;
+  } else {
+    outputFixEl.textContent = manifestResult.reason;
   }
 
   // Restore baseline python-dateutil so the visitor-facing runner

--- a/src/layer1_wasm/package.json
+++ b/src/layer1_wasm/package.json
@@ -5,7 +5,8 @@
   "description": "Layer 1 (browser-native WASM) reproduction sources for Vivarium. TypeScript sources transpile 1:1 to side-by-side .js files served as ES modules. Playwright tests assert each reproduction's contract-v1 verdict on every push and on a weekly schedule.",
   "type": "module",
   "scripts": {
-    "build": "bun run scripts/highlight-repros.ts && tsc -p tsconfig.json",
+    "build": "bun run scripts/validate-fix-candidates.ts && bun run scripts/highlight-repros.ts && tsc -p tsconfig.json",
+    "validate": "bun run scripts/validate-fix-candidates.ts",
     "highlight": "bun run scripts/highlight-repros.ts",
     "watch": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tests/tsconfig.json",

--- a/src/layer1_wasm/scripts/validate-fix-candidates.ts
+++ b/src/layer1_wasm/scripts/validate-fix-candidates.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env bun
+//
+// CI guard: every Layer 1 recipe that ships a `fix-candidate.json`
+// must also carry the matching baseline + fix-candidate side-by-side
+// rendering on its recipe page.
+//
+// Background: `prepare_fix_candidate` (and its CI wheel-build pipeline
+// in `scripts/build-layer1-wheels.sh`) builds the wheel artefact, but
+// the recipe page's HTML / JS wiring is per-recipe. Without that
+// wiring, the live page renders only the baseline pane and visitors
+// never see the fixed verdict — the regression that motivated PR #280.
+// This script catches that gap mechanically before the recipe ships.
+//
+// For each `src/layer1_wasm/<slug>/fix-candidate.json` it asserts:
+//
+//   1. `<slug>/index.html` contains `vh-output-multi` (the
+//      multi-pane output column class).
+//   2. `<slug>/index.html` contains `id="output-fix"` (the
+//      fix-candidate `<pre>` the JS writes results into).
+//   3. `<slug>/repro.ts` references the wheel manifest — either
+//      directly (`./wheels/manifest.json`) or via the shared
+//      helper (`fetchWheelManifest`). The helper internally points
+//      at the same path, so accepting either keeps lark-1585's
+//      worker pattern compatible.
+//
+// Exits 1 with a per-recipe failure list on any miss, so
+// `bun run build` (and therefore `mise run repro:build:ts`, and
+// therefore CI's `repro-regression.yml`) fails fast.
+//
+// Update path: when adopting a new dual-variant pattern that does not
+// match (1)–(3), extend the checks here in the same PR — never silence
+// the validator with a per-recipe carve-out. The point is to keep
+// "fix-candidate.json exists" and "the page actually renders it"
+// fused at build time.
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const LAYER1_DIR = dirname(SCRIPT_DIR);
+const REPO_ROOT = dirname(dirname(LAYER1_DIR));
+
+// Mirror the SKIP_DIRS / `_`-prefix convention from
+// `highlight-repros.ts` so non-recipe directories (node_modules,
+// scripts, tests, _shared) are not treated as recipes.
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'scripts',
+  'tests',
+  'playwright-report',
+  'test-results',
+  'blob-report',
+]);
+
+function looksLikeRecipe(name: string): boolean {
+  if (name.startsWith('_') || name.startsWith('.')) return false;
+  if (SKIP_DIRS.has(name)) return false;
+  return true;
+}
+
+interface CheckFailure {
+  slug: string;
+  /** Repo-root-relative path that failed the check. */
+  path: string;
+  /** Human-readable description of what is missing. */
+  reason: string;
+  /** What to do about it. One sentence, includes the reference recipe. */
+  remedy: string;
+}
+
+const failures: CheckFailure[] = [];
+
+function check(
+  slug: string,
+  path: string,
+  body: string,
+  needle: string | RegExp,
+  reason: string,
+  remedy: string,
+): void {
+  const matched =
+    typeof needle === 'string' ? body.includes(needle) : needle.test(body);
+  if (!matched) {
+    failures.push({
+      slug,
+      path: relative(REPO_ROOT, path),
+      reason,
+      remedy,
+    });
+  }
+}
+
+const slugs = readdirSync(LAYER1_DIR, { withFileTypes: true })
+  .filter((e) => e.isDirectory() && looksLikeRecipe(e.name))
+  .map((e) => e.name)
+  .sort();
+
+let recipesChecked = 0;
+for (const slug of slugs) {
+  const recipeDir = join(LAYER1_DIR, slug);
+  const fixCandidatePath = join(recipeDir, 'fix-candidate.json');
+  if (!existsSync(fixCandidatePath)) continue;
+  recipesChecked++;
+
+  const indexPath = join(recipeDir, 'index.html');
+  const reproTsPath = join(recipeDir, 'repro.ts');
+
+  if (!existsSync(indexPath)) {
+    failures.push({
+      slug,
+      path: relative(REPO_ROOT, indexPath),
+      reason: 'index.html is missing — every Layer 1 recipe must ship one.',
+      remedy:
+        'Author the recipe page; see src/layer1_wasm/sympy-29413/ or src/layer1_wasm/lark-1585/ for layout templates.',
+    });
+  } else {
+    const indexBody = readFileSync(indexPath, 'utf-8');
+    check(
+      slug,
+      indexPath,
+      indexBody,
+      'vh-output-multi',
+      'output column is missing the `vh-output-multi` class — the baseline + fix-candidate dual-pane layout is not wired up.',
+      'Replace the single `<pre id="output">` with the dual-pane scaffold from src/layer1_wasm/sympy-29413/index.html (two `<header data-variant>` headers + #output + #output-fix).',
+    );
+    check(
+      slug,
+      indexPath,
+      indexBody,
+      'id="output-fix"',
+      '`<pre id="output-fix">` is missing — the recipe JS has nowhere to write the fix-candidate output.',
+      'Add the fix-candidate pane: see src/layer1_wasm/sympy-29413/index.html for the exact markup.',
+    );
+  }
+
+  if (!existsSync(reproTsPath)) {
+    failures.push({
+      slug,
+      path: relative(REPO_ROOT, reproTsPath),
+      reason: 'repro.ts is missing — every Layer 1 recipe must ship one.',
+      remedy:
+        'Author the recipe driver; see src/layer1_wasm/sympy-29413/repro.ts for the dual-variant template.',
+    });
+  } else {
+    const reproBody = readFileSync(reproTsPath, 'utf-8');
+    const referencesManifest =
+      reproBody.includes('./wheels/manifest.json') ||
+      reproBody.includes('fetchWheelManifest');
+    if (!referencesManifest) {
+      failures.push({
+        slug,
+        path: relative(REPO_ROOT, reproTsPath),
+        reason:
+          'repro.ts neither calls `fetchWheelManifest` nor fetches `./wheels/manifest.json` — the fix-candidate wheel is never installed.',
+        remedy:
+          'Adopt the shared helper from `_shared/fix-candidate.ts` (sympy-29413, dateutil-1478) or the inline fetch pattern (lark-1585).',
+      });
+    }
+  }
+}
+
+if (failures.length === 0) {
+  console.log(
+    `[validate-fix-candidates] OK — ${recipesChecked} recipe(s) with fix-candidate.json pass the dual-variant wiring check.`,
+  );
+  process.exit(0);
+}
+
+console.error(
+  `[validate-fix-candidates] FAILED — ${failures.length} dual-variant wiring issue(s) across ${recipesChecked} recipe(s) with fix-candidate.json:\n`,
+);
+for (const f of failures) {
+  console.error(`  ✗ ${f.slug} — ${f.path}`);
+  console.error(`      ${f.reason}`);
+  console.error(`      → ${f.remedy}\n`);
+}
+console.error(
+  `Why this matters: the CI wheel-build pipeline ` +
+    `(scripts/build-layer1-wheels.sh) only builds the artefact; the ` +
+    `recipe page's HTML / JS wiring is per-recipe. Without the wiring ` +
+    `above, the live page renders only the baseline pane and visitors ` +
+    `never see the fixed verdict.\n`,
+);
+process.exit(1);

--- a/src/layer1_wasm/sympy-29413/repro.ts
+++ b/src/layer1_wasm/sympy-29413/repro.ts
@@ -23,6 +23,12 @@
 // side-by-side is a pure-Python wheel under `./wheels/` built from
 // the fork+branch `JamBalaya56562/sympy@claude/fix-sympy-29413-8Lyc6`.
 
+import {
+  fetchWheelManifest,
+  reinstallPyodidePackage,
+  resolveFixCandidateSpec,
+  type WheelManifest,
+} from '../_shared/fix-candidate.js';
 import { loadVivariumPyodide } from '../_shared/loader.js';
 import type { PathACapturedRun } from '../_shared/path_a.js';
 import { enableRunner } from '../_shared/runner.js';
@@ -62,22 +68,7 @@ interface PyodideRuntime {
   }>;
 }
 
-interface WheelManifest {
-  schema_version: number;
-  package: string;
-  filename: string;
-  version: string;
-  source: {
-    type: string;
-    url: string;
-    ref: string;
-    commit?: string;
-    spec?: string;
-    subdirectory?: string;
-  };
-  upstream_pr?: string;
-  fetched_at?: string;
-}
+const BASELINE_SPEC = 'sympy==1.14.0';
 
 const outputBaselineEl = document.getElementById('output');
 const outputFixEl = document.getElementById('output-fix');
@@ -143,26 +134,15 @@ async function captureRun(
   }
 }
 
-// Drop the in-memory sympy module tree so the next `import sympy`
-// resolves the freshly-installed wheel rather than the previously-
-// loaded version. Pyodide caches imports in `sys.modules`; `del` is
-// the only reliable way to force a re-resolution after
-// `micropip.uninstall`.
-async function reinstallSympy(
+const reinstallSympy = (
   runtime: PyodideRuntime,
   installSpec: string,
-): Promise<void> {
-  await runtime.runPythonAsync(`
-import micropip, sys
-try:
-    await micropip.uninstall("sympy")
-except Exception:
-    pass
-for _name in [n for n in list(sys.modules) if n == "sympy" or n.startswith("sympy.")]:
-    del sys.modules[_name]
-await micropip.install(${JSON.stringify(installSpec)})
-`);
-}
+): Promise<void> =>
+  reinstallPyodidePackage(runtime, {
+    pipPackageName: 'sympy',
+    pythonRootModule: 'sympy',
+    installSpec,
+  });
 
 const startedAt = new Date();
 
@@ -180,11 +160,8 @@ try {
   const runtime = pyodide as PyodideRuntime;
 
   // Baseline variant: PyPI sympy==1.14.0.
-  setVerdict('pending', 'Installing sympy==1.14.0 from PyPI…');
-  await runtime.runPythonAsync(`
-import micropip
-await micropip.install("sympy==1.14.0")
-`);
+  setVerdict('pending', `Installing ${BASELINE_SPEC} from PyPI…`);
+  await reinstallSympy(runtime, BASELINE_SPEC);
 
   setVerdict('pending', 'Running reproduction script (baseline)…');
   baselineCapture = await captureRun(runtime, REPRO_CODE);
@@ -227,7 +204,7 @@ await micropip.install("sympy==1.14.0")
         ask_result: baselineParsed.ask_result,
         reproduced: baselineParsed.reproduced,
         baseline: {
-          spec: 'sympy==1.14.0',
+          spec: BASELINE_SPEC,
           verdict: baselineCapture.verdict,
           sympy_version: baselineParsed.sympy_version,
           ask_result: baselineParsed.ask_result,
@@ -236,12 +213,7 @@ await micropip.install("sympy==1.14.0")
         fix_candidate:
           fixParsed && fixCapture && manifest
             ? {
-                spec:
-                  manifest.source.spec ??
-                  `sympy @ git+${manifest.source.url}@${manifest.source.ref}` +
-                    (manifest.source.subdirectory
-                      ? `#subdirectory=${manifest.source.subdirectory}`
-                      : ''),
+                spec: resolveFixCandidateSpec(manifest, 'sympy'),
                 verdict: fixCapture.verdict,
                 sympy_version: fixParsed.sympy_version,
                 ask_result: fixParsed.ask_result,
@@ -274,20 +246,10 @@ await micropip.install("sympy==1.14.0")
 
   // Fix-candidate variant: committed wheel.
   outputFixEl.textContent = 'Fetching wheel manifest…';
-  let manifestRes: Response | null = null;
-  try {
-    manifestRes = await fetch('./wheels/manifest.json', { cache: 'no-store' });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    outputFixEl.textContent = `Could not fetch wheel manifest: ${message}`;
-  }
+  const manifestResult = await fetchWheelManifest();
 
-  if (manifestRes && manifestRes.ok) {
-    manifest = (await manifestRes.json()) as WheelManifest;
-    const wheelUrl = new URL(
-      `./wheels/${manifest.filename}`,
-      window.location.href,
-    ).toString();
+  if (manifestResult.ok) {
+    manifest = manifestResult.manifest;
     outputFixEl.textContent =
       `Installing ${manifest.filename} (${manifest.version})…\n` +
       `from ${manifest.source.url}@${manifest.source.ref}` +
@@ -295,7 +257,7 @@ await micropip.install("sympy==1.14.0")
         ? ` (subdir: ${manifest.source.subdirectory})`
         : '');
     try {
-      await reinstallSympy(runtime, wheelUrl);
+      await reinstallSympy(runtime, manifestResult.wheelUrl);
       fixCapture = await captureRun(runtime, REPRO_CODE);
       try {
         fixParsed = JSON.parse(fixCapture.stdout) as ReproOutput;
@@ -309,8 +271,8 @@ await micropip.install("sympy==1.14.0")
         (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
       outputFixEl.textContent = `Fix-candidate install/run failed: ${message}`;
     }
-  } else if (manifestRes && !manifestRes.ok) {
-    outputFixEl.textContent = `Wheel manifest unavailable (HTTP ${manifestRes.status}).`;
+  } else {
+    outputFixEl.textContent = manifestResult.reason;
   }
 
   // Restore baseline sympy so the visitor-facing runner (Edit + Run)
@@ -320,7 +282,7 @@ await micropip.install("sympy==1.14.0")
   // execute against the fix-candidate sympy, which is semantically
   // surprising for visitors paste-editing the script.
   try {
-    await reinstallSympy(runtime, 'sympy==1.14.0');
+    await reinstallSympy(runtime, BASELINE_SPEC);
   } catch {
     console.warn(
       'sympy-29413: failed to restore baseline for the runner; runner.runFix will run against the fix-candidate.',


### PR DESCRIPTION

Two parts addressing the gap PR #280 closed by hand:

1. Extract `_shared/fix-candidate.ts` with three primitives that
   sympy-29413 + dateutil-1478 were duplicating verbatim:
   - `reinstallPyodidePackage()` — `micropip.uninstall` + `sys.modules`
     purge + `micropip.install`, parametrised by pip package name +
     Python module root.
   - `fetchWheelManifest()` — fetches `./wheels/manifest.json` next to
     the recipe page and resolves the wheel URL. Returns a tagged
     result so recipes can surface graceful errors in the
     fix-candidate pane without flipping the verdict.
   - `resolveFixCandidateSpec()` — assembles the `result.fix_candidate.spec`
     envelope field from `manifest.source.spec` (preferred) or a
     `<package> @ git+<url>@<ref>[#subdirectory=]` fallback.
   Migrate sympy-29413 and dateutil-1478 to the helper — each recipe
   sheds ~80 lines of boilerplate. lark-1585 stays unmigrated on
   purpose: its worker-per-variant pattern is genuinely different
   (timeout/terminate semantics) and doesn't benefit from
   uninstall/reinstall plumbing.

2. Add `scripts/validate-fix-candidates.ts`, wired into
   `bun run build` (and therefore `mise run repro:build:ts` and
   `repro-regression.yml` in CI). It iterates every
   `src/layer1_wasm/<slug>/fix-candidate.json` and asserts the
   matching `index.html` has `vh-output-multi` + `id="output-fix"`,
   and that `repro.ts` references the wheel manifest (either directly
   or via the new `fetchWheelManifest` helper). Mechanical check —
   no judgement, no carve-outs. Catches the exact regression that
   shipped dateutil-1478 with a registered fix-candidate but no
   fix-candidate pane on the live page.

Update `_shared/README.md` to register the new file.
