### PR TITLE
chore(ci): let dependabot update the docs and layer 1 manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,6 +83,63 @@ updates:
           - "*"
     open-pull-requests-limit: 5
 
+  # ─── bun — docs ──────────────────────────────
+  # The rspress documentation app: rspress itself, Biome, Playwright and
+  # the ajv toolchain behind the generated validators. Playwright lands
+  # here rather than being bumped by hand — the version decides both the
+  # client and the browser build the E2E lane runs, so it wants a PR with
+  # CI attached, not a drive-by edit.
+  - package-ecosystem: "bun"
+    directory: "/docs"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+      timezone: "Asia/Tokyo"
+    labels:
+      - "type: chore"
+      - "scope: js"
+      - "scope: docs"
+      - "ai: generated"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      docs-deps:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+
+  # ─── bun — src/layer1_wasm ───────────────────
+  # Layer 1's build and test toolchain (tsc, Shiki, Playwright). The
+  # recipes' own runtimes — Pyodide, Ruby.wasm, php-wasm — are pinned by
+  # URL inside the pages and are not visible to Dependabot; those move
+  # with the recipe, not with this manifest.
+  - package-ecosystem: "bun"
+    directory: "/src/layer1_wasm"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+      timezone: "Asia/Tokyo"
+    labels:
+      - "type: chore"
+      - "scope: js"
+      - "scope: wasm"
+      - "ai: generated"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      layer1-deps:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+
   # Future ecosystems to enable in Phase 1+:
   #
   # - package-ecosystem: "pip"      # Python deps (Layer 1 Pyodide-side, etc.)


### PR DESCRIPTION

`packages/mcp-server` has been on Dependabot since it landed; the other
two bun projects were never wired up, so their dependencies have only
moved when someone edited a manifest by hand. Add both.

The immediate motivation is Playwright. It sits in docs/ and
src/layer1_wasm/ and decides both the test client and the browser build
the E2E lanes run, so a bump wants a PR with CI attached rather than a
drive-by edit — bumping it by hand alongside a CI change is exactly what
made PR #354's first revision hard to read, where a 1.59.1 -> 1.62.1
bump turned out to cost the docs suite 29.6 s -> 114 s and had to be
separated out again.

Same shape as the existing entries: daily at 03:00 JST, majors ignored
(they need targeted review), one grouped PR per project. Labels follow
what .github/labeler.yml would derive from the changed paths — `scope:
js` plus `scope: docs` / `scope: wasm`.

Layer 1's recipe runtimes (Pyodide, Ruby.wasm, php-wasm) are pinned by
URL inside the pages and stay invisible to Dependabot; they move with
the recipe that pins them, which is the intent.
