### PR TITLE
fix(ci): resolve bun via mise which for ajv install (mise-action v4.2.1)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -107,9 +107,10 @@ jobs:
         # mise-installed bun does not), and without leaking ajv into
         # any tracked package.json.
         run: |
+          BUN="$(mise which bun)"
           cd "$RUNNER_TEMP"
-          bun init -y >/dev/null
-          bun add ajv-cli@5 ajv-formats
+          "$BUN" init -y >/dev/null
+          "$BUN" add ajv-cli@5 ajv-formats
           # Both forms — `$AJV_BIN` for explicit yaml callers, and the
           # bin dir on `$GITHUB_PATH` so shell scripts (e.g.
           # `scripts/capture_layer2_verdict.sh`) can call `ajv` directly

--- a/.github/workflows/repro-regression.yml
+++ b/.github/workflows/repro-regression.yml
@@ -137,9 +137,10 @@ jobs:
         # against `src/external_examples/*/.vivarium/manifest.toml` after
         # a TOML→JSON conversion via Python's stdlib `tomllib`).
         run: |
+          BUN="$(mise which bun)"
           cd "$RUNNER_TEMP"
-          bun init -y >/dev/null
-          bun add ajv-cli@5 ajv-formats
+          "$BUN" init -y >/dev/null
+          "$BUN" add ajv-cli@5 ajv-formats
           # Both forms — `$AJV_BIN` for explicit yaml callers, and the
           # bin dir on `$GITHUB_PATH` so shell scripts (e.g.
           # `scripts/capture_layer2_verdict.sh`) can call `ajv` directly


### PR DESCRIPTION
## Problem

`repro-regression` and `deploy-docs` have failed on every run since
2026-07-19 (PR #317), each dying in the **Install ajv-cli** step with:

```
mise ERROR No version is set for shim: bun
```

## Root cause

PR #317 bumped `jdx/mise-action` v4.2.0 → **v4.2.1**. v4.2.1 (upstream
issue #555) changed PATH handling: it **no longer exports resolved tool
bin dirs** (e.g. `…/mise/installs/bun/latest/bin`) into the step PATH —
only the `…/mise/shims` directory is added.

The ajv-cli install step does `cd "$RUNNER_TEMP"` (outside the repo)
before running `bun`. Post-v4.2.1, `bun` now resolves via the shim, and
the shim discovers its version from the current directory's `mise.toml`.
From `$RUNNER_TEMP` there is no discoverable config, so version
resolution fails — even though `mise ls` shows bun installed.

Only these two workflows are affected because they are the only ones
that invoke `bun` after `cd`-ing outside the repository tree.

## Fix

Resolve bun's absolute install path via `mise which bun` **before** the
`cd`, while the repo `mise.toml` is still discoverable, then invoke that
absolute path. This is cwd-independent and keeps `mise.toml` as the sole
source of truth for the bun version (no duplicated version literal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)