### PR TITLE
ci(lint): split polyglot autofix into untrusted build + trusted apply

### DIFF
--- a/.github/workflows/lint-autofix-apply.yml
+++ b/.github/workflows/lint-autofix-apply.yml
@@ -1,0 +1,144 @@
+name: Polyglot lint autofix apply
+
+# Trusted half of the polyglot autofix pair. `lint-autofix.yml` runs
+# the formatters on the PR head with no secrets and uploads the
+# resulting diff; this workflow pushes that diff back to the PR
+# branch.
+#
+# WHY THIS IS SAFE TO RUN WITH THE PAT
+#
+# `workflow_run` runs from the default branch with repository secrets
+# available, which is normally the classic "pwn request" trap. The
+# trap only closes when the trusted job executes something the PR
+# author controls. This job executes nothing from the PR:
+#
+#   - no mise, no package manager, no build, no task runner;
+#   - the only PR-derived input is `autofix.patch`, and it is fed to
+#     `git apply`, which treats it as data, not as code;
+#   - the identity of the target (repo / branch / head SHA) is read
+#     from the `workflow_run` event payload — set by GitHub — never
+#     from the artifact, so a tampered artifact cannot redirect the
+#     push at another repository the PAT can write to;
+#   - the push target is the PR's own head branch on the contributor's
+#     fork, i.e. the one place the patch is supposed to land.
+#
+# `allow-unsafe-pr-checkout: true` is therefore a deliberate opt-in:
+# actions/checkout v6.1.0+ blocks fork-PR checkouts from
+# `workflow_run` by default (see `assertSafePrCheckout`), and the risk
+# it guards against — running fork code in a trusted context — is
+# structurally absent here. Keep it that way: if this job ever needs
+# to *run* something out of the checkout, the split has been broken
+# and the credential must move out of this workflow.
+#
+# The PAT (TF_TOKEN_GITHUB) is required rather than GITHUB_TOKEN
+# because the branch lives on the contributor's personal fork; the
+# base repository token cannot push there.
+
+on:
+  workflow_run:
+    workflows: ['Polyglot lint autofix']
+    types:
+      - completed
+
+# `actions: read` to download the artifact from the triggering run.
+# No `contents: write`: the push uses the PAT, and GITHUB_TOKEN has no
+# business writing anywhere here.
+permissions:
+  contents: read
+  actions: read
+
+# Serialize per head branch so two runs for the same PR cannot race on
+# the push. Not cancel-in-progress: a cancelled apply would silently
+# drop fixes that were already computed.
+concurrency:
+  group: >-
+    lint-autofix-apply-${{ github.event.workflow_run.head_repository.full_name }}-${{
+    github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    name: Apply polyglot lint autofix
+    # Only for successful `pull_request` runs of the producer
+    # workflow. A failed producer has no trustworthy patch, and any
+    # other trigger (a push to main, a manual dispatch) has no PR
+    # branch to push to.
+    if: |
+      github.repository_owner == 'aletheia-works' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download autofix patch
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lint-autofix-patch
+          path: ./autofix-in
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Two gates before the credential is handed to anything:
+      #   1. an empty patch means "nothing to fix" — the common case,
+      #      and the case on the re-run our own push triggers, so it
+      #      must exit cleanly rather than fail;
+      #   2. no formatter in `lint:all:fix` touches YAML, so a patch
+      #      that rewrites a workflow file is a signal that something
+      #      other than formatting happened. Refuse it loudly instead
+      #      of pushing it.
+      - name: Inspect patch
+        id: patch
+        run: |
+          set -euo pipefail
+          patch=./autofix-in/autofix.patch
+          if [ ! -s "${patch}" ]; then
+            echo "No autofix changes to apply."
+            echo "apply=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if grep -qE '^diff --git a/\.github/workflows/' "${patch}"; then
+            echo "::error::Autofix patch touches .github/workflows/; refusing to apply."
+            exit 1
+          fi
+          echo "Patch touches:"
+          grep -E '^diff --git ' "${patch}" | sed 's/^diff --git a\///; s/ b\/.*$//'
+          echo "apply=true" >> "${GITHUB_OUTPUT}"
+
+      # Checked out into `pr/` so the untrusted tree never overlaps the
+      # workspace root that holds the downloaded artifact.
+      - name: Checkout PR branch
+        if: steps.patch.outputs.apply == 'true'
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          token: ${{ secrets.TF_TOKEN_GITHUB }}
+          persist-credentials: true
+          # See the security note at the top of this file. Nothing from
+          # this checkout is executed.
+          allow-unsafe-pr-checkout: true
+          path: pr
+
+      - name: Apply and push
+        if: steps.patch.outputs.apply == 'true'
+        working-directory: pr
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+
+          # The branch may have moved since the producer run computed
+          # the patch. Applying it anyway would either conflict or, at
+          # worst, revert newer work — skip and let the push that moved
+          # the branch produce its own autofix run.
+          current="$(git rev-parse HEAD)"
+          if [ "${current}" != "${HEAD_SHA}" ]; then
+            echo "Branch moved (${HEAD_SHA} -> ${current}); skipping stale patch."
+            exit 0
+          fi
+
+          git apply --index "${GITHUB_WORKSPACE}/autofix-in/autofix.patch"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "style: polyglot lint autofix (biome/mago/ruff/tombi/rumdl/cargo-fmt)"
+          git push origin "HEAD:${HEAD_BRANCH}"

--- a/.github/workflows/lint-autofix.yml
+++ b/.github/workflows/lint-autofix.yml
@@ -2,34 +2,52 @@ name: Polyglot lint autofix
 
 # Runs the polyglot formatter / linter toolchain — Biome (JS/TS/CSS/
 # JSON in docs/), Mago for PHP, Ruff for Python, Tombi for TOML,
-# rumdl for Markdown, cargo fmt for Rust — in autofix mode and pushes
-# any resulting changes back to the PR branch so contributors don't
-# have to fix formatting / lint by hand.
+# rumdl for Markdown, cargo fmt for Rust — in autofix mode and
+# uploads the resulting diff as an artifact. The companion
+# `lint-autofix-apply.yml` picks that artifact up and pushes the fixes
+# back to the PR branch, so contributors don't have to fix formatting
+# / lint by hand.
 #
-# Pattern mirrors `biome-autofix.yml` / `tofu-fmt-autofix.yml`. Inline
-# for now (first instance of polyglot autofix in vivarium); flag for
-# promotion to `aletheia-works/.github/.github/workflows/` when a
-# second repo in the org needs the same logic, per AGENTS.md §4.8.
+# WHY THE SPLIT (the "untrusted build, trusted apply" pattern)
 #
-# `pull_request_target` so fork PRs see autofix run too — `pull_request`
-# from a fork ships with read-only GITHUB_TOKEN, which can't push back.
-# Same TF_TOKEN_GITHUB PAT as biome / tofu autofix; that PAT has
-# write access to the maintainer's personal forks where `sl pr submit`
-# lands every PR.
+# This workflow used to run on `pull_request_target` with the
+# TF_TOKEN_GITHUB PAT so that fork PRs got autofix too. That stopped
+# working when actions/checkout v6.1.0 (backport of the v7 breaking
+# change, GitHub changelog "Safer pull_request_target defaults for
+# GitHub Actions checkout") began refusing fork-PR checkouts from
+# `pull_request_target`.
 #
-# SECURITY NOTE: combined with `secrets: inherit`, fork-PR PHP / Python /
-# TOML / Markdown / Rust source is touched with an org-scoped PAT.
-# Acceptable because each tool here is a textual formatter / linter
-# (no code execution from PR sources during the workflow). Same posture
-# as biome-autofix.yml.
+# Simply re-enabling it with `allow-unsafe-pr-checkout: true` would
+# not be safe here: `mise run lint:all:fix` executes task definitions
+# read from the PR's own `mise.toml` (which this workflow's paths
+# filter deliberately watches), so a malicious fork PR could redefine
+# the task and exfiltrate the PAT. That is exactly the "pwn request"
+# shape the new default protects against.
 #
-# Tooling: like `test-lint-check.yml`, this is the documented exception
-# to AGENTS.md §4.10's "CI does not use mise" rule. A single
+# So the work is split by trust level:
+#
+#   1. THIS workflow — `pull_request`, so a fork PR run gets NO
+#      secrets and a read-only GITHUB_TOKEN. It checks out the PR
+#      head and runs the (arbitrary, PR-controlled) lint tooling.
+#      Nothing here is worth stealing; the only output is a patch
+#      file uploaded as an artifact.
+#   2. `lint-autofix-apply.yml` — `workflow_run`, so it runs from the
+#      default branch with the PAT. It executes NOTHING from the PR:
+#      it only `git apply`s the patch and pushes. See that file for
+#      the full trust argument.
+#
+# Note that `pull_request` alone cannot do the push: GitHub strips
+# secrets and downgrades GITHUB_TOKEN to read-only for fork PRs, and
+# the branch lives on the contributor's fork anyway (every PR here
+# arrives via `sl pr submit` from a personal fork).
+#
+# Tooling: like `test-lint-check.yml`, this is the documented
+# exception to AGENTS.md §4.9's "CI does not use mise" rule. A single
 # `jdx/mise-action` allowlist entry replaces 5 per-tool action
 # registrations.
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       # Biome (docs/) — JS/TS/CSS/JSON
       - 'docs/**/*.ts'
@@ -59,10 +77,12 @@ on:
       - '.rumdl.toml'
       - 'mise.toml'
       - '.github/workflows/lint-autofix.yml'
+      - '.github/workflows/lint-autofix-apply.yml'
 
+# Read-only: this job produces a patch, it never pushes. The apply
+# half holds the write credential.
 permissions:
-  contents: write
-  pull-requests: read
+  contents: read
 
 concurrency:
   group: lint-autofix-${{ github.event.pull_request.number }}
@@ -74,16 +94,18 @@ jobs:
     if: github.repository_owner == 'aletheia-works'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR branch
+      # The PR head commit, not the merge commit: the patch has to
+      # apply cleanly on top of the branch the apply half pushes to.
+      # `persist-credentials: false` because nothing here talks back
+      # to GitHub over git.
+      - name: Checkout PR head
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.TF_TOKEN_GITHUB }}
-          persist-credentials: true
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       # Install every lint tool + the Rust toolchain in one step via
-      # mise. See test-lint-check.yml for the AGENTS.md §4.10
+      # mise. See test-lint-check.yml for the AGENTS.md §4.9
       # exception rationale.
       - name: Setup mise
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
@@ -115,17 +137,27 @@ jobs:
       - name: Run polyglot lint autofix
         run: mise run lint:all:fix || true
 
