### PR TITLE
feat(wasm): add layer 1 reproduction for mpmath/mpmath#930

### DIFF
--- a/docs/site/_data/projects.json
+++ b/docs/site/_data/projects.json
@@ -50,6 +50,13 @@
       "homepage": "https://www.sympy.org/",
       "github": "https://github.com/sympy/sympy"
     },
+    "mpmath": {
+      "display_name": "mpmath",
+      "tagline": "Pure-Python arbitrary-precision floating-point arithmetic.",
+      "description": "Precision-loss and wrong-result bugs in mpmath's special-function machinery, captured when mpmath is installed into Pyodide via micropip. The browser page and the host-Python repro.py share the exact same script and the same pinned wheel.",
+      "homepage": "https://mpmath.org/",
+      "github": "https://github.com/mpmath/mpmath"
+    },
     "lark": {
       "display_name": "Lark",
       "tagline": "Pure-Python parsing toolkit (LALR / Earley / CYK).",

--- a/docs/site/public/api/projects.json
+++ b/docs/site/public/api/projects.json
@@ -80,6 +80,19 @@
       "github": "https://github.com/lark-parser/lark"
     },
     {
+      "project": "mpmath",
+      "display_name": "mpmath",
+      "recipe_count": 1,
+      "layers": [
+        1
+      ],
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/mpmath/",
+      "tagline": "Pure-Python arbitrary-precision floating-point arithmetic.",
+      "description": "Precision-loss and wrong-result bugs in mpmath's special-function machinery, captured when mpmath is installed into Pyodide via micropip. The browser page and the host-Python repro.py share the exact same script and the same pinned wheel.",
+      "homepage": "https://mpmath.org/",
+      "github": "https://github.com/mpmath/mpmath"
+    },
+    {
       "project": "node",
       "display_name": "Node.js",
       "recipe_count": 1,

--- a/docs/site/public/api/recipes.json
+++ b/docs/site/public/api/recipes.json
@@ -102,6 +102,38 @@
       }
     },
     {
+      "slug": "mpmath-930",
+      "layer": 1,
+      "project": "mpmath",
+      "issue": 930,
+      "title": "mpmath/mpmath#930",
+      "page_url": "https://aletheia-works.github.io/vivarium/repro/mpmath/930/",
+      "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/mpmath-930",
+      "language": "python",
+      "tags": [
+        "mpmath",
+        "jtheta",
+        "jacobi-theta",
+        "precision",
+        "elliptic-functions"
+      ],
+      "symptom": "silent-precision-loss-at-default-dps",
+      "severity": "wrong-result",
+      "expected_verdict": "reproduced",
+      "expected_runtime": "pyodide",
+      "roundtrip": {
+        "schema_version": 1,
+        "slug": "mpmath-930",
+        "upstream_issue": "https://github.com/mpmath/mpmath/issues/930",
+        "status": "draft",
+        "updated_at": "2026-05-19T00:00:00Z",
+        "notes": [
+          "scaffolded from upstream issue mpmath/mpmath#930 (Jacobi Theta Wrong Output)",
+          "verified locally that mpmath 1.4.1 (latest) still reproduces the bug at default dps=15 — jtheta returns ~1.87e9 magnitude vs the dps=200 reference ~1.5e-57"
+        ]
+      }
+    },
+    {
       "slug": "numpy-28287",
       "layer": 1,
       "project": "numpy",

--- a/src/layer1_wasm/mpmath-930/README.md
+++ b/src/layer1_wasm/mpmath-930/README.md
@@ -1,0 +1,139 @@
+# Reproduction — mpmath/mpmath#930
+
+> Layer 1 reproduction page. Uses the shared
+> [`_shared/`](../_shared/) helpers and TypeScript toolchain, and emits
+> the canonical `vivarium-contract: v1` surface.
+
+## The bug
+
+[mpmath/mpmath#930](https://github.com/mpmath/mpmath/issues/930) —
+At the default precision (`mp.dps=15`),
+`mpmath.jtheta(2, mpc("99","1"), mpc("0.99","0"))` returns roughly
+`-1.73e9 + 7.19e8j`. The correct value (verified at `mp.dps=200`,
+agreeing with Mathematica) is roughly `-1.50e-57 + 1.13e-58j` —
+about 66 orders of magnitude off.
+
+The Jacobi theta function of the second kind sums a series whose
+intermediate terms grow exponentially before cancelling. For
+arguments with large `Im(z)` and `|q|` close to 1, the default
+working precision is too low to track the cancellation, and mpmath
+silently returns the uncancelled partial sum instead of either
+raising or auto-bumping precision.
+
+## Why this bug
+
+- One-line reproduction (a single `mpmath.jtheta` call), zero
+  non-mpmath dependencies beyond the Python stdlib.
+- Verdict is a magnitude threshold (`abs(result) > 1e6`) — a single
+  boolean — so the page emits a mechanically-distinguishable
+  `reproduced` / `unreproduced` value.
+- Reported against mpmath 1.3.0; **still reproduces against mpmath
+  1.4.1** (the latest PyPI release as of 2026-05-19, locally
+  verified). This page pins `mpmath==1.4.1` via micropip so the
+  verdict flips only when an upstream fix lands.
+- Pure mpmath — no plotting, no FFI, no filesystem. Nothing in the
+  repro path touches a browser-restricted surface.
+
+## Files
+
+| File             | Role                                                              |
+| ---------------- | ----------------------------------------------------------------- |
+| `index.html`     | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
+| `repro.ts`       | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `repro.js`       | Generated; gitignored. Loaded by `index.html` at runtime.         |
+| `repro.py`       | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. See "Native verification" below. |
+| `recipe.json`    | Per-recipe metadata (gallery facets, regression-suite expectations). |
+| `roundtrip.json` | Tracked workflow state (round-trip schema_version 1). Updated as the recipe moves through verify → Vivarium PR → fork+fix → upstream PR. |
+
+Shared visual presentation lives in [`../_shared/style.css`](../_shared/style.css);
+this directory does not carry its own copy.
+
+## Verdict contract — `vivarium-contract: v1`
+
+The page conforms to the contract canonicalised in
+[`../_shared/verdict.ts`](../_shared/verdict.ts):
+
+- `<meta name="vivarium-contract" content="v1">` declared in `<head>`.
+- `document.querySelector('#verdict').dataset.verdict` ∈
+  `{"pending", "reproduced", "unreproduced"}`.
+- `globalThis.__VIVARIUM_VERDICT__` — mirror of the DOM verdict.
+- `globalThis.__VIVARIUM_RESULT__` — a `VivariumResultV1` envelope:
+  `{ contract: "v1", bug: { project: "mpmath", issue: 930, upstream_url },
+  runtime: { name: "pyodide", version, extras: { python, mpmath } },
+  result: { mp_dps, result_real, result_imag, result_abs, reproduced }, timing }`.
+- Visible verdict text starts with `bug reproduced` or
+  `bug not reproduced`.
+
+A `reproduced` verdict means **the bug reproduced** (the magnitude
+at default precision exceeded `1e6`, indicating mpmath returned the
+uncancelled partial sum). An `unreproduced` verdict means either
+the bug was fixed in the mpmath wheel micropip currently resolves,
+or the runtime itself errored before producing a result.
+
+## Running locally — in-browser
+
+```bash
+# 1. From src/layer1_wasm/, build the TypeScript sources once.
+cd src/layer1_wasm
+bun install        # one-time per machine / lockfile change
+bun run build      # emits repro.js next to repro.ts (gitignored)
+
+# 2. Serve the parent directory so ../_shared/ resolves at runtime.
+python -m http.server -d . 8769
+# then open http://localhost:8769/mpmath-930/
+```
+
+Pyodide does not require COOP/COEP headers for this page (no
+`SharedArrayBuffer`, no threading), so a plain server is enough.
+
+## Native verification — same reproduction under a real CPython + mpmath
+
+The companion `repro.py` script reproduces the bug without any
+WASM layer, so a contributor can confirm the gallery page is
+catching a *real* upstream behaviour rather than a Pyodide /
+micropip quirk. PEP 723 inline metadata pins **`mpmath==1.4.1`**
+and the `mise.toml` at the repo root pins Python to 3.13:
+
+```bash
+# One-time per machine / mise.toml change.
+mise install
+
+# Reproduces the bug; exits 0 on `reproduced`. uv reads the inline
+# metadata, builds an ephemeral venv, and runs the script.
+mise exec uv -- uv run src/layer1_wasm/mpmath-930/repro.py
+
+# Expected output (mpmath 1.4.1):
+# {
+#   "mpmath_version": "1.4.1",
+#   "python_version": "3.13.x",
+#   "mp_dps": 15,
+#   "result_real": -1727079129.2142,
+#   "result_imag": 719261908.645394,
+#   "result_abs": 1870866112.7390957,
+#   "expected_abs_at_dps200": 1.5e-57,
+#   "reproduced": true
+# }
+# verdict=reproduced — jtheta(2, 99+1j, 0.99) returned magnitude 1.871e+09 at dps=15, expected ~1.5e-57.
+```
+
+## Round-trip state
+
+`roundtrip.json` tracks the recipe's progress through the round-
+trip loop. Stages reflect:
+
+- `status: "draft"` — recipe just scaffolded.
+- `status: "verifying"` — `verdicts.unfixed` captured.
+- `status: "verified"` — both verdicts captured, the fix actually
+  flips the page.
+- `status: "upstream_open"` — upstream draft PR opened.
+- `status: "merged"` — upstream merged. (Terminal.)
+- `status: "blocked"` — any stage failure; reason in `notes[]`.
+
+## Deployment
+
+Published to GitHub Pages at
+`https://aletheia-works.github.io/vivarium/repro/mpmath/930/` by
+the `deploy-docs` workflow. The workflow runs `bun install` +
+`bun run build` in `src/layer1_wasm/` first so the compiled
+`repro.js` exists when the bundling step copies the directory
+into the Pages artefact.

--- a/src/layer1_wasm/mpmath-930/index.html
+++ b/src/layer1_wasm/mpmath-930/index.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="vivarium-contract" content="v1" />
+    <title>Vivarium · Reproducing mpmath/mpmath#930</title>
+    <!-- vivarium-chrome-injected -->
+    <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.asm.wasm" as="fetch" type="application/wasm" crossorigin />
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/python_stdlib.zip" as="fetch" crossorigin />
+    <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide-lock.json" as="fetch" type="application/json" crossorigin />
+    <!-- Warm the TLS/HTTP3 handshake to jsDelivr in parallel with HTML parse. -->
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <!-- Keep the version below in sync with DEFAULT_PYODIDE_VERSION in
+         ../_shared/loader.ts. -->
+    <link
+      rel="modulepreload"
+      href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.mjs"
+      crossorigin
+    />
+    <link rel="stylesheet" href="../_shared/style.css" />
+    <template id="bug-context">
+      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <div class="vh-drawer__body" id="vh-drawer-body">
+        <p>
+          At the default precision (<code>mp.dps=15</code>),
+          <code>mpmath.jtheta(2, 99+1j, 0.99)</code> returns a value
+          of magnitude near <strong>1.87×10<sup>9</sup></strong>. The
+          correct value (verified at <code>mp.dps=200</code>, agreeing
+          with Mathematica) is near
+          <strong>1.50×10<sup>-57</sup></strong> — the buggy answer
+          is off by about <em>66 orders of magnitude</em>.
+        </p>
+        <p>
+          The Jacobi theta function of the second kind sums a series
+          whose terms grow exponentially before cancelling. For
+          arguments with large <code>Im(z)</code> and
+          <code>|q|</code> close to 1, default precision is too low
+          to track the cancellation, and mpmath silently returns the
+          uncancelled partial sum instead of warning.
+        </p>
+        <p>
+          The script on this page evaluates the call at default
+          precision and reports the magnitude. If the magnitude is
+          larger than <code>1e6</code>, the bug reproduces; if it
+          falls back to the correct ~<code>10<sup>-57</sup></code>
+          range, the upstream regime has been fixed.
+        </p>
+        <p>
+          The full discussion (upstream history, fix progress) lives
+          in the GitHub issue thread linked below.
+        </p>
+      </div>
+      <hr class="vh-drawer__divider" />
+      <div class="vh-drawer__meta-grid">
+        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-val">mpmath/mpmath</span>
+        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-val">#930</span>
+        <span class="vh-drawer__meta-key">Layer</span>
+        <span class="vh-drawer__meta-val">L1 · WASM</span>
+        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-val">Pyodide v0.29.3 + mpmath 1.4.1 (micropip)</span>
+      </div>
+    </template>
+  </head>
+  <body>
+    <main class="vh-main">
+      <header class="vh-main__header">
+        <div class="vh-main__header-text">
+          <p class="kicker">L1 · Pyodide</p>
+          <h1>Reproducing <a href="https://github.com/mpmath/mpmath/issues/930" target="_blank" rel="noreferrer">mpmath/mpmath#930</a></h1>
+          <div class="vh-main__header-actions">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+              Bug context
+            </button>
+          </div>
+        </div>
+        <div class="vh-main__header-aside">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+            Loading Pyodide runtime…
+          </div>
+          <p class="meta" id="meta"></p>
+        </div>
+      </header>
+
+      <div class="vh-main__cols">
+        <section class="vh-main__col vh-main__col--script">
+          <h2>Reproduction script</h2>
+          <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
+<span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> mpmath</span></span>
+<span class="line"><span style="color:#F97583">from</span><span style="color:#E1E4E8"> mpmath </span><span style="color:#F97583">import</span><span style="color:#E1E4E8"> mpc</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">result_value </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> mpmath.jtheta(</span><span style="color:#79B8FF">2</span><span style="color:#E1E4E8">, mpc(</span><span style="color:#9ECBFF">'99'</span><span style="color:#E1E4E8">, </span><span style="color:#9ECBFF">'1'</span><span style="color:#E1E4E8">), mpc(</span><span style="color:#9ECBFF">'0.99'</span><span style="color:#E1E4E8">, </span><span style="color:#9ECBFF">'0'</span><span style="color:#E1E4E8">))</span></span>
+<span class="line"><span style="color:#E1E4E8">real </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> float</span><span style="color:#E1E4E8">(mpmath.re(result_value))</span></span>
+<span class="line"><span style="color:#E1E4E8">imag </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> float</span><span style="color:#E1E4E8">(mpmath.im(result_value))</span></span>
+<span class="line"><span style="color:#E1E4E8">magnitude </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> float</span><span style="color:#E1E4E8">(</span><span style="color:#79B8FF">abs</span><span style="color:#E1E4E8">(result_value))</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#E1E4E8">{</span></span>
+<span class="line"><span style="color:#9ECBFF">    "mpmath_version"</span><span style="color:#E1E4E8">: mpmath.</span><span style="color:#79B8FF">__version__</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "python_version"</span><span style="color:#E1E4E8">: sys.version.split()[</span><span style="color:#79B8FF">0</span><span style="color:#E1E4E8">],</span></span>
+<span class="line"><span style="color:#9ECBFF">    "mp_dps"</span><span style="color:#E1E4E8">: mpmath.mp.dps,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "result_real"</span><span style="color:#E1E4E8">: real,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "result_imag"</span><span style="color:#E1E4E8">: imag,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "result_abs"</span><span style="color:#E1E4E8">: magnitude,</span></span>
+<span class="line"><span style="color:#9ECBFF">    "reproduced"</span><span style="color:#E1E4E8">: magnitude </span><span style="color:#F97583">></span><span style="color:#79B8FF"> 1e6</span><span style="color:#E1E4E8">,</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span></code></pre>
+        </section>
+
+        <section class="vh-main__col vh-main__col--output">
+          <h2>Output</h2>
+          <pre id="output">(running)</pre>
+        </section>
+      </div>
+
+    </main>
+
+    <script type="module" src="./repro.js"></script>
+  </body>
+</html>

--- a/src/layer1_wasm/mpmath-930/recipe.json
+++ b/src/layer1_wasm/mpmath-930/recipe.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "language": "python",
+  "symptom": "silent-precision-loss-at-default-dps",
+  "severity": "wrong-result",
+  "tags": ["mpmath", "jtheta", "jacobi-theta", "precision", "elliptic-functions"],
+  "expected_verdict": "reproduced",
+  "expected_runtime": "pyodide"
+}

--- a/src/layer1_wasm/mpmath-930/repro.py
+++ b/src/layer1_wasm/mpmath-930/repro.py
@@ -1,0 +1,75 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#   "mpmath==1.4.1",
+# ]
+# ///
+"""Vivarium Layer 1 reproduction — mpmath/mpmath#930, native variant.
+
+Mirrors the script that runs in ``repro.ts`` (under Pyodide) so a
+contributor can re-verify the bug against a real CPython interpreter
++ a real mpmath install:
+
+    mise install                                                    # one-time
+    mise exec uv -- uv run src/layer1_wasm/mpmath-930/repro.py
+
+PEP 723 inline metadata pins mpmath to **1.4.1** — the latest PyPI
+release as of 2026-05-19. The bug remains unfixed there.
+
+``mpmath.jtheta(2, mpc("99", "1"), mpc("0.99", "0"))`` at the default
+precision (``mp.dps=15``) returns roughly ``-1.73e9 + 7.19e8j``. The
+correct value (verified at ``mp.dps=200``, agreeing with Mathematica)
+is roughly ``-1.50e-57 + 1.13e-58j`` — the buggy answer is off by
+about 66 orders of magnitude. Verdict is "reproduced" when the
+absolute value of the result exceeds ``1e6`` (the buggy magnitude is
+~1.87e9; the correct magnitude is ~1.5e-57).
+
+Prints ``reproduced=true`` to JSON output. Exit code: 0 on
+``reproduced``, 1 on ``unreproduced`` so CI can shell-script around
+it without parsing stdout.
+"""
+
+import json
+import sys
+
+import mpmath
+from mpmath import mpc
+
+# Default precision (mp.dps = 15) — the regime where the bug appears.
+result_value = mpmath.jtheta(2, mpc("99", "1"), mpc("0.99", "0"))
+real = float(mpmath.re(result_value))
+imag = float(mpmath.im(result_value))
+magnitude = float(abs(result_value))
+
+# Bug: magnitude lands near 1.87e9 instead of ~1.5e-57. Use 1e6 as the
+# threshold — anything above is the buggy regime; anything below would
+# only happen if upstream fixed the precision loss at default dps.
+reproduced = magnitude > 1e6
+
+result = {
+    "mpmath_version": mpmath.__version__,
+    "python_version": sys.version.split()[0],
+    "mp_dps": mpmath.mp.dps,
+    "result_real": real,
+    "result_imag": imag,
+    "result_abs": magnitude,
+    "expected_abs_at_dps200": 1.5e-57,
+    "reproduced": reproduced,
+}
+
+print(json.dumps(result, indent=2))
+
+if reproduced:
+    print(
+        "verdict=reproduced — jtheta(2, 99+1j, 0.99) returned magnitude "
+        f"{magnitude:.3e} at dps=15, expected ~1.5e-57.",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+else:
+    print(
+        "verdict=unreproduced — jtheta returned a near-zero magnitude at "
+        "default dps (likely fixed upstream).",
+        file=sys.stderr,
+    )
+    sys.exit(1)

--- a/src/layer1_wasm/mpmath-930/repro.ts
+++ b/src/layer1_wasm/mpmath-930/repro.ts
@@ -1,0 +1,219 @@
+// Vivarium Layer 1 reproduction — mpmath/mpmath#930.
+//
+// At default precision (`mp.dps=15`),
+//   mpmath.jtheta(2, mpc('99','1'), mpc('0.99','0'))
+// returns roughly `-1.73e9 + 7.19e8j`. The correct value (verified
+// at `mp.dps=200`, matching Mathematica) is roughly
+// `-1.50e-57 + 1.13e-58j` — off by about 66 orders of magnitude.
+// Silent precision loss inside the Jacobi-theta sum for arguments
+// with large imaginary part of `z` and `|q|` close to 1.
+//
+// Verdict semantics (per ADR-0008 / contract v1):
+//   - "reproduced"   — magnitude > 1e6 (the bug puts it near 1.87e9).
+//   - "unreproduced" — magnitude < 1e6 (default dps now gives a
+//                      correctly-small value, i.e. fixed upstream),
+//                      or the runtime errored.
+//
+// mpmath is **not** in Pyodide's bundled package set, so we install
+// it via `micropip` after the Pyodide bootstrap. mpmath is pure
+// Python with no compiled deps, so the install is a single PyPI
+// wheel — well under the Playwright timeout.
+
+import { loadVivariumPyodide } from '../_shared/loader.js';
+import type { PathACapturedRun } from '../_shared/path_a.js';
+import { enableRunner } from '../_shared/runner.js';
+import {
+  setResult,
+  setVerdict,
+  type VivariumResultV1,
+} from '../_shared/verdict.js';
+
+const BASELINE_SPEC = 'mpmath==1.4.1';
+
+const REPRO_CODE = `
+import sys
+import mpmath
+from mpmath import mpc
+
+result_value = mpmath.jtheta(2, mpc('99', '1'), mpc('0.99', '0'))
+real = float(mpmath.re(result_value))
+imag = float(mpmath.im(result_value))
+magnitude = float(abs(result_value))
+
+{
+    "mpmath_version": mpmath.__version__,
+    "python_version": sys.version.split()[0],
+    "mp_dps": mpmath.mp.dps,
+    "result_real": real,
+    "result_imag": imag,
+    "result_abs": magnitude,
+    "reproduced": magnitude > 1e6,
+}
+`.trim();
+
+interface ReproOutput {
+  mpmath_version: string;
+  python_version: string;
+  mp_dps: number;
+  result_real: number;
+  result_imag: number;
+  result_abs: number;
+  reproduced: boolean;
+}
+
+interface PyodideRuntime {
+  loadPackage(name: string | string[]): Promise<void>;
+  pyimport(module: string): {
+    install(spec: string): Promise<void>;
+  };
+  runPythonAsync(code: string): Promise<{
+    toJs(opts: { dict_converter: typeof Object.fromEntries }): ReproOutput;
+    destroy?(): void;
+  }>;
+}
+
+const outputEl = document.getElementById('output');
+const metaEl = document.getElementById('meta');
+const reproCodeEl = document.getElementById('repro-code');
+
+if (!outputEl || !metaEl || !reproCodeEl) {
+  throw new Error(
+    'mpmath-930: missing required DOM elements (#output, #meta, #repro-code).',
+  );
+}
+
+if (!reproCodeEl.firstChild) {
+  reproCodeEl.textContent = REPRO_CODE;
+  fetch('./repro.highlighted.html')
+    .then((r) => (r.ok ? r.text() : null))
+    .then((html) => {
+      if (html) reproCodeEl.innerHTML = html;
+    })
+    .catch(() => {});
+}
+
+function evaluate(result: ReproOutput): {
+  verdict: 'reproduced' | 'unreproduced';
+  message: string;
+} {
+  if (result.reproduced) {
+    return {
+      verdict: 'reproduced',
+      message:
+        `bug reproduced — jtheta returned magnitude ${result.result_abs.toExponential(3)} ` +
+        `at dps=${result.mp_dps}, expected ~1.5e-57.`,
+    };
+  }
+  return {
+    verdict: 'unreproduced',
+    message:
+      `bug not reproduced — jtheta returned magnitude ${result.result_abs.toExponential(3)} ` +
+      `(default dps appears to deliver the correct small value).`,
+  };
+}
+
+async function captureRun(
+  runtime: PyodideRuntime,
+  source: string,
+): Promise<PathACapturedRun> {
+  try {
+    const proxy = await runtime.runPythonAsync(source);
+    const result = proxy.toJs({ dict_converter: Object.fromEntries });
+    proxy.destroy?.();
+    const ev = evaluate(result);
+    return {
+      exitCode: 0,
+      verdict: ev.verdict,
+      message: ev.message,
+      stdout: JSON.stringify(result, null, 2),
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      exitCode: 1,
+      verdict: 'unreproduced',
+      message: `runtime error: ${message}`,
+      stdout: message,
+    };
+  }
+}
+
+const startedAt = new Date();
+
+try {
+  const { pyodide, version } = await loadVivariumPyodide({
+    packages: ['micropip'],
+    pendingText: 'Loading Pyodide runtime and micropip…',
+  });
+  const runtime = pyodide as PyodideRuntime;
+
+  setVerdict('pending', `Installing ${BASELINE_SPEC} from PyPI…`);
+  const micropip = runtime.pyimport('micropip');
+  await micropip.install(BASELINE_SPEC);
+
+  setVerdict('pending', 'Running reproduction script…');
+  const baseline = await captureRun(runtime, REPRO_CODE);
+
+  let baselineResult: ReproOutput | null = null;
+  try {
+    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
+  } catch {
+    outputEl.textContent = baseline.stdout;
+    setVerdict(baseline.verdict, baseline.message);
+    throw new Error(baseline.message);
+  }
+
+  metaEl.textContent =
+    `mpmath ${baselineResult.mpmath_version} on Python ` +
+    `${baselineResult.python_version} via Pyodide v${version}.`;
+  outputEl.textContent = baseline.stdout;
+  setVerdict(baseline.verdict, baseline.message);
+
+  const finishedAt = new Date();
+  const envelope: VivariumResultV1 = {
+    contract: 'v1',
+    bug: {
+      project: 'mpmath',
+      issue: 930,
+      upstream_url: 'https://github.com/mpmath/mpmath/issues/930',
+    },
+    runtime: {
+      name: 'pyodide',
+      version,
+      extras: {
+        python: baselineResult.python_version,
+        mpmath: baselineResult.mpmath_version,
+      },
+    },
+    result: {
+      mp_dps: baselineResult.mp_dps,
+      result_real: baselineResult.result_real,
+      result_imag: baselineResult.result_imag,
+      result_abs: baselineResult.result_abs,
+      reproduced: baselineResult.reproduced,
+    },
+    timing: {
+      started_at: startedAt.toISOString(),
+      finished_at: finishedAt.toISOString(),
+      duration_ms: finishedAt.getTime() - startedAt.getTime(),
+    },
+  };
+  setResult(envelope);
+
+  enableRunner({
+    slug: 'mpmath-930',
+    baselineSource: REPRO_CODE,
+    runFix: (source) => captureRun(runtime, source),
+  });
+} catch (err: unknown) {
+  console.error(err);
+  const errAny = err as { stack?: string; message?: string } | null;
+  outputEl.textContent =
+    (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
+  if (globalThis.__VIVARIUM_VERDICT__ !== 'unreproduced') {
+    setVerdict(
+      'unreproduced',
+      `bug not reproduced — runtime error: ${errAny?.message ?? String(err)}`,
+    );
+  }
+}

--- a/src/layer1_wasm/mpmath-930/roundtrip.json
+++ b/src/layer1_wasm/mpmath-930/roundtrip.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "slug": "mpmath-930",
+  "upstream_issue": "https://github.com/mpmath/mpmath/issues/930",
+  "status": "draft",
+  "updated_at": "2026-05-19T00:00:00Z",
+  "notes": [
+    "scaffolded from upstream issue mpmath/mpmath#930 (Jacobi Theta Wrong Output)",
+    "verified locally that mpmath 1.4.1 (latest) still reproduces the bug at default dps=15 — jtheta returns ~1.87e9 magnitude vs the dps=200 reference ~1.5e-57"
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a Layer 1 (Pyodide) reproduction for [mpmath/mpmath#930 "Jacobi Theta Wrong Output"](https://github.com/mpmath/mpmath/issues/930)
- `mpmath.jtheta(2, mpc('99','1'), mpc('0.99','0'))` returns magnitude ~`1.87e9` at the default `mp.dps=15`, but the `dps=200` reference (matching Mathematica) is ~`1.5e-57` — about 66 orders of magnitude off, caused by silent precision loss in the series cancellation for large `Im(z)` with `|q|` close to 1
- Pins `mpmath==1.4.1` (latest PyPI release as of 2026-05-19; locally verified to still reproduce). Single-variant layout — fix-candidate variant will be added in a follow-up PR once a fork+branch exists

## The recipe

```
src/layer1_wasm/mpmath-930/
├── README.md
├── index.html       — Contract v1 page; declares `vivarium-contract: v1`
├── recipe.json      — schema_version 1, language=python, symptom=silent-precision-loss-at-default-dps
├── repro.py         — PEP 723 native CLI variant pinning mpmath==1.4.1
├── repro.ts         — Pyodide driver using shared _shared/ helpers
└── roundtrip.json   — status=draft
```

Verdict semantics: `reproduced` when `abs(result) > 1e6` (the buggy regime; buggy value ≈ 1.87e9); `unreproduced` when the magnitude lands in the correct ~`1e-57` range or the runtime errors. Single boolean → mechanically distinguishable.

## Out-of-recipe changes

- `docs/site/_data/projects.json` — adds `mpmath` project row
- `docs/site/public/api/recipes.json`, `docs/site/public/api/projects.json` — regenerated via `mise run recipes:index`

## Test plan

- [x] Verify upstream bug reproduces locally against `mpmath==1.4.1` (the latest PyPI release): `uv run --with mpmath==1.4.1 python -c "..."` → `-1.73e9 + 7.19e8j` (matches issue #930 exactly)
- [x] Verify dps=200 reference value: `-1.50e-57 + 1.13e-58j` (matches Mathematica per the upstream issue)
- [x] `bun run tsc --noEmit` (and `tsc -p tests/tsconfig.json`) — passes
- [x] `bun run build` — `highlight-repros.ts` inlines syntax-highlighted source into `index.html`; tsc emits `repro.js`
- [x] `mise run docs:check` (biome) — passes
- [x] `mise run markdown:check` (rumdl) — passes
- [x] `mise run ci:lint` — python / php / markdown / toml / docs all pass (rust:check fails on local Amazon Linux due to a missing `cc` linker for the pre-existing regex-779 crate; unrelated to this PR — CI environment has the linker)
- [x] `cd docs && bun run build` — site builds; `doc_build/repro/mpmath/index.html` (en/ja) generated
- [x] `mise run ci:repro` — recipe is auto-discovered by the catalog-driven Playwright suite (`mpmath-930 reproduction produces reproduced` test name generated). Browser launch failed locally due to missing system shared libraries (`libatk-1.0.so.0`) on Amazon Linux without `apt-get`; will execute on `ubuntu-latest` in CI

## Round-trip state

`roundtrip.json` starts at `status: draft`. Follow-up work (`verifying` → `verified` → `upstream_open` → `merged`) is out of scope for this PR — the `verdicts.unfixed` capture will land on this PR's first CI run, and the fix-candidate variant arrives in a follow-up once a fork+branch is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)