### PR TITLE
feat(repro): japanese translations for all 12 recipes

### DIFF
--- a/docs/scripts/__tests__/reproI18n.test.ts
+++ b/docs/scripts/__tests__/reproI18n.test.ts
@@ -119,15 +119,14 @@ describe('repro i18n — annotation and translation keys agree', () => {
 });
 
 describe('repro i18n — EN/JA coverage', () => {
-  // Not yet strict: the infrastructure lands before the translations.
-  // The PR that adds all twelve `i18n.ja.json` files flips this to
-  // "every recipe page has a translation" and turns the generator's
-  // skip-with-a-note into a hard error.
-  test('every translated recipe is a real reproduction page', () => {
-    const translated = RECIPES.filter((r) => existsSync(r.translation));
-    for (const r of translated) {
-      expect(existsSync(r.html)).toBe(true);
-    }
+  test('every reproduction page ships a translation', () => {
+    // ADR-0028's i18n Definition of Done: EN + JA in the same PR. This
+    // is the reproduction-page counterpart of the docs-tree symmetry
+    // assertion in docs/tests/i18n.spec.ts.
+    const missing = RECIPES.filter((r) => !existsSync(r.translation)).map(
+      (r) => r.label,
+    );
+    expect(missing).toEqual([]);
   });
 
   test('the Layer 2 scaffolder template ships a translation', () => {

--- a/docs/scripts/generate-recipes-index.ts
+++ b/docs/scripts/generate-recipes-index.ts
@@ -122,7 +122,9 @@ interface RecipeMeta {
 interface ProjectMetaEntry {
   display_name?: string;
   tagline?: string;
+  tagline_ja?: string;
   description?: string;
+  description_ja?: string;
   homepage?: string;
   github?: string;
 }
@@ -135,7 +137,9 @@ interface ProjectEntry {
   project: string;
   display_name: string;
   tagline?: string;
+  tagline_ja?: string;
   description?: string;
+  description_ja?: string;
   homepage?: string;
   github?: string;
   recipe_count: number;
@@ -396,7 +400,9 @@ function aggregateProjects(
       page_url: `${PAGES_BASE}/repro/${project}/`,
     };
     if (meta.tagline) entry.tagline = meta.tagline;
+    if (meta.tagline_ja) entry.tagline_ja = meta.tagline_ja;
     if (meta.description) entry.description = meta.description;
+    if (meta.description_ja) entry.description_ja = meta.description_ja;
     if (meta.homepage) entry.homepage = meta.homepage;
     if (meta.github) entry.github = meta.github;
     projects.push(entry);

--- a/docs/scripts/generate-repro-i18n.ts
+++ b/docs/scripts/generate-repro-i18n.ts
@@ -453,6 +453,7 @@ function main(): void {
   const index = loadRecipeIndex();
   let written = 0;
   let skipped = 0;
+  void skipped;
 
   for (const layerDir of LAYER_DIRS) {
     const root = join(REPO_ROOT, 'src', layerDir);
@@ -472,10 +473,15 @@ function main(): void {
       }
 
       if (!existsSync(join(recipeDir, 'i18n.ja.json'))) {
-        // Not yet translated. The strict EN/JA symmetry check lives in
-        // docs/scripts/__tests__/reproI18n.test.ts and is turned on in
-        // the PR that lands all twelve translations.
-        console.error(`NOTE: ${slug} has no i18n.ja.json; skipping.`);
+        // Every reproduction page ships both locales (ADR-0028's i18n
+        // Definition of Done, the same rule docs/tests/i18n.spec.ts
+        // enforces for the rspress tree). A page without a translation
+        // is a half-shipped recipe, not a valid intermediate state.
+        fail(
+          `src/${layerDir}/${slug}`,
+          'no i18n.ja.json. Every reproduction page ships EN + JA in the ' +
+            'same PR; copy the keys out of index.html and translate them.',
+        );
         skipped += 1;
         continue;
       }
@@ -500,9 +506,7 @@ function main(): void {
     process.exit(1);
   }
 
-  console.error(
-    `Wrote ${written} Japanese reproduction page(s); ${skipped} untranslated.`,
-  );
+  console.error(`Wrote ${written} Japanese reproduction page(s).`);
 }
 
 if (import.meta.main) main();

--- a/docs/site/_components/ProjectPage.tsx
+++ b/docs/site/_components/ProjectPage.tsx
@@ -30,7 +30,9 @@ interface ProjectEntry {
   project: string;
   display_name: string;
   tagline?: string;
+  tagline_ja?: string;
   description?: string;
+  description_ja?: string;
   homepage?: string;
   github?: string;
   recipe_count: number;
@@ -162,6 +164,15 @@ export function ProjectPage({
   }
 
   const displayName = meta?.display_name ?? project;
+  // Locale-specific prose, falling back to English rather than to blank:
+  // a project added before its translation still reads on the JA page.
+  // `display_name`, `homepage` and `github` are locale-invariant.
+  const tagline =
+    lang === 'ja' ? (meta?.tagline_ja ?? meta?.tagline) : meta?.tagline;
+  const description =
+    lang === 'ja'
+      ? (meta?.description_ja ?? meta?.description)
+      : meta?.description;
   const layers =
     meta?.layers ?? Array.from(new Set(recipes.map((r) => r.layer))).sort();
 
@@ -170,9 +181,9 @@ export function ProjectPage({
       <header className="v-pp__hero">
         <p className="v-pp__eyebrow">{s.eyebrow(project)}</p>
         <h1 className="v-pp__title">{displayName}</h1>
-        {meta?.tagline ? <p className="v-pp__tagline">{meta.tagline}</p> : null}
-        {meta?.description ? (
-          <p className="v-pp__description">{meta.description}</p>
+        {tagline ? <p className="v-pp__tagline">{tagline}</p> : null}
+        {description ? (
+          <p className="v-pp__description">{description}</p>
         ) : null}
         <div className="v-pp__chips">
           <span className="v-pp__count-chip">

--- a/docs/site/_data/projects.json
+++ b/docs/site/_data/projects.json
@@ -1,94 +1,120 @@
 {
-  "$comment": "Project-level metadata overlay for /repro/<project>/ landing pages. Hand-curated and reviewed in PR diff (per-recipe metadata moved into src/layer*_*/<slug>/recipe.json on 2026-05-18; this remaining overlay is intentionally project-scoped, not recipe-scoped, because display_name / tagline / homepage are project facts not recipe facts). Project keys must match the `project` field generate-recipes-index.ts derives from each recipe slug. Recipes whose project has no row here fall back to slug-as-display-name with no description.",
+  "$comment": "Project-level metadata overlay for /repro/<project>/ landing pages. Hand-curated and reviewed in PR diff (per-recipe metadata moved into src/layer*_*/<slug>/recipe.json on 2026-05-18; this remaining overlay is intentionally project-scoped, not recipe-scoped, because display_name / tagline / homepage are project facts not recipe facts). Project keys must match the `project` field generate-recipes-index.ts derives from each recipe slug. Recipes whose project has no row here fall back to slug-as-display-name with no description. Japanese renderings live alongside their English siblings as `tagline_ja` / `description_ja`; `display_name`, `homepage` and `github` are locale-invariant and have no _ja twin.",
   "projects": {
     "cpython": {
       "display_name": "CPython",
       "tagline": "The reference Python interpreter.",
+      "tagline_ja": "リファレンス実装の Python インタプリタ。",
       "description": "Reproductions hit Python 3.13 / sqlite3 in the same Pyodide build that ships in the browser; pages also publish a CLI repro.py that runs against a host CPython pinned via mise.",
+      "description_ja": "ブラウザで動くのと同じ Pyodide ビルドの Python 3.13 / sqlite3 を突く再現。各ページは mise で版を固定した host CPython でも走る CLI 版 repro.py も公開する。",
       "homepage": "https://www.python.org/",
       "github": "https://github.com/python/cpython"
     },
     "numpy": {
       "display_name": "NumPy",
       "tagline": "Array programming in Python.",
+      "tagline_ja": "Python の配列プログラミング。",
       "description": "Bugs in numeric or temporal semantics that survive when numpy is loaded inside Pyodide. The browser page and the host-Python repro.py share the exact same script.",
+      "description_ja": "Pyodide 内に numpy を読み込んでも残る、数値や時間の意味論の bug。ブラウザページと host Python 用の repro.py はまったく同じスクリプトを共有する。",
       "homepage": "https://numpy.org/",
       "github": "https://github.com/numpy/numpy"
     },
     "pandas": {
       "display_name": "pandas",
       "tagline": "DataFrames for Python.",
+      "tagline_ja": "Python の DataFrame。",
       "description": "Empty / dtype-edge regressions that reproduce against the pandas wheel bundled with Pyodide; the same script also runs against host pandas via uv.",
+      "description_ja": "Pyodide に同梱される pandas wheel で再現する、空データや dtype の境界での regression。同じスクリプトは uv 経由で host の pandas でも走る。",
       "homepage": "https://pandas.pydata.org/",
       "github": "https://github.com/pandas-dev/pandas"
     },
     "ruby": {
       "display_name": "Ruby",
       "tagline": "Ruby standard library and language semantics.",
+      "tagline_ja": "Ruby の標準ライブラリと言語仕様。",
       "description": "Reproductions run on ruby.wasm (CRuby compiled to WASI). Host parity is provided by mise-pinned ruby for the repro.rb script.",
+      "description_ja": "再現は ruby.wasm (WASI 向けにコンパイルした CRuby) で走る。host 側の等価性は mise で版を固定した ruby が repro.rb を実行することで担保する。",
       "homepage": "https://www.ruby-lang.org/",
       "github": "https://github.com/ruby/ruby"
     },
     "php": {
       "display_name": "PHP",
       "tagline": "PHP runtime and standard extensions.",
+      "tagline_ja": "PHP の runtime と標準拡張。",
       "description": "Reproductions execute under php-wasm; host parity via mise-pinned php running the same repro.php.",
+      "description_ja": "再現は php-wasm 上で実行される。host 側の等価性は mise で版を固定した php が同じ repro.php を実行することで担保する。",
       "homepage": "https://www.php.net/",
       "github": "https://github.com/php/php-src"
     },
     "regex": {
       "display_name": "rust-lang/regex",
       "tagline": "Rust's standard regex crate.",
+      "tagline_ja": "Rust の標準的な regex crate。",
       "description": "Compiled to wasm32-wasip1 with a pinned crate version, so verdicts flip when the upstream fix lands in a future regex release — turning the page into a fix-detection sentinel.",
+      "description_ja": "crate の版を固定して wasm32-wasip1 にコンパイルしてあるため、upstream の fix が将来の regex リリースに入ると verdict が反転する——ページ自体が fix 検知のセンサーになる。",
       "homepage": "https://docs.rs/regex/",
       "github": "https://github.com/rust-lang/regex"
     },
     "lark": {
       "display_name": "Lark",
       "tagline": "Pure-Python parsing toolkit (LALR / Earley / CYK).",
+      "tagline_ja": "純 Python の構文解析ツールキット (LALR / Earley / CYK)。",
       "description": "Grammar-engine bugs that survive when lark is installed into Pyodide via micropip. Layer 1 recipes that involve hangs (e.g. LALR-construction infinite loops) run inside a Web Worker so the page can hard-terminate the worker on budget overrun without freezing the visitor's tab.",
+      "description_ja": "micropip 経由で Pyodide に lark を入れても残る、文法エンジンの bug。",
       "homepage": "https://lark-parser.readthedocs.io/",
       "github": "https://github.com/lark-parser/lark"
     },
     "dateutil": {
       "display_name": "python-dateutil",
       "tagline": "Extensions to the standard Python datetime module.",
+      "tagline_ja": "標準の Python datetime モジュールの拡張。",
       "description": "Date/time parsing and arithmetic bugs that survive when python-dateutil is installed into Pyodide via micropip. The browser page and the host-Python repro.py share the exact same script and the same pinned wheel.",
+      "description_ja": "micropip 経由で Pyodide に python-dateutil を入れても残る、日付時刻の parse と演算の bug。",
       "homepage": "https://dateutil.readthedocs.io/",
       "github": "https://github.com/dateutil/dateutil"
     },
     "bash": {
       "display_name": "bash",
       "tagline": "GNU bash and POSIX shell semantics.",
+      "tagline_ja": "GNU bash と POSIX シェルの意味論。",
       "description": "Layer 2 reproductions ship as Docker images: visitors run a single `docker run` command to observe the documented footgun on their own machine.",
+      "description_ja": "Layer 2 の再現は Docker イメージとして配布される。訪問者は `docker run` 一発で挙動を観察できる。",
       "homepage": "https://www.gnu.org/software/bash/",
       "github": "https://git.savannah.gnu.org/cgit/bash.git/"
     },
     "find": {
       "display_name": "find / xargs",
       "tagline": "Coreutils-style filesystem traversal.",
+      "tagline_ja": "coreutils 系のファイルシステム走査。",
       "description": "Cross-tool footguns at the find/xargs boundary, packaged as Layer 2 Docker reproductions for one-shot local replication.",
+      "description_ja": "find と xargs の境界にあるツール間の footgun を、一発で確認できる Layer 2 の Docker 再現としてパッケージしたもの。",
       "homepage": "https://www.gnu.org/software/findutils/",
       "github": "https://git.savannah.gnu.org/cgit/findutils.git"
     },
     "flock": {
       "display_name": "flock",
       "tagline": "util-linux flock(2) advisory locks.",
+      "tagline_ja": "util-linux の flock(2) advisory ロック。",
       "description": "Layer 2 reproductions demonstrating advisory-only lock semantics — non-flock-aware tools bypass the lock silently.",
+      "description_ja": "ロックが advisory でしかないことを示す Layer 2 の再現。flock を認識しないツールはロックを素通りする。",
       "homepage": "https://man7.org/linux/man-pages/man2/flock.2.html",
       "github": "https://github.com/util-linux/util-linux"
     },
     "postgres": {
       "display_name": "PostgreSQL",
       "tagline": "PostgreSQL transaction and isolation-level semantics.",
+      "tagline_ja": "PostgreSQL のトランザクションと分離レベルの意味論。",
       "description": "Layer 2 Docker reproductions targeting documented (but easily-missed) behaviours under default isolation levels.",
+      "description_ja": "既定の分離レベル下で文書化されてはいるが見落としやすい挙動を狙った Layer 2 の Docker 再現。",
       "homepage": "https://www.postgresql.org/",
       "github": "https://github.com/postgres/postgres"
     },
     "pthread": {
       "display_name": "POSIX threads",
       "tagline": "Native pthread races, captured deterministically.",
+      "tagline_ja": "ネイティブな pthread の race を決定的に捕まえる。",
       "description": "Layer 3 record-replay reproductions: a real pthreaded program is run under rr, the recorded trace ships in the image, and replay produces a bit-identical verdict every time.",
+      "description_ja": "Layer 3 の record-replay 再現。実際に pthread を使うプログラムを rr の下で走らせ、記録したトレースを配布する。",
       "homepage": "https://man7.org/linux/man-pages/man7/pthreads.7.html",
       "github": "https://github.com/rr-debugger/rr"
     }

--- a/docs/site/public/api/projects.json
+++ b/docs/site/public/api/projects.json
@@ -10,7 +10,9 @@
       ],
       "page_url": "https://aletheia-works.github.io/vivarium/repro/bash/",
       "tagline": "GNU bash and POSIX shell semantics.",
+      "tagline_ja": "GNU bash と POSIX シェルの意味論。",
       "description": "Layer 2 reproductions ship as Docker images: visitors run a single `docker run` command to observe the documented footgun on their own machine.",
+      "description_ja": "Layer 2 の再現は Docker イメージとして配布される。訪問者は `docker run` 一発で挙動を観察できる。",
       "homepage": "https://www.gnu.org/software/bash/",
       "github": "https://git.savannah.gnu.org/cgit/bash.git/"
     },
@@ -23,7 +25,9 @@
       ],
       "page_url": "https://aletheia-works.github.io/vivarium/repro/cpython/",
       "tagline": "The reference Python interpreter.",
+      "tagline_ja": "リファレンス実装の Python インタプリタ。",
       "description": "Reproductions hit Python 3.13 / sqlite3 in the same Pyodide build that ships in the browser; pages also publish a CLI repro.py that runs against a host CPython pinned via mise.",
+      "description_ja": "ブラウザで動くのと同じ Pyodide ビルドの Python 3.13 / sqlite3 を突く再現。各ページは mise で版を固定した host CPython でも走る CLI 版 repro.py も公開する。",
       "homepage": "https://www.python.org/",
       "github": "https://github.com/python/cpython"
     },
@@ -36,7 +40,9 @@
       ],
       "page_url": "https://aletheia-works.github.io/vivarium/repro/dateutil/",
       "tagline": "Extensions to the standard Python datetime module.",
+      "tagline_ja": "標準の Python datetime モジュールの拡張。",
       "description": "Date/time parsing and arithmetic bugs that survive when python-dateutil is installed into Pyodide via micropip. The browser page and the host-Python repro.py share the exact same script and the same pinned wheel.",
+      "description_ja": "micropip 経由で Pyodide に python-dateutil を入れても残る、日付時刻の parse と演算の bug。",
       "homepage": "https://dateutil.readthedocs.io/",
       "github": "https://github.com/dateutil/dateutil"
     },
@@ -49,7 +55,9 @@
       ],
       "page_url": "https://aletheia-works.github.io/vivarium/repro/find/",
       "tagline": "Coreutils-style filesystem traversal.",
+      "tagline_ja": "coreutils 系のファイルシステム走査。",
       "description": "Cross-tool footguns at the find/xargs boundary, packaged as Layer 2 Docker reproductions for one-shot local replication.",
+      "description_ja": "find と xargs の境界にあるツール間の footgun を、一発で確認できる Layer 2 の Docker 再現としてパッケージしたもの。",
       "homepage": "https://www.gnu.org/software/findutils/",
       "github": "https://git.savannah.gnu.org/cgit/findutils.git"
     },
@@ -62,7 +70,9 @@
       ],
       "page_url": "https://aletheia-works.github.io/vivarium/repro/flock/",
       "tagline": "util-linux flock(2) advisory locks.",
+      "tagline_ja": "util-linux の flock(2) advisory ロック。",
       "description": "Layer 2 reproductions demonstrating advisory-only lock semantics — non-flock-aware tools bypass the lock silently.",
+      "description_ja": "ロックが advisory でしかないことを示す Layer 2 の再現。flock を認識しないツールはロックを素通りする。",
       "homepage": "https://man7.org/linux/man-pages/man2/flock.2.html",
       "github": "https://github.com/util-linux/util-linux"
     },
@@ -75,7 +85,9 @@
       ],
       "page_url": "https://aletheia-works.github.io/vivarium/repro/lark/",
       "tagline": "Pure-Python parsing toolkit (LALR / Earley / CYK).",
+      "tagline_ja": "純 Python の構文解析ツールキット (LALR / Earley / CYK)。",
       "description": "Grammar-engine bugs that survive when lark is installed into Pyodide via micropip. Layer 1 recipes that involve hangs (e.g. LALR-construction infinite loops) run inside a Web Worker so the page can hard-terminate the worker on budget overrun without freezing the visitor's tab.",
+      "description_ja": "micropip 経由で Pyodide に lark を入れても残る、文法エンジンの bug。",
       "homepage": "https://lark-parser.readthedocs.io/",
       "github": "https://github.com/lark-parser/lark"
     },
@@ -88,7 +100,9 @@
       ],
       "page_url": "https://aletheia-works.github.io/vivarium/repro/numpy/",
       "tagline": "Array programming in Python.",
+      "tagline_ja": "Python の配列プログラミング。",
       "description": "Bugs in numeric or temporal semantics that survive when numpy is loaded inside Pyodide. The browser page and the host-Python repro.py share the exact same script.",
+      "description_ja": "Pyodide 内に numpy を読み込んでも残る、数値や時間の意味論の bug。ブラウザページと host Python 用の repro.py はまったく同じスクリプトを共有する。",
       "homepage": "https://numpy.org/",
       "github": "https://github.com/numpy/numpy"
     },
@@ -101,7 +115,9 @@
       ],
       "page_url": "https://aletheia-works.github.io/vivarium/repro/pandas/",
       "tagline": "DataFrames for Python.",
+      "tagline_ja": "Python の DataFrame。",
       "description": "Empty / dtype-edge regressions that reproduce against the pandas wheel bundled with Pyodide; the same script also runs against host pandas via uv.",
+      "description_ja": "Pyodide に同梱される pandas wheel で再現する、空データや dtype の境界での regression。同じスクリプトは uv 経由で host の pandas でも走る。",
       "homepage": "https://pandas.pydata.org/",
       "github": "https://github.com/pandas-dev/pandas"
     },
@@ -114,7 +130,9 @@
       ],
       "page_url": "https://aletheia-works.github.io/vivarium/repro/php/",
       "tagline": "PHP runtime and standard extensions.",