-      # Commit & push only when something actually changed.
-      - name: Commit and push fixes
-        env:
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      # Always emit the artifact, even when the patch is empty: the
+      # apply half is triggered by this run finishing, so a missing
+      # artifact would turn "nothing to fix" into a download failure.
+      # `--binary` keeps the patch appliable if a tool ever rewrites a
+      # non-UTF-8 file.
+      - name: Capture autofix patch
         run: |
-          if git diff --quiet; then
-            echo "No autofix changes to commit."
-            exit 0
+          set -euo pipefail
+          mkdir -p autofix-out
+          git diff --binary > autofix-out/autofix.patch
+          if [ -s autofix-out/autofix.patch ]; then
+            echo "Autofix produced changes in:"
+            git diff --name-only
+          else
+            echo "No autofix changes."
           fi
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "style: polyglot lint autofix (biome/mago/ruff/tombi/rumdl/cargo-fmt)"
-          git push origin "HEAD:${PR_HEAD_REF}"
+
+      - name: Upload autofix patch
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lint-autofix-patch
+          path: autofix-out/autofix.patch
+          retention-days: 1
+          if-no-files-found: error


### PR DESCRIPTION

`lint-autofix.yml` has been failing on every fork PR since
actions/checkout v6.1.0 (the v7 breaking change, backported) began
refusing fork-PR checkouts from `pull_request_target`. Every PR in
this repo arrives from a personal fork via `sl pr submit`, so autofix
has effectively been dead for contributors — the failure only stayed
hidden because the runs in between were all same-repo Dependabot
branches.

