### PR TITLE
refactor(docs): single-source footer, favicon and repo url

### DIFF
--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig } from '@rspress/core';
 import { setupReproDevMiddleware } from './scripts/repro-dev-middleware';
+import {
+  DOC_REPO_BASE_URL,
+  FAVICONS,
+  FOOTER_MESSAGE_HTML,
+  GITHUB_REPO_URL,
+} from './scripts/site-chrome';
 import { NAV_OVERRIDES_CSS, SITE_BASE, SITE_ROOT } from './scripts/site-paths';
 
 // Vivarium docs site configuration.
@@ -40,41 +46,10 @@ export default defineConfig({
     },
   },
   head: [
-    [
-      'link',
-      {
-        rel: 'icon',
-        type: 'image/png',
-        sizes: '32x32',
-        href: `${SITE_BASE}favicon-32x32.png`,
-      },
-    ],
-    [
-      'link',
-      {
-        rel: 'icon',
-        type: 'image/png',
-        sizes: '16x16',
-        href: `${SITE_BASE}favicon-16x16.png`,
-      },
-    ],
-    [
-      'link',
-      {
-        rel: 'icon',
-        type: 'image/png',
-        sizes: '192x192',
-        href: `${SITE_BASE}icon-192.png`,
-      },
-    ],
-    [
-      'link',
-      {
-        rel: 'apple-touch-icon',
-        sizes: '180x180',
-        href: `${SITE_BASE}apple-touch-icon.png`,
-      },
-    ],
+    // Favicons come from scripts/site-chrome.ts so the reproduction
+    // pages' chrome.js, which injects the same icons, cannot drift.
+    ...FAVICONS.map((attrs) => ['link', attrs] as [string, typeof attrs]),
+    // The font links stay inline: reproduction pages don't use them.
     [
       'link',
       {
@@ -103,16 +78,14 @@ export default defineConfig({
       {
         icon: 'github',
         mode: 'link',
-        content: 'https://github.com/aletheia-works/vivarium',
+        content: GITHUB_REPO_URL,
       },
     ],
     footer: {
-      message:
-        'Apache License 2.0 · part of <a href="https://github.com/aletheia-works">aletheia-works</a>',
+      message: FOOTER_MESSAGE_HTML,
     },
     editLink: {
-      docRepoBaseUrl:
-        'https://github.com/aletheia-works/vivarium/tree/main/docs/site',
+      docRepoBaseUrl: DOC_REPO_BASE_URL,
     },
     enableContentAnimation: true,
     lastUpdated: true,
@@ -126,8 +99,7 @@ export default defineConfig({
         lastUpdatedText: 'Last updated',
         searchPlaceholderText: 'Search',
         editLink: {
-          docRepoBaseUrl:
-            'https://github.com/aletheia-works/vivarium/tree/main/docs/site',
+          docRepoBaseUrl: DOC_REPO_BASE_URL,
           text: 'Edit this page on GitHub',
         },
       },
@@ -140,8 +112,7 @@ export default defineConfig({
         lastUpdatedText: '最終更新',
         searchPlaceholderText: '検索',
         editLink: {
-          docRepoBaseUrl:
-            'https://github.com/aletheia-works/vivarium/tree/main/docs/site',
+          docRepoBaseUrl: DOC_REPO_BASE_URL,
           text: 'GitHub でこのページを編集',
         },
       },

--- a/docs/scripts/__tests__/reproChrome.test.ts
+++ b/docs/scripts/__tests__/reproChrome.test.ts
@@ -23,6 +23,7 @@ import { describe, expect, test } from 'bun:test';
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { buildNavByLocale, renderChromeData } from '../generate-repro-chrome';
+import { FAVICONS, FOOTER_MESSAGE_HTML, GITHUB_REPO_URL } from '../site-chrome';
 import { SITE_ROOT } from '../site-paths';
 
 const LOCALES = ['en', 'ja'] as const;
@@ -108,6 +109,41 @@ describe('repro nav — generated module matches the source', () => {
     }
     for (const item of nav.ja) {
       expect(item.link.startsWith('/vivarium/ja/')).toBe(true);
+    }
+  });
+});
+
+describe('site chrome — repro pages and rspress agree', () => {
+  // The footer line, the favicon set and the GitHub URL are rendered
+  // twice: once by rspress (themeConfig / head[]) and once by chrome.js
+  // on reproduction pages. Both now read docs/scripts/site-chrome.ts.
+  // These cases assert the config really consumes it, so a future edit
+  // that re-inlines a literal into rspress.config.ts is caught.
+  test('rspress config renders the shared footer message', async () => {
+    const config = (await import('../../rspress.config')).default;
+    expect(config.themeConfig?.footer?.message).toBe(FOOTER_MESSAGE_HTML);
+  });
+
+  test('rspress config renders the shared favicons', async () => {
+    const config = (await import('../../rspress.config')).default;
+    const heads = (config.head ?? []) as unknown[];
+    for (const icon of FAVICONS) {
+      const found = heads.some(
+        (h) =>
+          Array.isArray(h) &&
+          h[0] === 'link' &&
+          (h[1] as Record<string, string>)?.href === icon.href,
+      );
+      expect(found).toBe(true);
+    }
+  });
+
+  test('generated module carries the same values as the config module', () => {
+    const rendered = renderChromeData(buildNavByLocale());
+    expect(rendered).toContain(JSON.stringify(FOOTER_MESSAGE_HTML));
+    expect(rendered).toContain(JSON.stringify(GITHUB_REPO_URL));
+    for (const icon of FAVICONS) {
+      expect(rendered).toContain(JSON.stringify(icon.href));
     }
   });
 });

--- a/docs/scripts/generate-repro-chrome.ts
+++ b/docs/scripts/generate-repro-chrome.ts
@@ -49,6 +49,7 @@
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { FAVICONS, FOOTER_MESSAGE_HTML, GITHUB_REPO_URL } from './site-chrome';
 import { SITE_BASE, SITE_ROOT } from './site-paths';
 
 const LOCALES = ['en', 'ja'] as const;
@@ -160,6 +161,18 @@ export function renderChromeData(
   lines.push('};');
   lines.push('');
   lines.push(`export const SITE_BASE = ${JSON.stringify(SITE_BASE)};`);
+  lines.push('');
+  lines.push(`export const GH_REPO = ${JSON.stringify(GITHUB_REPO_URL)};`);
+  lines.push('');
+  lines.push(
+    `export const FOOTER_MESSAGE_HTML = ${JSON.stringify(FOOTER_MESSAGE_HTML)};`,
+  );
+  lines.push('');
+  lines.push('export const FAVICONS = [');
+  for (const icon of FAVICONS) {
+    lines.push(`  ${JSON.stringify(icon)},`);
+  }
+  lines.push('];');
   lines.push('');
   return lines.join('\n');
 }

--- a/docs/scripts/site-chrome.ts
+++ b/docs/scripts/site-chrome.ts
@@ -1,0 +1,71 @@
+// Site chrome constants shared by the two surfaces that render it.
+//
+// The docs site (rspress, `docs/rspress.config.ts`) and the standalone
+// reproduction pages (`src/layer1_wasm/_assets/chrome.js`, fed by
+// `generate-repro-chrome.ts`) both paint the same favicons, the same
+// footer line, and the same GitHub links. Until now each held its own
+// copy, kept in agreement by hand — the same arrangement that let the
+// nav drift into shipping two dead links.
+//
+// Sibling of `site-paths.ts`, which `rspress.config.ts` already imports.
+
+import { SITE_BASE } from './site-paths';
+
+export const GITHUB_ORG_URL = 'https://github.com/aletheia-works';
+export const GITHUB_REPO_URL = `${GITHUB_ORG_URL}/vivarium`;
+export const DOC_REPO_BASE_URL = `${GITHUB_REPO_URL}/tree/main/docs/site`;
+
+/**
+ * The site-wide footer line.
+ *
+ * Canonical form is rspress's — `themeConfig.footer.message` renders this
+ * string as-is. chrome.js adds `target="_blank" rel="noreferrer"` to the
+ * anchor when it injects the footer, because a reproduction page is a
+ * leaf the visitor is actively running something on and shouldn't lose.
+ * That difference is deliberate; the *text* is what must not diverge.
+ *
+ * Note this is distinct from `_components/VivariumFooter.tsx`, which is
+ * the landing page's own large footer and is not shared with repro pages.
+ */
+export const FOOTER_MESSAGE_HTML = `Apache License 2.0 · part of <a href="${GITHUB_ORG_URL}">aletheia-works</a>`;
+
+export interface FaviconLink {
+  rel: string;
+  type?: string;
+  sizes: string;
+  href: string;
+}
+
+/**
+ * Favicon `<link>` attributes.
+ *
+ * rspress wants `['link', attrs]` tuples in `head[]`; chrome.js wants
+ * plain objects to feed `setAttribute`. Export the objects and let
+ * rspress.config.ts map them into tuples, so neither consumer forces its
+ * shape on the other.
+ */
+export const FAVICONS: readonly FaviconLink[] = [
+  {
+    rel: 'icon',
+    type: 'image/png',
+    sizes: '32x32',
+    href: `${SITE_BASE}favicon-32x32.png`,
+  },
+  {
+    rel: 'icon',
+    type: 'image/png',
+    sizes: '16x16',
+    href: `${SITE_BASE}favicon-16x16.png`,
+  },
+  {
+    rel: 'icon',
+    type: 'image/png',
+    sizes: '192x192',
+    href: `${SITE_BASE}icon-192.png`,
+  },
+  {
+    rel: 'apple-touch-icon',
+    sizes: '180x180',
+    href: `${SITE_BASE}apple-touch-icon.png`,
+  },
+];

--- a/src/layer1_wasm/_assets/chrome-data.js
+++ b/src/layer1_wasm/_assets/chrome-data.js
@@ -22,3 +22,14 @@ export const NAV_ITEMS = {
 };
 
 export const SITE_BASE = "/vivarium/";
+
+export const GH_REPO = "https://github.com/aletheia-works/vivarium";
+
+export const FOOTER_MESSAGE_HTML = "Apache License 2.0 · part of <a href=\"https://github.com/aletheia-works\">aletheia-works</a>";
+
+export const FAVICONS = [
+  {"rel":"icon","type":"image/png","sizes":"32x32","href":"/vivarium/favicon-32x32.png"},
+  {"rel":"icon","type":"image/png","sizes":"16x16","href":"/vivarium/favicon-16x16.png"},
+  {"rel":"icon","type":"image/png","sizes":"192x192","href":"/vivarium/icon-192.png"},
+  {"rel":"apple-touch-icon","sizes":"180x180","href":"/vivarium/apple-touch-icon.png"},
+];

--- a/src/layer1_wasm/_assets/chrome.js
+++ b/src/layer1_wasm/_assets/chrome.js
@@ -12,23 +12,23 @@
 // fetch: chrome.js paints the header before anything else, and this
 // module is resolved by the same graph that already loads chrome.js, so
 // it adds no round-trip.
-import { NAV_ITEMS, SITE_BASE } from './chrome-data.js';
+import {
+  FAVICONS,
+  FOOTER_MESSAGE_HTML,
+  GH_REPO,
+  NAV_ITEMS,
+  SITE_BASE,
+} from './chrome-data.js';
 
 // ── Favicon injection ───────────────────────────────────────────────────
-// Mirrors the rspress docs site config (docs/rspress.config.ts head[]).
-// Repro pages don't go through rspress, so we attach the same icons here
-// once per page load. Absolute /vivarium/ paths because SITE_BASE is
-// fixed at /vivarium/ (docs/scripts/site-paths.ts) and repro URLs nest
-// two levels deep (/vivarium/repro/<project>/<issue>/), so absolute
-// paths sidestep brittle relative-path arithmetic.
+// The same icons rspress puts in `head[]`, both sourced from
+// docs/scripts/site-chrome.ts. Repro pages don't go through rspress, so
+// we attach them here once per page load. The hrefs are absolute
+// (SITE_BASE-prefixed) because repro URLs nest two levels deep
+// (/vivarium/repro/<project>/<issue>/), so absolute paths sidestep
+// brittle relative-path arithmetic.
 (function injectFavicons() {
-  const icons = [
-    { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/vivarium/favicon-32x32.png' },
-    { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/vivarium/favicon-16x16.png' },
-    { rel: 'icon', type: 'image/png', sizes: '192x192', href: '/vivarium/icon-192.png' },
-    { rel: 'apple-touch-icon', sizes: '180x180', href: '/vivarium/apple-touch-icon.png' },
-  ];
-  for (const spec of icons) {
+  for (const spec of FAVICONS) {
     // Skip if an equivalent link already exists (e.g. a future template
     // adds a static <link> for the same rel+sizes pair).
     if (document.head.querySelector(`link[rel="${spec.rel}"][sizes="${spec.sizes}"]`)) continue;
@@ -80,8 +80,6 @@ const moon =
   '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
 const github =
   '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12.02c0 5.09 3.29 9.4 7.86 10.93.58.11.79-.25.79-.55 0-.27-.01-.99-.02-1.94-3.2.69-3.87-1.54-3.87-1.54-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.69 1.24 3.34.95.1-.74.4-1.24.72-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.18.91-.25 1.89-.38 2.86-.38.97 0 1.95.13 2.86.38 2.18-1.49 3.14-1.18 3.14-1.18.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14 0 1.55-.01 2.79-.01 3.17 0 .31.21.67.79.55 4.57-1.53 7.86-5.84 7.86-10.93C23.5 5.65 18.35.5 12 .5z"/></svg>';
-
-const GH_REPO = 'https://github.com/aletheia-works/vivarium';
 
 // Locale of the page being decorated. Reproduction pages are English
 // today; the JA tree sets `<html lang="ja">` and picks the JA nav table
@@ -165,14 +163,16 @@ function injectChrome() {
     outputEl.parentElement.insertBefore(progress, outputEl);
   }
 
-  // Footer — matches the docs site (themeConfig.footer.message): a
-  // centred single line of light copy, no big wordmark / link grid.
+  // Footer — the same line rspress renders via
+  // `themeConfig.footer.message`, both from docs/scripts/site-chrome.ts:
+  // a centred single line of light copy, no big wordmark / link grid.
+  // `target`/`rel` are added here because a reproduction page is a leaf
+  // the visitor is actively running something on and shouldn't lose.
   const footer = document.createElement('footer');
   footer.className = 'vh-footer';
   footer.innerHTML = `
     <p class="vh-footer__msg">
-      Apache License 2.0 · part of
-      <a href="https://github.com/aletheia-works" target="_blank" rel="noreferrer">aletheia-works</a>
+      ${FOOTER_MESSAGE_HTML.replace('<a ', '<a target="_blank" rel="noreferrer" ')}
     </p>
   `;
   document.body.appendChild(footer);


### PR DESCRIPTION

The footer line, the four favicon links and the GitHub repo URL were each
written twice — once in docs/rspress.config.ts for the docs site, once in
src/layer1_wasm/_assets/chrome.js for the reproduction pages — and kept in
agreement by hand. That is the same arrangement that let the nav drift
into shipping two dead links.

All of it now comes from docs/scripts/site-chrome.ts, a sibling of
site-paths.ts (which rspress.config.ts already imports). rspress reads it
directly; the reproduction pages get it through chrome-data.js, which
generate-repro-chrome.ts already emits.

FAVICONS exports plain attribute objects rather than rspress's
`['link', attrs]` tuples, so neither consumer forces its shape on the
other: rspress.config.ts maps them into tuples, chrome.js feeds them to
setAttribute.

The footer's `target="_blank" rel="noreferrer"` stays a chrome.js-side
addition rather than moving into the shared string. A reproduction page is
a leaf the visitor is actively running something on and shouldn't lose;
the docs site has no such constraint. The text is what must not diverge,
and that is now shared.

Not touched: _components/VivariumFooter.tsx, which is the landing page's
own large footer and is not rendered on reproduction pages. The shared
value is themeConfig.footer.message.

The new tests import rspress.config.ts itself and assert the config really
consumes the shared module, so re-inlining a literal into the config is
caught rather than silently re-forking the two copies.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/350).
* #352
* #351
* __->__ #350