+      "tagline_ja": "PHP の runtime と標準拡張。",
       "description": "Reproductions execute under php-wasm; host parity via mise-pinned php running the same repro.php.",
+      "description_ja": "再現は php-wasm 上で実行される。host 側の等価性は mise で版を固定した php が同じ repro.php を実行することで担保する。",
       "homepage": "https://www.php.net/",
       "github": "https://github.com/php/php-src"
     },
@@ -127,7 +145,9 @@
       ],
       "page_url": "https://aletheia-works.github.io/vivarium/repro/postgres/",
       "tagline": "PostgreSQL transaction and isolation-level semantics.",
+      "tagline_ja": "PostgreSQL のトランザクションと分離レベルの意味論。",
       "description": "Layer 2 Docker reproductions targeting documented (but easily-missed) behaviours under default isolation levels.",
+      "description_ja": "既定の分離レベル下で文書化されてはいるが見落としやすい挙動を狙った Layer 2 の Docker 再現。",
       "homepage": "https://www.postgresql.org/",
       "github": "https://github.com/postgres/postgres"
     },
@@ -140,7 +160,9 @@
       ],
       "page_url": "https://aletheia-works.github.io/vivarium/repro/pthread/",
       "tagline": "Native pthread races, captured deterministically.",
+      "tagline_ja": "ネイティブな pthread の race を決定的に捕まえる。",
       "description": "Layer 3 record-replay reproductions: a real pthreaded program is run under rr, the recorded trace ships in the image, and replay produces a bit-identical verdict every time.",
+      "description_ja": "Layer 3 の record-replay 再現。実際に pthread を使うプログラムを rr の下で走らせ、記録したトレースを配布する。",
       "homepage": "https://man7.org/linux/man-pages/man7/pthreads.7.html",
       "github": "https://github.com/rr-debugger/rr"
     },
@@ -153,7 +175,9 @@
       ],
       "page_url": "https://aletheia-works.github.io/vivarium/repro/regex/",
       "tagline": "Rust's standard regex crate.",
+      "tagline_ja": "Rust の標準的な regex crate。",
       "description": "Compiled to wasm32-wasip1 with a pinned crate version, so verdicts flip when the upstream fix lands in a future regex release — turning the page into a fix-detection sentinel.",
+      "description_ja": "crate の版を固定して wasm32-wasip1 にコンパイルしてあるため、upstream の fix が将来の regex リリースに入ると verdict が反転する——ページ自体が fix 検知のセンサーになる。",
       "homepage": "https://docs.rs/regex/",
       "github": "https://github.com/rust-lang/regex"
     },
@@ -166,7 +190,9 @@
       ],
       "page_url": "https://aletheia-works.github.io/vivarium/repro/ruby/",
       "tagline": "Ruby standard library and language semantics.",