Re-enabling it with `allow-unsafe-pr-checkout: true` would not be
safe: `mise run lint:all:fix` resolves its task definitions from the
PR's own `mise.toml`, which the workflow's paths filter watches, so a
fork PR could redefine the task and exfiltrate TF_TOKEN_GITHUB. That
is the "pwn request" shape the new default exists to stop.

Split the workflow by trust level instead:

- `lint-autofix.yml` now runs on `pull_request` with
  `permissions: contents: read` and no secrets. It runs the lint
  tooling on the PR head and uploads the diff as `lint-autofix-patch`
  (always, so "nothing to fix" is not a download failure downstream).
- `lint-autofix-apply.yml` (new) runs on `workflow_run` with the PAT
  and executes nothing from the PR: it downloads the patch, refuses
  one that touches `.github/workflows/`, checks out the PR branch,
  `git apply`s and pushes. Repo / branch / head SHA come from the
  `workflow_run` payload rather than the artifact, so a tampered
  artifact cannot redirect the push; the run is skipped if the branch
  moved since the patch was computed.

`allow-unsafe-pr-checkout: true` appears only in the apply half, where
the risk it guards — executing fork code in a trusted context — is
structurally absent. Both files carry the reasoning inline.

Note: `tofu-fmt-autofix.yml` still uses `pull_request_target` through
an org-level reusable workflow and has the same fork breakage; fixing
it belongs in aletheia-works/.github.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/344).
* #346
* __->__ #344