+      "tagline_ja": "Ruby の標準ライブラリと言語仕様。",
       "description": "Reproductions run on ruby.wasm (CRuby compiled to WASI). Host parity is provided by mise-pinned ruby for the repro.rb script.",
+      "description_ja": "再現は ruby.wasm (WASI 向けにコンパイルした CRuby) で走る。host 側の等価性は mise で版を固定した ruby が repro.rb を実行することで担保する。",
       "homepage": "https://www.ruby-lang.org/",
       "github": "https://github.com/ruby/ruby"
     }

--- a/docs/site/public/api/recipes.json
+++ b/docs/site/public/api/recipes.json
@@ -20,7 +20,8 @@
       "symptom": "fk-pragma-silently-dropped",
       "severity": "spec-violation",
       "expected_verdict": "reproduced",
-      "expected_runtime": "pyodide"
+      "expected_runtime": "pyodide",
+      "page_url_ja": "https://aletheia-works.github.io/vivarium/ja/repro/cpython/137205/"
     },
     {
       "slug": "dateutil-1478",
@@ -42,6 +43,7 @@
       "severity": "bug",
       "expected_verdict": "reproduced",
       "expected_runtime": "pyodide",
+      "page_url_ja": "https://aletheia-works.github.io/vivarium/ja/repro/dateutil/1478/",
       "roundtrip": {
         "schema_version": 1,
         "slug": "dateutil-1478",
@@ -82,6 +84,7 @@
       "severity": "bug",
       "expected_verdict": "reproduced",
       "expected_runtime": "pyodide",
+      "page_url_ja": "https://aletheia-works.github.io/vivarium/ja/repro/lark/1585/",
       "roundtrip": {
         "schema_version": 1,
         "slug": "lark-1585",
@@ -118,7 +121,8 @@
       "symptom": "ordering-non-transitive",
       "severity": "bug",
       "expected_verdict": "reproduced",
-      "expected_runtime": "pyodide"
+      "expected_runtime": "pyodide",
+      "page_url_ja": "https://aletheia-works.github.io/vivarium/ja/repro/numpy/28287/"
     },
     {
       "slug": "pandas-56679",
@@ -137,7 +141,8 @@
       "symptom": "dtype-mismatch",
       "severity": "regression",
       "expected_verdict": "reproduced",
-      "expected_runtime": "pyodide"
+      "expected_runtime": "pyodide",
+      "page_url_ja": "https://aletheia-works.github.io/vivarium/ja/repro/pandas/56679/"
     },
     {
       "slug": "php-12167",
@@ -155,7 +160,8 @@
       "symptom": "json-encode-recursion",
       "severity": "bug",
       "expected_verdict": "reproduced",
-      "expected_runtime": "php-wasm"
+      "expected_runtime": "php-wasm",
+      "page_url_ja": "https://aletheia-works.github.io/vivarium/ja/repro/php/12167/"
     },
     {
       "slug": "regex-779",
@@ -173,7 +179,8 @@
       "symptom": "regex-engine-edge-case",
       "severity": "bug",
       "expected_verdict": "reproduced",
-      "expected_runtime": "rust-wasi"
+      "expected_runtime": "rust-wasi",
+      "page_url_ja": "https://aletheia-works.github.io/vivarium/ja/repro/regex/779/"
     },
     {
       "slug": "ruby-21709",
@@ -192,7 +199,8 @@
       "symptom": "unicode-normalize-nfd",
       "severity": "bug",
       "expected_verdict": "reproduced",
-      "expected_runtime": "ruby.wasm"
+      "expected_runtime": "ruby.wasm",
+      "page_url_ja": "https://aletheia-works.github.io/vivarium/ja/repro/ruby/21709/"
     },
     {
       "slug": "bash-local-shadows-exit",
@@ -234,6 +242,7 @@
       "severity": "footgun",
       "expected_verdict": "reproduced",
       "expected_runtime": "docker-snapshot",
+      "page_url_ja": "https://aletheia-works.github.io/vivarium/ja/repro/find/xargs-whitespace/",
       "verdict_url": "https://aletheia-works.github.io/vivarium/repro/find/xargs-whitespace/verdict.json"
     },
     {
@@ -254,6 +263,7 @@
       "severity": "spec-violation",
       "expected_verdict": "reproduced",
       "expected_runtime": "docker-snapshot",
+      "page_url_ja": "https://aletheia-works.github.io/vivarium/ja/repro/flock/is-advisory/",
       "verdict_url": "https://aletheia-works.github.io/vivarium/repro/flock/is-advisory/verdict.json"
     },
     {
@@ -274,6 +284,7 @@
       "severity": "datarace",
       "expected_verdict": "reproduced",
       "expected_runtime": "docker-snapshot",
+      "page_url_ja": "https://aletheia-works.github.io/vivarium/ja/repro/postgres/lost-update/",
       "verdict_url": "https://aletheia-works.github.io/vivarium/repro/postgres/lost-update/verdict.json"
     },
     {

--- a/src/layer1_wasm/cpython-137205/i18n.ja.json
+++ b/src/layer1_wasm/cpython-137205/i18n.ja.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "lang": "ja",
+  "slug": "cpython-137205",
+  "strings": {
+    "drawer.eyebrow": "// BUG CONTEXT",
+    "drawer.heading": "このページが存在する理由",
+    "drawer.meta.k1": "プロジェクト",
+    "drawer.meta.k2": "Issue",
+    "drawer.meta.k3": "レイヤ",
+    "drawer.meta.layer": "L1 · WASM",
+    "drawer.meta.k4": "ランタイム",
+    "page.h1": "{0} の再現",
+    "chip.bugContext": "{0} bug の背景",
+    "section.script.h2": "再現スクリプト",
+    "section.output.h2": "出力",
+    "output.placeholder": "(実行中)",
+    "page.title": "Vivarium · python/cpython#137205 の再現",
+    "verdict.pending": "Pyodide runtime を読み込み中…",
+    "drawer.body.p1": "Python の {0} は、{2} で開いた接続では {1} を黙って捨てる。{3} で開いた別の接続では同じ PRAGMA が効くため、本来同じ FK 強制になるはずの 2 つの接続が食い違う。",
+    "drawer.body.p2": "このページのスクリプトは両方の接続を開き、それぞれに同じ PRAGMA を発行して、結果の {0} を読み戻す。2 つの値が食い違えば、いま開いているタブの runtime で bug が再現している。",
+    "drawer.body.p3": "議論の全体（動機、再現のバリエーション、パッチの進捗など）は下の GitHub issue リンクを辿る。そのスレッドがこの bug の正典。"
+  }
+}

--- a/src/layer1_wasm/cpython-137205/index.html
+++ b/src/layer1_wasm/cpython-137205/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="vivarium-contract" content="v1" />
-    <title>Vivarium · Reproducing python/cpython#137205</title>
+    <title data-i18n="page.title">Vivarium · Reproducing python/cpython#137205</title>
     <!-- vivarium-chrome-injected -->
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
     <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.asm.wasm" as="fetch" type="application/wasm" crossorigin />
@@ -20,10 +20,10 @@
     />
     <link rel="stylesheet" href="../_shared/style.css" />
     <template id="bug-context">
-      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
-      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
       <div class="vh-drawer__body" id="vh-drawer-body">
-        <p>
+        <p data-i18n="drawer.body.p1">
           Python's <code>sqlite3</code> stdlib silently drops
           <code>PRAGMA foreign_keys = ON</code> when the connection
           was opened with <code>autocommit=False</code>. The same
@@ -32,14 +32,14 @@
           connections that should have identical FK enforcement
           disagree.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p2">
           The script on this page opens both kinds of connection,
           issues the same PRAGMA on each, and reads the resulting
           <code>foreign_keys</code> value back. If the two values
           disagree, the bug reproduces in the runtime currently
           loaded in your browser tab.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p3">
           For the full discussion (motivation, repro variations,
           patch progress, etc.), follow the GitHub issue link
           below — that thread is the canonical home for this bug.
@@ -47,13 +47,13 @@
       </div>
       <hr class="vh-drawer__divider" />
       <div class="vh-drawer__meta-grid">
-        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k1">Project</span>
         <span class="vh-drawer__meta-val">python/cpython</span>
-        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k2">Issue</span>
         <span class="vh-drawer__meta-val">#137205</span>
-        <span class="vh-drawer__meta-key">Layer</span>
-        <span class="vh-drawer__meta-val">L1 · WASM</span>
-        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k3">Layer</span>
+        <span class="vh-drawer__meta-val" data-i18n="drawer.meta.layer">L1 · WASM</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k4">Runtime</span>
         <span class="vh-drawer__meta-val">Pyodide v0.29.3</span>
       </div>
     </template>
@@ -63,16 +63,16 @@
       <header class="vh-main__header">
         <div class="vh-main__header-text">
           <p class="kicker">L1 · Pyodide · sqlite3</p>
-          <h1>Reproducing <a href="https://github.com/python/cpython/issues/137205" target="_blank" rel="noreferrer">python/cpython#137205</a></h1>
+          <h1 data-i18n="page.h1">Reproducing <a href="https://github.com/python/cpython/issues/137205" target="_blank" rel="noreferrer">python/cpython#137205</a></h1>
           <div class="vh-main__header-actions">
-            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer" data-i18n="chip.bugContext">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
               Bug context
             </button>
           </div>
         </div>
         <div class="vh-main__header-aside">
-          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite" data-i18n="verdict.pending">
             Loading Pyodide runtime…
           </div>
           <p class="meta" id="meta"></p>
@@ -81,7 +81,7 @@
 
       <div class="vh-main__cols">
         <section class="vh-main__col vh-main__col--script">
-          <h2>Reproduction script</h2>
+          <h2 data-i18n="section.script.h2">Reproduction script</h2>
           <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
 <span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sqlite3</span></span>
 <span class="line"></span>
@@ -105,8 +105,8 @@
         </section>
 
         <section class="vh-main__col vh-main__col--output">
-          <h2>Output</h2>
-          <pre id="output">(running)</pre>
+          <h2 data-i18n="section.output.h2">Output</h2>
+          <pre id="output" data-i18n="output.placeholder">(running)</pre>
         </section>
       </div>
 

--- a/src/layer1_wasm/dateutil-1478/i18n.ja.json
+++ b/src/layer1_wasm/dateutil-1478/i18n.ja.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "lang": "ja",
+  "slug": "dateutil-1478",
+  "strings": {
+    "drawer.eyebrow": "// BUG CONTEXT",
+    "drawer.heading": "このページが存在する理由",
+    "drawer.meta.k1": "プロジェクト",
+    "drawer.meta.k2": "Issue",
+    "drawer.meta.k3": "レイヤ",
+    "drawer.meta.layer": "L1 · WASM",
+    "drawer.meta.k4": "ランタイム",
+    "page.h1": "{0} の再現",
+    "chip.bugContext": "{0} bug の背景",
+    "section.script.h2": "再現スクリプト",
+    "page.title": "Vivarium · dateutil/dateutil#1478 の再現",
+    "verdict.pending": "Pyodide runtime を読み込み中…",
+    "drawer.body.p1": "{0} は、数値の UTC オフセットの直前に {1} という接頭辞が付いていると、その符号を反転させてしまう。",
+    "drawer.body.p2": "{0} は {1} を返す（期待値は {2}）、{3} は {4} を返す（期待値は {5}）。素の ISO 8601 形式（{8} 接頭辞のない {6} / {7}）は正しく parse されるので、この反転は {9} と符号付きオフセットの組み合わせの code path に限定される。",
+    "drawer.body.p3": "このページのスクリプトは 4 つの形（{0}、{1}、{2}、{3}）を試し、parse された {4} をそれぞれ期待値と比較する。",
+    "drawer.body.p4": "議論の全体（動機、経緯、fix の進捗）は下の GitHub issue スレッドにある。",
+    "drawer.body.p5": "fix 候補のブランチ（{0}）が {1} 配下の pure-Python wheel としてビルドされ、baseline の実行が終わったあとに同じ Pyodide タブへインストールされる。1 回のページ読み込みで before/after の verdict を比較できる。",
+    "chip.fixCandidate": "{0} fix 候補ブランチ",
+    "section.baseline.h2": "baseline の出力",
+    "output.pending": "(待機中)",
+    "section.fix.h2": "fix 候補の出力",
+    "output.waitingBaseline": "(baseline を待機中)"
+  }
+}

--- a/src/layer1_wasm/dateutil-1478/index.html
+++ b/src/layer1_wasm/dateutil-1478/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="vivarium-contract" content="v1" />
-    <title>Vivarium · Reproducing dateutil/dateutil#1478</title>
+    <title data-i18n="page.title">Vivarium · Reproducing dateutil/dateutil#1478</title>
     <!-- vivarium-chrome-injected -->
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
     <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.asm.wasm" as="fetch" type="application/wasm" crossorigin />
@@ -21,15 +21,15 @@
     />
     <link rel="stylesheet" href="../_shared/style.css" />
     <template id="bug-context">
-      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
-      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
       <div class="vh-drawer__body" id="vh-drawer-body">
-        <p>
+        <p data-i18n="drawer.body.p1">
           <code>dateutil.parser.parse</code> inverts the sign of a
           numeric UTC offset whenever the offset is preceded by the
           literal <code>UTC</code> prefix.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p2">
           <code>parse('2026-03-11 14:32:45 UTC-4')</code> returns
           <code>2026-03-11T14:32:45+04:00</code> (expected
           <code>-04:00</code>), and <code>parse('… UTC+4')</code>
@@ -39,18 +39,18 @@
           parse correctly, so the inversion is isolated to the
           <code>UTC</code> + signed-offset code path.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p3">
           The script on this page exercises four shapes
           (<code>UTC-4</code>, <code>UTC+4</code>,
           <code>UTC-04:00</code>, <code>UTC+04:00</code>) and
           compares each parsed <code>utcoffset()</code> against the
           expected value.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p4">
           The full discussion (motivation, history, fix progress)
           lives in the GitHub issue thread linked below.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p5">
           A fix-candidate branch
           (<code>JamBalaya56562/dateutil@fix-1478-utc-gmt-offset-sign</code>)
           is built into a pure-Python wheel under <code>./wheels/</code>
@@ -61,13 +61,13 @@
       </div>
       <hr class="vh-drawer__divider" />
       <div class="vh-drawer__meta-grid">
-        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k1">Project</span>
         <span class="vh-drawer__meta-val">dateutil/dateutil</span>
-        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k2">Issue</span>
         <span class="vh-drawer__meta-val">#1478</span>
-        <span class="vh-drawer__meta-key">Layer</span>
-        <span class="vh-drawer__meta-val">L1 · WASM</span>
-        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k3">Layer</span>
+        <span class="vh-drawer__meta-val" data-i18n="drawer.meta.layer">L1 · WASM</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k4">Runtime</span>
         <span class="vh-drawer__meta-val">Pyodide v0.29.3 + python-dateutil 2.9.0.post0 (micropip)</span>
       </div>
     </template>
@@ -77,20 +77,20 @@
       <header class="vh-main__header">
         <div class="vh-main__header-text">
           <p class="kicker">L1 · Pyodide</p>
-          <h1>Reproducing <a href="https://github.com/dateutil/dateutil/issues/1478" target="_blank" rel="noreferrer">dateutil/dateutil#1478</a></h1>
+          <h1 data-i18n="page.h1">Reproducing <a href="https://github.com/dateutil/dateutil/issues/1478" target="_blank" rel="noreferrer">dateutil/dateutil#1478</a></h1>
           <div class="vh-main__header-actions">
-            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer" data-i18n="chip.bugContext">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
               Bug context
             </button>
-            <a class="vh-chip" href="https://github.com/JamBalaya56562/dateutil/tree/fix-1478-utc-gmt-offset-sign" target="_blank" rel="noreferrer">
+            <a class="vh-chip" href="https://github.com/JamBalaya56562/dateutil/tree/fix-1478-utc-gmt-offset-sign" target="_blank" rel="noreferrer" data-i18n="chip.fixCandidate">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><line x1="6" y1="9" x2="6" y2="21"/></svg>
               Fix candidate branch
             </a>
           </div>
         </div>
         <div class="vh-main__header-aside">
-          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite" data-i18n="verdict.pending">
             Loading Pyodide runtime…
           </div>
           <p class="meta" id="meta"></p>
@@ -99,7 +99,7 @@
 
       <div class="vh-main__cols">
         <section class="vh-main__col vh-main__col--script">
-          <h2>Reproduction script</h2>
+          <h2 data-i18n="section.script.h2">Reproduction script</h2>
           <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
 <span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> dateutil</span></span>
 <span class="line"><span style="color:#F97583">from</span><span style="color:#E1E4E8"> dateutil.parser </span><span style="color:#F97583">import</span><span style="color:#E1E4E8"> parse</span></span>
@@ -136,20 +136,20 @@
 
         <section class="vh-main__col vh-main__col--output vh-output-multi">
           <header class="vh-variant-head" data-variant="baseline">
-            <h2 class="vh-variant-head__title">Baseline output</h2>
+            <h2 class="vh-variant-head__title" data-i18n="section.baseline.h2">Baseline output</h2>
           </header>
           <div class="vh-variant-stage" data-variant="baseline">
             <!-- chrome.js inserts <div class="vh-progress"> before #output;
                  the stage stacks both children in one grid cell so the
                  overlay covers the pre during loading without taking
                  extra column height. -->
-            <pre id="output" class="vh-variant-output">(pending)</pre>
+            <pre id="output" class="vh-variant-output" data-i18n="output.pending">(pending)</pre>
           </div>
 
           <header class="vh-variant-head vh-variant-head--secondary" data-variant="fix-candidate">
-            <h2 class="vh-variant-head__title">Fix-candidate output</h2>
+            <h2 class="vh-variant-head__title" data-i18n="section.fix.h2">Fix-candidate output</h2>
           </header>
-          <pre id="output-fix" class="vh-variant-output">(waiting for baseline)</pre>
+          <pre id="output-fix" class="vh-variant-output" data-i18n="output.waitingBaseline">(waiting for baseline)</pre>
         </section>
       </div>
 

--- a/src/layer1_wasm/lark-1585/i18n.ja.json
+++ b/src/layer1_wasm/lark-1585/i18n.ja.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "lang": "ja",
+  "slug": "lark-1585",
+  "strings": {
+    "drawer.eyebrow": "// BUG CONTEXT",
+    "drawer.heading": "このページが存在する理由",
+    "drawer.meta.k1": "プロジェクト",
+    "drawer.meta.k2": "Issue",
+    "drawer.meta.k3": "レイヤ",
+    "drawer.meta.layer": "L1 · WASM",
+    "drawer.meta.k4": "ランタイム",
+    "page.h1": "{0} の再現",
+    "chip.bugContext": "{0} bug の背景",
+    "section.script.h2": "再現スクリプト",
+    "page.title": "Vivarium · lark-parser/lark#1585 の再現",
+    "verdict.pending": "Pyodide runtime を読み込み中…",
+    "drawer.body.p1": "lark の文法 {0} は、{1} を要求すると lark の LALR バックエンド（および CYK）を無限ループに陥らせる。Earley は正常に終了する。{3} への {2} 優先度が無いと lark は代わりに {4} を送出するので、優先度と再帰的な alt の組み合わせだけが hang を引き起こす。",
+    "drawer.body.p2": "この bug は誤った結果ではなく hang なので、このページは Pyodide と lark を Web Worker 内で走らせ、メインスレッドが実時間の予算を課す。worker が時間内に結果を返さなければ verdict は {0} となり worker は終了させられる。予算内に parse が返るか例外を送出すれば verdict は {1} になる。",
+    "drawer.body.p3": "議論の全体は下の GitHub issue スレッドにある。",
+    "drawer.body.p4": "fix 候補のブランチ（{0}）が {1} 配下の pure-Python wheel としてビルドされ、baseline の実行が終わったあとに 2 つ目の Pyodide worker へインストールされる。1 回のページ読み込みで before/after の verdict を比較できる。",
+    "chip.fixCandidate": "{0} fix 候補ブランチ",
+    "section.baseline.h2": "baseline の出力",
+    "output.pending": "(待機中)",
+    "section.fix.h2": "fix 候補の出力",
+    "output.waitingBaseline": "(baseline を待機中)"
+  }
+}

--- a/src/layer1_wasm/lark-1585/index.html
+++ b/src/layer1_wasm/lark-1585/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="vivarium-contract" content="v1" />
-    <title>Vivarium · Reproducing lark-parser/lark#1585</title>
+    <title data-i18n="page.title">Vivarium · Reproducing lark-parser/lark#1585</title>
     <!-- vivarium-chrome-injected -->
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
     <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.asm.wasm" as="fetch" type="application/wasm" crossorigin />
@@ -21,10 +21,10 @@
     />
     <link rel="stylesheet" href="../_shared/style.css" />
     <template id="bug-context">
-      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
-      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
       <div class="vh-drawer__body" id="vh-drawer-body">
-        <p>
+        <p data-i18n="drawer.body.p1">
           The lark grammar <code>start.1: "a" | start start*</code>
           causes lark's LALR back-end (and CYK) to enter an infinite
           loop when <code>parser='lalr'</code> is requested. Earley
@@ -33,7 +33,7 @@
           instead — only the priority-plus-recursive-alt combination
           triggers the hang.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p2">
           Because the bug is a hang rather than a wrong result,
           this page runs Pyodide + lark inside a Web Worker and the
           main thread imposes a wall-clock budget. If the worker
@@ -42,11 +42,11 @@
           the parse returns or raises before the budget elapses,
           the verdict is <code>unreproduced</code>.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p3">
           The full discussion lives in the GitHub issue thread
           linked below.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p4">
           A fix-candidate branch
           (<code>JamBalaya56562/lark@claude/fix-lark-1585-QLVa7</code>)
           is built into a pure-Python wheel under <code>./wheels/</code>
@@ -57,13 +57,13 @@
       </div>
       <hr class="vh-drawer__divider" />
       <div class="vh-drawer__meta-grid">
-        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k1">Project</span>
         <span class="vh-drawer__meta-val">lark-parser/lark</span>
-        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k2">Issue</span>
         <span class="vh-drawer__meta-val">#1585</span>
-        <span class="vh-drawer__meta-key">Layer</span>
-        <span class="vh-drawer__meta-val">L1 · WASM</span>
-        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k3">Layer</span>
+        <span class="vh-drawer__meta-val" data-i18n="drawer.meta.layer">L1 · WASM</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k4">Runtime</span>
         <span class="vh-drawer__meta-val">Pyodide v0.29.3 + lark 1.3.1 (micropip, inside a Web Worker)</span>
       </div>
     </template>
@@ -73,20 +73,20 @@
       <header class="vh-main__header">
         <div class="vh-main__header-text">
           <p class="kicker">L1 · Pyodide</p>
-          <h1>Reproducing <a href="https://github.com/lark-parser/lark/issues/1585" target="_blank" rel="noreferrer">lark-parser/lark#1585</a></h1>
+          <h1 data-i18n="page.h1">Reproducing <a href="https://github.com/lark-parser/lark/issues/1585" target="_blank" rel="noreferrer">lark-parser/lark#1585</a></h1>
           <div class="vh-main__header-actions">
-            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer" data-i18n="chip.bugContext">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
               Bug context
             </button>
-            <a class="vh-chip" href="https://github.com/JamBalaya56562/lark/tree/claude/fix-lark-1585-QLVa7" target="_blank" rel="noreferrer">
+            <a class="vh-chip" href="https://github.com/JamBalaya56562/lark/tree/claude/fix-lark-1585-QLVa7" target="_blank" rel="noreferrer" data-i18n="chip.fixCandidate">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><line x1="6" y1="9" x2="6" y2="21"/></svg>
               Fix candidate branch
             </a>
           </div>
         </div>
         <div class="vh-main__header-aside">
-          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite" data-i18n="verdict.pending">
             Loading Pyodide runtime…
           </div>
           <p class="meta" id="meta"></p>
@@ -95,26 +95,26 @@
 
       <div class="vh-main__cols">
         <section class="vh-main__col vh-main__col--script">
-          <h2>Reproduction script</h2>
+          <h2 data-i18n="section.script.h2">Reproduction script</h2>
           <pre><code id="repro-code"><span class="line"><span style="color:#E1E4E8">Lark(</span><span style="color:#9ECBFF">'start.1: "a" | start start*'</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">parser</span><span style="color:#F97583">=</span><span style="color:#9ECBFF">'lalr'</span><span style="color:#E1E4E8">).parse(</span><span style="color:#9ECBFF">'aa'</span><span style="color:#E1E4E8">)</span></span></code></pre>
         </section>
 
         <section class="vh-main__col vh-main__col--output vh-output-multi">
           <header class="vh-variant-head" data-variant="baseline">
-            <h2 class="vh-variant-head__title">Baseline output</h2>
+            <h2 class="vh-variant-head__title" data-i18n="section.baseline.h2">Baseline output</h2>
           </header>
           <div class="vh-variant-stage" data-variant="baseline">
             <!-- chrome.js inserts <div class="vh-progress"> before #output;
                  the stage stacks both children in one grid cell so the
                  overlay covers the pre during loading without taking
                  extra column height. -->
-            <pre id="output" class="vh-variant-output">(pending)</pre>
+            <pre id="output" class="vh-variant-output" data-i18n="output.pending">(pending)</pre>
           </div>
 
           <header class="vh-variant-head vh-variant-head--secondary" data-variant="fix-candidate">
-            <h2 class="vh-variant-head__title">Fix-candidate output</h2>
+            <h2 class="vh-variant-head__title" data-i18n="section.fix.h2">Fix-candidate output</h2>
           </header>
-          <pre id="output-fix" class="vh-variant-output">(waiting for baseline)</pre>
+          <pre id="output-fix" class="vh-variant-output" data-i18n="output.waitingBaseline">(waiting for baseline)</pre>
         </section>
       </div>
 

--- a/src/layer1_wasm/numpy-28287/i18n.ja.json
+++ b/src/layer1_wasm/numpy-28287/i18n.ja.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "lang": "ja",
+  "slug": "numpy-28287",
+  "strings": {
+    "drawer.eyebrow": "// BUG CONTEXT",
+    "drawer.heading": "このページが存在する理由",
+    "drawer.meta.k1": "プロジェクト",
+    "drawer.meta.k2": "Issue",
+    "drawer.meta.k3": "レイヤ",
+    "drawer.meta.layer": "L1 · WASM",
+    "drawer.meta.k4": "ランタイム",
+    "page.h1": "{0} の再現",
+    "chip.bugContext": "{0} bug の背景",
+    "section.script.h2": "再現スクリプト",
+    "section.output.h2": "出力",
+    "output.placeholder": "(実行中)",
+    "page.title": "Vivarium · numpy/numpy#28287 の再現",
+    "verdict.pending": "Pyodide runtime を読み込み中…",
+    "drawer.body.p1": "NumPy の {0} の順序付けは、値のひとつが {1} 単位を使っていると推移的でなくなる。{2}、{3}、{4} に対して NumPy は {5} と {6} を報告するのに {7} となる——組み込みの比較演算子における推移律の違反。",
+    "drawer.body.p2": "このページのスクリプトはその 3 つの値を構築し、3 通りの pairwise 比較をすべて実行して、合成条件（{0} かつ {1} かつ {2}）が成り立つかを報告する。成り立てば、Pyodide が現在同梱する NumPy ビルドで bug が再現している。",
+    "drawer.body.p3": "議論の全体（動機、再現のバリエーション、fix の進捗）は下の GitHub issue スレッドにある。"
+  }
+}

--- a/src/layer1_wasm/numpy-28287/index.html
+++ b/src/layer1_wasm/numpy-28287/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="vivarium-contract" content="v1" />
-    <title>Vivarium · Reproducing numpy/numpy#28287</title>
+    <title data-i18n="page.title">Vivarium · Reproducing numpy/numpy#28287</title>
     <!-- vivarium-chrome-injected -->
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
     <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.asm.wasm" as="fetch" type="application/wasm" crossorigin />
@@ -21,10 +21,10 @@
     />
     <link rel="stylesheet" href="../_shared/style.css" />
     <template id="bug-context">
-      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
-      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
       <div class="vh-drawer__body" id="vh-drawer-body">
-        <p>
+        <p data-i18n="drawer.body.p1">
           NumPy's <code>timedelta64</code> ordering is non-transitive
           when one of the values uses the <em>generic</em> unit. With
           <code>x = 1&nbsp;ms</code>, <code>y = 2 (generic)</code>, and
@@ -33,27 +33,27 @@
           <code>x &gt; z</code> — a transitivity violation in a
           built-in comparison operator.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p2">
           The script on this page constructs those three values, runs
           all three pairwise comparisons, and reports whether the
           composite (<code>x &lt; y</code> AND <code>y &lt; z</code>
           AND <code>x &gt; z</code>) holds. If it does, the bug
           reproduces in the NumPy build Pyodide currently ships.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p3">
           The full discussion (motivation, repro variations, fix
           progress) lives in the GitHub issue thread linked below.
         </p>
       </div>
       <hr class="vh-drawer__divider" />
       <div class="vh-drawer__meta-grid">
-        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k1">Project</span>
         <span class="vh-drawer__meta-val">numpy/numpy</span>
-        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k2">Issue</span>
         <span class="vh-drawer__meta-val">#28287</span>
-        <span class="vh-drawer__meta-key">Layer</span>
-        <span class="vh-drawer__meta-val">L1 · WASM</span>
-        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k3">Layer</span>
+        <span class="vh-drawer__meta-val" data-i18n="drawer.meta.layer">L1 · WASM</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k4">Runtime</span>
         <span class="vh-drawer__meta-val">Pyodide v0.29.3</span>
       </div>
     </template>
@@ -63,16 +63,16 @@
       <header class="vh-main__header">
         <div class="vh-main__header-text">
           <p class="kicker">L1 · Pyodide</p>
-          <h1>Reproducing <a href="https://github.com/numpy/numpy/issues/28287" target="_blank" rel="noreferrer">numpy/numpy#28287</a></h1>
+          <h1 data-i18n="page.h1">Reproducing <a href="https://github.com/numpy/numpy/issues/28287" target="_blank" rel="noreferrer">numpy/numpy#28287</a></h1>
           <div class="vh-main__header-actions">
-            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer" data-i18n="chip.bugContext">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
               Bug context
             </button>
           </div>
         </div>
         <div class="vh-main__header-aside">
-          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite" data-i18n="verdict.pending">
             Loading Pyodide runtime…
           </div>
           <p class="meta" id="meta"></p>
@@ -81,7 +81,7 @@
 
       <div class="vh-main__cols">
         <section class="vh-main__col vh-main__col--script">
-          <h2>Reproduction script</h2>
+          <h2 data-i18n="section.script.h2">Reproduction script</h2>
           <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
 <span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> numpy </span><span style="color:#F97583">as</span><span style="color:#E1E4E8"> np</span></span>
 <span class="line"></span>
@@ -104,8 +104,8 @@
         </section>
 
         <section class="vh-main__col vh-main__col--output">
-          <h2>Output</h2>
-          <pre id="output">(running)</pre>
+          <h2 data-i18n="section.output.h2">Output</h2>
+          <pre id="output" data-i18n="output.placeholder">(running)</pre>
         </section>
       </div>
 

--- a/src/layer1_wasm/pandas-56679/i18n.ja.json
+++ b/src/layer1_wasm/pandas-56679/i18n.ja.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "lang": "ja",
+  "slug": "pandas-56679",
+  "strings": {
+    "drawer.eyebrow": "// BUG CONTEXT",
+    "drawer.heading": "このページが存在する理由",
+    "drawer.meta.k1": "プロジェクト",
+    "drawer.meta.k2": "Issue",
+    "drawer.meta.k3": "レイヤ",
+    "drawer.meta.layer": "L1 · WASM",
+    "drawer.meta.k4": "ランタイム",
+    "page.h1": "{0} の再現",
+    "chip.bugContext": "{0} bug の背景",
+    "section.script.h2": "再現スクリプト",
+    "section.output.h2": "出力",
+    "output.placeholder": "(実行中)",
+    "page.title": "Vivarium · pandas-dev/pandas#56679 の再現",
+    "verdict.pending": "Pyodide runtime を読み込み中…",
+    "drawer.body.p1": "{0} は dtype {1} を返すのに、{2} は dtype {3} を返す。この 2 つのコンストラクタは、空の入力に対して一貫した dtype を返すべき。",
+    "drawer.body.p2": "このページのスクリプトは両方の形を構築して dtype を比較する。dtype が食い違えば、Pyodide が現在同梱する pandas ビルドで bug が再現している。",
+    "drawer.body.p3": "議論の全体（動機、経緯、fix の進捗）は下の GitHub issue スレッドにある。"
+  }
+}

--- a/src/layer1_wasm/pandas-56679/index.html
+++ b/src/layer1_wasm/pandas-56679/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="vivarium-contract" content="v1" />
-    <title>Vivarium · Reproducing pandas-dev/pandas#56679</title>
+    <title data-i18n="page.title">Vivarium · Reproducing pandas-dev/pandas#56679</title>
     <!-- vivarium-chrome-injected -->
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
     <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.asm.wasm" as="fetch" type="application/wasm" crossorigin />
@@ -21,34 +21,34 @@
     />
     <link rel="stylesheet" href="../_shared/style.css" />
     <template id="bug-context">
-      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
-      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
       <div class="vh-drawer__body" id="vh-drawer-body">
-        <p>
+        <p data-i18n="drawer.body.p1">
           <code>pd.Series([])</code> returns dtype <code>object</code>,
           but <code>pd.DataFrame({'a': []})['a']</code> returns dtype
           <code>float64</code>. The two constructors should produce a
           consistent dtype for an empty input.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p2">
           The script on this page constructs both shapes and compares
           their dtypes. If the dtypes differ, the bug reproduces in
           the pandas build Pyodide currently ships.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p3">
           The full discussion (motivation, history, fix progress)
           lives in the GitHub issue thread linked below.
         </p>
       </div>
       <hr class="vh-drawer__divider" />
       <div class="vh-drawer__meta-grid">
-        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k1">Project</span>
         <span class="vh-drawer__meta-val">pandas-dev/pandas</span>
-        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k2">Issue</span>
         <span class="vh-drawer__meta-val">#56679</span>
-        <span class="vh-drawer__meta-key">Layer</span>
-        <span class="vh-drawer__meta-val">L1 · WASM</span>
-        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k3">Layer</span>
+        <span class="vh-drawer__meta-val" data-i18n="drawer.meta.layer">L1 · WASM</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k4">Runtime</span>
         <span class="vh-drawer__meta-val">Pyodide v0.29.3</span>
       </div>
     </template>
@@ -58,16 +58,16 @@
       <header class="vh-main__header">
         <div class="vh-main__header-text">
           <p class="kicker">L1 · Pyodide</p>
-          <h1>Reproducing <a href="https://github.com/pandas-dev/pandas/issues/56679" target="_blank" rel="noreferrer">pandas-dev/pandas#56679</a></h1>
+          <h1 data-i18n="page.h1">Reproducing <a href="https://github.com/pandas-dev/pandas/issues/56679" target="_blank" rel="noreferrer">pandas-dev/pandas#56679</a></h1>
           <div class="vh-main__header-actions">
-            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer" data-i18n="chip.bugContext">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
               Bug context
             </button>
           </div>
         </div>
         <div class="vh-main__header-aside">
-          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite" data-i18n="verdict.pending">
             Loading Pyodide runtime…
           </div>
           <p class="meta" id="meta"></p>
@@ -76,7 +76,7 @@
 
       <div class="vh-main__cols">
         <section class="vh-main__col vh-main__col--script">
-          <h2>Reproduction script</h2>
+          <h2 data-i18n="section.script.h2">Reproduction script</h2>
           <pre><code id="repro-code"><span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> sys</span></span>
 <span class="line"><span style="color:#F97583">import</span><span style="color:#E1E4E8"> pandas </span><span style="color:#F97583">as</span><span style="color:#E1E4E8"> pd</span></span>
 <span class="line"></span>
@@ -93,8 +93,8 @@
         </section>
 
         <section class="vh-main__col vh-main__col--output">
-          <h2>Output</h2>
-          <pre id="output">(running)</pre>
+          <h2 data-i18n="section.output.h2">Output</h2>
+          <pre id="output" data-i18n="output.placeholder">(running)</pre>
         </section>
       </div>
 

--- a/src/layer1_wasm/php-12167/i18n.ja.json
+++ b/src/layer1_wasm/php-12167/i18n.ja.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "lang": "ja",
+  "slug": "php-12167",
+  "strings": {
+    "drawer.eyebrow": "// BUG CONTEXT",
+    "drawer.heading": "このページが存在する理由",
+    "drawer.meta.k1": "プロジェクト",
+    "drawer.meta.k2": "Issue",
+    "drawer.meta.k3": "レイヤ",
+    "drawer.meta.layer": "L1 · WASM",
+    "drawer.meta.k4": "ランタイム",
+    "page.h1": "{0} の再現",
+    "chip.bugContext": "{0} bug の背景",
+    "section.script.h2": "再現スクリプト",
+    "section.output.h2": "出力",
+    "output.placeholder": "(実行中)",
+    "page.title": "Vivarium · php/php-src#12167 の再現",
+    "verdict.pending": "php-wasm runtime を読み込み中…",
+    "drawer.body.p1": "PHP の SimpleXML は {0} で processing-instruction ノードを見つけられるが、そのノードを文字列にキャストすると PI の内容ではなく空の値になる。xpath はノードを返しており件数も 1 なので、bug は processing-instruction ノードの文字列キャストの経路だけにある。",
+    "drawer.body.p2": "このページのスクリプトは processing instruction を 1 つ持つ小さな XML 文書を組み立て、xpath クエリを実行し、返ったノードを文字列にキャストして、件数とキャスト結果の両方を報告する。件数が {0} でキャスト結果が空なら、このページが読み込む php-wasm ビルドで bug が再現している。",
+    "drawer.body.p3": "このレシピは下に {0} パネルも備える。baseline の実行後、スクリプトの代替版（例えば AI が提案したユーザーランドの fix）をペーストして、同じブラウザ内 PHP runtime で再走させられる。bug 自体の議論は下の GitHub issue スレッドにある。"
+  }
+}

--- a/src/layer1_wasm/php-12167/index.html
+++ b/src/layer1_wasm/php-12167/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="vivarium-contract" content="v1" />
-    <title>Vivarium · Reproducing php/php-src#12167</title>
+    <title data-i18n="page.title">Vivarium · Reproducing php/php-src#12167</title>
     <!-- vivarium-chrome-injected -->
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
     <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.asm.wasm" as="fetch" type="application/wasm" crossorigin />
@@ -20,10 +20,10 @@
     />
     <link rel="stylesheet" href="../_shared/style.css" />
     <template id="bug-context">
-      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
-      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
       <div class="vh-drawer__body" id="vh-drawer-body">
-        <p>
+        <p data-i18n="drawer.body.p1">
           PHP's SimpleXML can find a processing-instruction node via
           <code>xpath("//processing-instruction()")</code>, but casting
           that node to string yields an empty value instead of the
@@ -31,7 +31,7 @@
           the bug is purely in the string-cast path for
           processing-instruction nodes.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p2">
           The script on this page builds a small XML document with one
           processing instruction, runs the xpath query, casts the
           returned node to string, and reports both the count and
@@ -39,7 +39,7 @@
           cast result is empty, the bug reproduces in the php-wasm
           build this page loads.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p3">
           This recipe also carries the <strong>"Try a fix"</strong>
           panel below. After the baseline run,
           you can paste an alternative version of the script
@@ -51,13 +51,13 @@
       </div>
       <hr class="vh-drawer__divider" />
       <div class="vh-drawer__meta-grid">
-        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k1">Project</span>
         <span class="vh-drawer__meta-val">php/php-src</span>
-        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k2">Issue</span>
         <span class="vh-drawer__meta-val">#12167</span>
-        <span class="vh-drawer__meta-key">Layer</span>
-        <span class="vh-drawer__meta-val">L1 · WASM</span>
-        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k3">Layer</span>
+        <span class="vh-drawer__meta-val" data-i18n="drawer.meta.layer">L1 · WASM</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k4">Runtime</span>
         <span class="vh-drawer__meta-val">php-wasm</span>
       </div>
     </template>
@@ -67,16 +67,16 @@
       <header class="vh-main__header">
         <div class="vh-main__header-text">
           <p class="kicker">L1 · php-wasm</p>
-          <h1>Reproducing <a href="https://github.com/php/php-src/issues/12167" target="_blank" rel="noreferrer">php/php-src#12167</a></h1>
+          <h1 data-i18n="page.h1">Reproducing <a href="https://github.com/php/php-src/issues/12167" target="_blank" rel="noreferrer">php/php-src#12167</a></h1>
           <div class="vh-main__header-actions">
-            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer" data-i18n="chip.bugContext">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
               Bug context
             </button>
           </div>
         </div>
         <div class="vh-main__header-aside">
-          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite" data-i18n="verdict.pending">
             Loading php-wasm runtime…
           </div>
           <p class="meta" id="meta"></p>
@@ -85,7 +85,7 @@
 
       <div class="vh-main__cols">
         <section class="vh-main__col vh-main__col--script">
-          <h2>Reproduction script</h2>
+          <h2 data-i18n="section.script.h2">Reproduction script</h2>
           <pre><code id="repro-code"><span class="line"><span style="color:#F97583">&#x3C;?</span><span style="color:#79B8FF">php</span></span>
 <span class="line"><span style="color:#E1E4E8">$xml </span><span style="color:#F97583">=</span><span style="color:#9ECBFF"> '&#x3C;?xml version="1.0"?>&#x3C;foo>&#x3C;bar>&#x3C;?stylesheet hello ?>&#x3C;/bar>&#x3C;/foo>'</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"><span style="color:#E1E4E8">$sxe </span><span style="color:#F97583">=</span><span style="color:#79B8FF"> simplexml_load_string</span><span style="color:#E1E4E8">($xml);</span></span>
@@ -101,8 +101,8 @@
         </section>
 
         <section class="vh-main__col vh-main__col--output">
-          <h2>Output</h2>
-          <pre id="output">(running)</pre>
+          <h2 data-i18n="section.output.h2">Output</h2>
+          <pre id="output" data-i18n="output.placeholder">(running)</pre>
         </section>
       </div>
 

--- a/src/layer1_wasm/regex-779/i18n.ja.json
+++ b/src/layer1_wasm/regex-779/i18n.ja.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "lang": "ja",
+  "slug": "regex-779",
+  "strings": {
+    "drawer.eyebrow": "// BUG CONTEXT",
+    "drawer.heading": "このページが存在する理由",
+    "drawer.meta.k1": "プロジェクト",
+    "drawer.meta.k2": "Issue",
+    "drawer.meta.k3": "レイヤ",
+    "drawer.meta.layer": "L1 · WASM",
+    "drawer.meta.k4": "ランタイム",
+    "page.h1": "{0} の再現",
+    "chip.bugContext": "{0} bug の背景",
+    "section.script.h2": "再現スクリプト (Rust)",
+    "section.output.h2": "出力",
+    "output.placeholder": "(実行中)",
+    "page.title": "Vivarium · rust-lang/regex#779 の再現",
+    "verdict.pending": "WASI shim 経由で Rust wasm32-wasip1 の成果物を読み込み中…",
+    "drawer.body.p1": "Rust の {0} crate は基本的な正規表現の代数則を破っている。{1} は {2} と等しいはずだが、haystack {4} に対する {3} では等価なはずの 2 つの形が異なるマッチ列挙結果を返す。RE2 と Go の regexp にも同じ乖離があり、PCRE2 は正しく扱う。つまり正規表現言語の曖昧さではなく、正規表現エンジンの代数的な bug。",
+    "drawer.body.p2": "実際の再現ロジックは {0} にあり、deploy 時に {2} からビルドされた {1} として配布される。左のスクリプトパネルは該当箇所の抜粋、出力パネルは wasm が実行時に stdout へ出す JSON エンベロープ。",
+    "drawer.body.p3": "Pyodide / Ruby.wasm / php-wasm のレシピと違い、このページはブラウザ内での編集と実行の機能を{0}。Rust のソースはビルド時に {1} へコンパイルされるため、その場での編集にはブラウザ外での再コンパイルが要る。バリエーションを試すには crate を fork して {2} を再ビルドする。"
+  }
+}

--- a/src/layer1_wasm/regex-779/index.html
+++ b/src/layer1_wasm/regex-779/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="vivarium-contract" content="v1" />
-    <title>Vivarium · Reproducing rust-lang/regex#779</title>
+    <title data-i18n="page.title">Vivarium · Reproducing rust-lang/regex#779</title>
     <!-- vivarium-chrome-injected -->
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
     <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.asm.wasm" as="fetch" type="application/wasm" crossorigin />
@@ -20,10 +20,10 @@
     />
     <link rel="stylesheet" href="../_shared/style.css" />
     <template id="bug-context">
-      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
-      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
       <div class="vh-drawer__body" id="vh-drawer-body">
-        <p>
+        <p data-i18n="drawer.body.p1">
           The Rust <code>regex</code> crate violates a basic regex
           algebra: <code>(re)+</code> should equal
           <code>(re)(re)*</code>, but with
@@ -34,7 +34,7 @@
           is an algebraic regex-engine bug rather than a
           regex-language ambiguity.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p2">
           The actual reproduction logic lives in <code>src/main.rs</code>
           and ships as <code>repro.wasm</code>, built from
           <code>Cargo.toml</code> at deploy time. The script panel
@@ -42,7 +42,7 @@
           shows the JSON envelope the wasm prints to stdout when it
           runs.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p3">
           Unlike the Pyodide / Ruby.wasm / php-wasm recipes, this
           page does <strong>not</strong> ship an in-browser
           edit-and-run affordance — the Rust source is compiled
@@ -54,13 +54,13 @@
       </div>
       <hr class="vh-drawer__divider" />
       <div class="vh-drawer__meta-grid">
-        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k1">Project</span>
         <span class="vh-drawer__meta-val">rust-lang/regex</span>
-        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k2">Issue</span>
         <span class="vh-drawer__meta-val">#779</span>
-        <span class="vh-drawer__meta-key">Layer</span>
-        <span class="vh-drawer__meta-val">L1 · WASM</span>
-        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k3">Layer</span>
+        <span class="vh-drawer__meta-val" data-i18n="drawer.meta.layer">L1 · WASM</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k4">Runtime</span>
         <span class="vh-drawer__meta-val">Rust wasm32-wasip1</span>
       </div>
     </template>
@@ -70,16 +70,16 @@
       <header class="vh-main__header">
         <div class="vh-main__header-text">
           <p class="kicker">L1 · Rust wasm32-wasip1</p>
-          <h1>Reproducing <a href="https://github.com/rust-lang/regex/issues/779" target="_blank" rel="noreferrer">rust-lang/regex#779</a></h1>
+          <h1 data-i18n="page.h1">Reproducing <a href="https://github.com/rust-lang/regex/issues/779" target="_blank" rel="noreferrer">rust-lang/regex#779</a></h1>
           <div class="vh-main__header-actions">
-            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer" data-i18n="chip.bugContext">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
               Bug context
             </button>
           </div>
         </div>
         <div class="vh-main__header-aside">
-          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite" data-i18n="verdict.pending">
             Loading Rust wasm32-wasip1 artefact via WASI shim…
           </div>
           <p class="meta" id="meta"></p>
@@ -88,7 +88,7 @@
 
       <div class="vh-main__cols">
         <section class="vh-main__col vh-main__col--script">
-          <h2>Reproduction script (Rust)</h2>
+          <h2 data-i18n="section.script.h2">Reproduction script (Rust)</h2>
           <pre><code id="repro-code"><span class="line"><span style="color:#6A737D">// src/main.rs (excerpt — see this directory for the full crate)</span></span>
 <span class="line"><span style="color:#F97583">let</span><span style="color:#E1E4E8"> haystack </span><span style="color:#F97583">=</span><span style="color:#9ECBFF"> "a</span><span style="color:#79B8FF">\n</span><span style="color:#9ECBFF">aaa</span><span style="color:#79B8FF">\n</span><span style="color:#9ECBFF">"</span><span style="color:#E1E4E8">;</span></span>
 <span class="line"><span style="color:#F97583">let</span><span style="color:#E1E4E8"> re_plus     </span><span style="color:#F97583">=</span><span style="color:#B392F0"> Regex</span><span style="color:#F97583">::</span><span style="color:#B392F0">new</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">"(?m)(^|a)+"</span><span style="color:#E1E4E8">)</span><span style="color:#F97583">.</span><span style="color:#B392F0">unwrap</span><span style="color:#E1E4E8">();</span></span>
@@ -103,8 +103,8 @@
         </section>
 
         <section class="vh-main__col vh-main__col--output">
-          <h2>Output</h2>
-          <pre id="output">(running)</pre>
+          <h2 data-i18n="section.output.h2">Output</h2>
+          <pre id="output" data-i18n="output.placeholder">(running)</pre>
         </section>
       </div>
 

--- a/src/layer1_wasm/ruby-21709/i18n.ja.json
+++ b/src/layer1_wasm/ruby-21709/i18n.ja.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "lang": "ja",
+  "slug": "ruby-21709",
+  "strings": {
+    "drawer.eyebrow": "// BUG CONTEXT",
+    "drawer.heading": "このページが存在する理由",
+    "drawer.meta.k1": "プロジェクト",
+    "drawer.meta.k2": "Issue",
+    "drawer.meta.k3": "レイヤ",
+    "drawer.meta.layer": "L1 · WASM",
+    "drawer.meta.k4": "ランタイム",
+    "page.h1": "{0} の再現",
+    "chip.bugContext": "{0} bug の背景",
+    "section.script.h2": "再現スクリプト",
+    "section.output.h2": "出力",
+    "output.placeholder": "(実行中)",
+    "page.title": "Vivarium · ruby/ruby#21709 の再現",
+    "verdict.pending": "Ruby.wasm runtime を読み込み中…",
+    "drawer.body.p1": "Ruby の Regexp の式展開はエンコーディングの異なる断片を拒否するのに、String の式展開は黙って UTF-8 に昇格させる。{0} と {1} を使うと、{2} は {3} を送出する一方で {4} は UTF-8 の文字列を組み立てる。",
+    "drawer.body.p2": "2 つの式展開は、エンコーディングの異なる断片をどう結合するかで一致すべき。このページのスクリプトは両方を試し、それぞれが例外を送出したかを記録して、verdict のロジックが reproduced か unreproduced かを決めるのに使う JSON サマリを返す。",
+    "drawer.body.p3": "議論の全体（動機、fix の進捗）は下の GitHub issue スレッドにある。"
+  }
+}

--- a/src/layer1_wasm/ruby-21709/index.html
+++ b/src/layer1_wasm/ruby-21709/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="vivarium-contract" content="v1" />
-    <title>Vivarium · Reproducing ruby/ruby#21709</title>
+    <title data-i18n="page.title">Vivarium · Reproducing ruby/ruby#21709</title>
     <!-- vivarium-chrome-injected -->
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
     <link rel="preload" href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.asm.wasm" as="fetch" type="application/wasm" crossorigin />
@@ -20,10 +20,10 @@
     />
     <link rel="stylesheet" href="../_shared/style.css" />
     <template id="bug-context">
-      <p class="vh-drawer__eyebrow">// BUG CONTEXT</p>
-      <h2 class="vh-drawer__heading">Why this reproduction page exists</h2>
+      <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
+      <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
       <div class="vh-drawer__body" id="vh-drawer-body">
-        <p>
+        <p data-i18n="drawer.body.p1">
           Ruby's Regexp interpolation rejects fragments of differing
           encodings, while String interpolation silently upgrades them
           to UTF-8. With <code>prefix = '\p{In_Arabic}'</code> and
@@ -32,27 +32,27 @@
           <code>RegexpError</code> while
           <code>"#{prefix}#{suffix}"</code> builds a UTF-8 string.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p2">
           The two interpolation forms should agree on how to combine
           fragments of different encodings. The script on this page
           attempts both, captures whether each raised, and returns
           a JSON summary the verdict logic uses to decide reproduced
           vs unreproduced.
         </p>
-        <p>
+        <p data-i18n="drawer.body.p3">
           The full discussion (motivation, fix progress) lives in the
           GitHub issue thread linked below.
         </p>
       </div>
       <hr class="vh-drawer__divider" />
       <div class="vh-drawer__meta-grid">
-        <span class="vh-drawer__meta-key">Project</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k1">Project</span>
         <span class="vh-drawer__meta-val">ruby/ruby</span>
-        <span class="vh-drawer__meta-key">Issue</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k2">Issue</span>
         <span class="vh-drawer__meta-val">#21709</span>
-        <span class="vh-drawer__meta-key">Layer</span>
-        <span class="vh-drawer__meta-val">L1 · WASM</span>
-        <span class="vh-drawer__meta-key">Runtime</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k3">Layer</span>
+        <span class="vh-drawer__meta-val" data-i18n="drawer.meta.layer">L1 · WASM</span>
+        <span class="vh-drawer__meta-key" data-i18n="drawer.meta.k4">Runtime</span>
         <span class="vh-drawer__meta-val">Ruby.wasm</span>
       </div>
     </template>
@@ -62,16 +62,16 @@
       <header class="vh-main__header">
         <div class="vh-main__header-text">
           <p class="kicker">L1 · Ruby.wasm</p>
-          <h1>Reproducing <a href="https://bugs.ruby-lang.org/issues/21709" target="_blank" rel="noreferrer">ruby/ruby#21709</a></h1>
+          <h1 data-i18n="page.h1">Reproducing <a href="https://bugs.ruby-lang.org/issues/21709" target="_blank" rel="noreferrer">ruby/ruby#21709</a></h1>
           <div class="vh-main__header-actions">
-            <button type="button" class="vh-chip" data-vh-action="open-drawer">
+            <button type="button" class="vh-chip" data-vh-action="open-drawer" data-i18n="chip.bugContext">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
               Bug context
             </button>
           </div>
         </div>
         <div class="vh-main__header-aside">
-          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+          <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite" data-i18n="verdict.pending">
             Loading Ruby.wasm runtime…
           </div>
           <p class="meta" id="meta"></p>
@@ -80,7 +80,7 @@
 
       <div class="vh-main__cols">
         <section class="vh-main__col vh-main__col--script">
-          <h2>Reproduction script</h2>
+          <h2 data-i18n="section.script.h2">Reproduction script</h2>
           <pre><code id="repro-code"><span class="line"><span style="color:#F97583">require</span><span style="color:#9ECBFF"> "json"</span></span>
 <span class="line"></span>
 <span class="line"><span style="color:#FFAB70">result</span><span style="color:#E1E4E8"> = { </span><span style="color:#79B8FF">ruby_version:</span><span style="color:#79B8FF"> RUBY_VERSION</span><span style="color:#E1E4E8"> }</span></span>
@@ -112,8 +112,8 @@
         </section>
 
         <section class="vh-main__col vh-main__col--output">
-          <h2>Output</h2>
-          <pre id="output">(running)</pre>
+          <h2 data-i18n="section.output.h2">Output</h2>
+          <pre id="output" data-i18n="output.placeholder">(running)</pre>
         </section>
       </div>
 

--- a/src/layer2_docker/find-xargs-whitespace/i18n.ja.json
+++ b/src/layer2_docker/find-xargs-whitespace/i18n.ja.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "lang": "ja",
+  "slug": "find-xargs-whitespace",
+  "strings": {
+    "section.verdict.h2": "CI verdict スナップショット",
+    "verdict.pending": "verdict スナップショットを読み込み中…",
+    "section.reproduce.h2": "自分で再現する",
+    "link.recipeDir": "レシピディレクトリ",
+    "section.snapshot.h2": "CI スナップショットの出力",
+    "output.placeholder": "(読み込み中…)",
+    "footer.note": "Layer 2 のページは CI スナップショットの verdict を表示する。訪問者のローカルでの {0} がライブの確認になる。カタログは {1} を参照。",
+    "link.gallery": "/repro/",
+    "page.title": "Vivarium · find | xargs の空白分割の再現",
+    "page.h1": "{0} はファイル名中の空白に対して安全でない",
+    "page.lede": "{0} は既定で stdin を空白で分割する。パイプライン {1} は、パスに空白・タブ・改行を含むファイルをすべて黙って取りこぼす。{2} が空白区切りの各トークンを別々の引数として {3} に渡すため。対処である {4} は NUL バイトを区切りに使う——NUL はファイル名に決して現れない。",
+    "section.reproduce.meta": "初回 pull は約 10 MB (alpine:3.19 + GNU findutils)。実行は 1 秒未満。{1} と {2} は {0} にある。"
+  }
+}

--- a/src/layer2_docker/find-xargs-whitespace/index.html
+++ b/src/layer2_docker/find-xargs-whitespace/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="vivarium-contract" content="v1" />
-    <title>Vivarium · Reproducing find | xargs whitespace splitting</title>
+    <title data-i18n="page.title">Vivarium · Reproducing find | xargs whitespace splitting</title>
     <!-- vivarium-chrome-injected -->
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
     <link rel="stylesheet" href="../_shared/style.css" />
@@ -13,8 +13,8 @@
     <main>
       <header>
         <p class="kicker">Vivarium · Layer 2 · Docker (catalogue)</p>
-        <h1><code>find … | xargs cmd</code> is unsafe for whitespace in filenames</h1>
-        <p class="lede">
+        <h1 data-i18n="page.h1"><code>find … | xargs cmd</code> is unsafe for whitespace in filenames</h1>
+        <p class="lede" data-i18n="page.lede">
           <code>xargs</code> splits its stdin on whitespace by
           default. The pipeline
           <code>find . -name '*.txt' | xargs grep -l 'secret'</code>
@@ -28,35 +28,35 @@
       </header>
 
       <section>
-        <h2>CI verdict snapshot</h2>
-        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+        <h2 data-i18n="section.verdict.h2">CI verdict snapshot</h2>
+        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite" data-i18n="verdict.pending">
           Loading verdict snapshot…
         </div>
         <p class="meta" id="meta"></p>
       </section>
 
       <section>
-        <h2>Reproduce yourself</h2>
+        <h2 data-i18n="section.reproduce.h2">Reproduce yourself</h2>
         <pre><code>docker run --rm ghcr.io/aletheia-works/vivarium-find-xargs-whitespace:latest</code></pre>
-        <p class="meta">
+        <p class="meta" data-i18n="section.reproduce.meta">
           First-pull cost ~10 MB (alpine:3.19 + GNU findutils).
           Run takes well under a second. See the
-          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker/find-xargs-whitespace">
+          <a data-i18n="link.recipeDir" href="https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker/find-xargs-whitespace">
             recipe directory</a> for the <code>Dockerfile</code> and
           <code>repro.sh</code>.
         </p>
       </section>
 
       <section>
-        <h2>CI snapshot output</h2>
-        <pre id="output">(loading…)</pre>
+        <h2 data-i18n="section.snapshot.h2">CI snapshot output</h2>
+        <pre id="output" data-i18n="output.placeholder">(loading…)</pre>
       </section>
 
       <footer>
-        <p class="meta">
+        <p class="meta" data-i18n="footer.note">
           Layer 2 pages report a CI-snapshot verdict; the visitor's
           local <code>docker run</code> is the live confirmation.
-          See <a href="../">/repro/</a> for the gallery.
+          See <a data-i18n="link.gallery" href="../">/repro/</a> for the gallery.
         </p>
       </footer>
     </main>

--- a/src/layer2_docker/flock-is-advisory/i18n.ja.json
+++ b/src/layer2_docker/flock-is-advisory/i18n.ja.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "lang": "ja",
+  "slug": "flock-is-advisory",
+  "strings": {
+    "section.verdict.h2": "CI verdict スナップショット",
+    "verdict.pending": "verdict スナップショットを読み込み中…",
+    "section.reproduce.h2": "自分で再現する",
+    "link.recipeDir": "レシピディレクトリ",
+    "section.snapshot.h2": "CI スナップショットの出力",
+    "output.placeholder": "(読み込み中…)",
+    "footer.note": "Layer 2 のページは CI スナップショットの verdict を表示する。訪問者のローカルでの {0} がライブの確認になる。カタログは {1} を参照。",
+    "link.gallery": "/repro/",
+    "page.title": "Vivarium · flock(2) は advisory でしかないことの再現",
+    "page.h1": "Linux の {0} は advisory でしかない",
+    "page.lede": "あるプログラムがファイルに排他 {0} を保持していても、{1}、{2}、{3} をはじめ自身で {4} を呼ばないツールがそのファイルを読み書きするのは止められない。Linux のファイルロックは advisory であり、ロックが見えるのは opt-in したプログラムだけ。これを誤解している開発者は多い。このページで一連の挙動を確認できる。",
+    "section.reproduce.meta": "初回 pull は約 10 MB (alpine:3.19 + util-linux)。実行は約 2.5 秒。{1} と {2} は {0} にある。"
+  }
+}

--- a/src/layer2_docker/flock-is-advisory/index.html
+++ b/src/layer2_docker/flock-is-advisory/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="vivarium-contract" content="v1" />
-    <title>Vivarium · Reproducing flock(2) is advisory only</title>
+    <title data-i18n="page.title">Vivarium · Reproducing flock(2) is advisory only</title>
     <!-- vivarium-chrome-injected -->
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
     <link rel="stylesheet" href="../_shared/style.css" />
@@ -13,8 +13,8 @@
     <main>
       <header>
         <p class="kicker">Vivarium · Layer 2 · Docker (catalogue)</p>
-        <h1>Linux <code>flock(2)</code> is advisory only</h1>
-        <p class="lede">
+        <h1 data-i18n="page.h1">Linux <code>flock(2)</code> is advisory only</h1>
+        <p class="lede" data-i18n="page.lede">
           A program holding an exclusive <code>flock</code> on a
           file does not stop <code>cat</code>, <code>cp</code>,
           <code>grep</code>, or any other tool that doesn't
@@ -27,35 +27,35 @@
       </header>
 
       <section>
-        <h2>CI verdict snapshot</h2>
-        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+        <h2 data-i18n="section.verdict.h2">CI verdict snapshot</h2>
+        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite" data-i18n="verdict.pending">
           Loading verdict snapshot…
         </div>
         <p class="meta" id="meta"></p>
       </section>
 
       <section>
-        <h2>Reproduce yourself</h2>
+        <h2 data-i18n="section.reproduce.h2">Reproduce yourself</h2>
         <pre><code>docker run --rm ghcr.io/aletheia-works/vivarium-flock-is-advisory:latest</code></pre>
-        <p class="meta">
+        <p class="meta" data-i18n="section.reproduce.meta">
           First-pull cost ~10 MB (alpine:3.19 + util-linux). Run
           takes ~2.5 s. See the
-          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker/flock-is-advisory">
+          <a data-i18n="link.recipeDir" href="https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker/flock-is-advisory">
             recipe directory</a> for the <code>Dockerfile</code> and
           <code>repro.sh</code>.
         </p>
       </section>
 
       <section>
-        <h2>CI snapshot output</h2>
-        <pre id="output">(loading…)</pre>
+        <h2 data-i18n="section.snapshot.h2">CI snapshot output</h2>
+        <pre id="output" data-i18n="output.placeholder">(loading…)</pre>
       </section>
 
       <footer>
-        <p class="meta">
+        <p class="meta" data-i18n="footer.note">
           Layer 2 pages report a CI-snapshot verdict; the visitor's
           local <code>docker run</code> is the live confirmation.
-          See <a href="../">/repro/</a> for the gallery.
+          See <a data-i18n="link.gallery" href="../">/repro/</a> for the gallery.
         </p>
       </footer>
     </main>

--- a/src/layer2_docker/postgres-lost-update/i18n.ja.json
+++ b/src/layer2_docker/postgres-lost-update/i18n.ja.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "lang": "ja",
+  "slug": "postgres-lost-update",
+  "strings": {
+    "section.verdict.h2": "CI verdict スナップショット",
+    "verdict.pending": "verdict スナップショットを読み込み中…",
+    "section.reproduce.h2": "自分で再現する",
+    "link.recipeDir": "レシピディレクトリ",
+    "section.snapshot.h2": "CI スナップショットの出力",
+    "output.placeholder": "(読み込み中…)",
+    "footer.note": "Layer 2 のページは CI スナップショットの verdict を表示する。訪問者のローカルでの {0} がライブの確認になる。カタログは {1} を参照。",
+    "link.gallery": "/repro/",
+    "page.title": "Vivarium · READ COMMITTED 下での PostgreSQL の lost update の再現",
+    "page.h1": "{0} 下での PostgreSQL の lost update",
+    "page.lede": "PostgreSQL の既定である {1} 分離レベルの下では、アプリケーション側の並行する 2 つの {0} トランザクションが increment を 1 回黙って失うことがある。下のページは CI の最新の再現スナップショットを表示する。自分の Docker で同じ挙動を確かめるにはレシピをローカルで実行する。",
+    "section.reproduce.meta": "初回 pull は約 80 MB (postgres:16-alpine)。実行は約 5 秒。{1} と {2} は {0} にある。"
+  }
+}

--- a/src/layer2_docker/postgres-lost-update/index.html
+++ b/src/layer2_docker/postgres-lost-update/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="vivarium-contract" content="v1" />
-    <title>Vivarium · Reproducing PostgreSQL lost update under READ COMMITTED</title>
+    <title data-i18n="page.title">Vivarium · Reproducing PostgreSQL lost update under READ COMMITTED</title>
     <!-- vivarium-chrome-injected -->
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
     <link rel="stylesheet" href="../_shared/style.css" />
@@ -13,8 +13,8 @@
     <main>
       <header>
         <p class="kicker">Vivarium · Layer 2 · Docker (catalogue)</p>
-        <h1>PostgreSQL lost update under <code>READ COMMITTED</code></h1>
-        <p class="lede">
+        <h1 data-i18n="page.h1">PostgreSQL lost update under <code>READ COMMITTED</code></h1>
+        <p class="lede" data-i18n="page.lede">
           Two concurrent application-side <code>read → modify →
           write</code> transactions under PostgreSQL's default
           <code>READ COMMITTED</code> isolation can silently lose one
@@ -25,35 +25,35 @@
       </header>
 
       <section>
-        <h2>CI verdict snapshot</h2>
-        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite">
+        <h2 data-i18n="section.verdict.h2">CI verdict snapshot</h2>
+        <div id="verdict" class="verdict pending" data-verdict="pending" role="status" aria-live="polite" data-i18n="verdict.pending">
           Loading verdict snapshot…
         </div>
         <p class="meta" id="meta"></p>
       </section>
 
       <section>
-        <h2>Reproduce yourself</h2>
+        <h2 data-i18n="section.reproduce.h2">Reproduce yourself</h2>
         <pre><code>docker run --rm ghcr.io/aletheia-works/vivarium-postgres-lost-update:latest</code></pre>
-        <p class="meta">
+        <p class="meta" data-i18n="section.reproduce.meta">
           First-pull cost ~80 MB (postgres:16-alpine). Run takes
           ~5 s. See the
-          <a href="https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker/postgres-lost-update">
+          <a data-i18n="link.recipeDir" href="https://github.com/aletheia-works/vivarium/tree/main/src/layer2_docker/postgres-lost-update">
             recipe directory</a> for the <code>Dockerfile</code> and
           <code>repro.sh</code>.
         </p>
       </section>
 
       <section>
-        <h2>CI snapshot output</h2>
-        <pre id="output">(loading…)</pre>
+        <h2 data-i18n="section.snapshot.h2">CI snapshot output</h2>
+        <pre id="output" data-i18n="output.placeholder">(loading…)</pre>
       </section>
 
       <footer>
-        <p class="meta">
+        <p class="meta" data-i18n="footer.note">
           Layer 2 pages report a CI-snapshot verdict; the visitor's
           local <code>docker run</code> is the live confirmation.
-          See <a href="../">/repro/</a> for the gallery.
+          See <a data-i18n="link.gallery" href="../">/repro/</a> for the gallery.
         </p>
       </footer>
     </main>


### PR DESCRIPTION

Completes the bilingual reproduction pages: the eleven remaining recipes
get their data-i18n annotations and i18n.ja.json, joining the worked
example that shipped with the machinery. Every reproduction page now
renders at /vivarium/ja/repro/<project>/<issue>/.

Layer 3's lost-update has no index.html and no deploy bundling step, so
it correctly gets no page_url_ja. Worth noting separately that its
page_url in recipes.json has always pointed at a URL with no page behind
it — a pre-existing gap, not one this PR introduces.

Coverage is now strict in both directions. generate-repro-i18n.ts fails
on a reproduction page with no translation instead of skipping it with a
note, and reproI18n.test.ts asserts the two sets are equal — the
reproduction-page counterpart of the EN/JA tree symmetry that
docs/tests/i18n.spec.ts already enforces for the rspress pages, per
ADR-0028's i18n Definition of Done.

Translation notes:

- Only genuinely translatable prose is annotated. The `.kicker`
  (`L1 · Pyodide`), the drawer's project/issue/runtime meta values
  (`numpy/numpy`, `#28287`, `Pyodide v0.29.3`) and the four verdict pill
  literals are technical labels that read the same in both locales, so
  they carry no key at all rather than a key with an identical value.
- Links and inline SVG travel through {n} slots, so no href or icon
  markup appears in any translation file. Where a link's label itself
  needed Japanese (the Layer 2 "recipe directory" anchor), the anchor
  carries its own nested key.
- page.title is plain text everywhere — markup inside <title> renders
  literally in the browser tab, which the generator now rejects.
- Register follows _shared/path_a.ts's DEFAULT_STRINGS_JA: plain form
  (常体), technical vocabulary (verdict, fix, runtime, baseline, race,
  advisory) left in English.

projects.json gains tagline_ja / description_ja for all 13 projects, as
flat suffixed keys rather than a nested locale object: display_name,
homepage and github are locale-invariant, so nesting would either
duplicate them or produce a mixed shape, and projects.json is a
published generated API where an added field is additive while a
restructure is breaking. ProjectPage falls back to English per-field, so
a project added before its translation still reads on the JA page.

Verified: all 12 generated pages contain no leftover English from the
annotated nodes, `<code id="repro-code">` is byte-identical to its
English source (Shiki output untouched), and a staged deploy-shaped tree
serves the JA page with every asset resolving into the English tree via
`<base href>`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
