### PR TITLE
fix(docs): keep explicit /ja/ links from bouncing to the EN page

### DIFF
--- a/docs/playwright.config.ts
+++ b/docs/playwright.config.ts
@@ -57,6 +57,12 @@ export default defineConfig({
 
   use: {
     baseURL: DOCS_BASE,
+    // Pin `navigator.language`. rspress's first-visit locale redirect
+    // (see `route.localeRedirect` in rspress.config.ts) reads it, so an
+    // unpinned locale makes the suite pass or fail depending on the
+    // machine's system language — EN pages would bounce to `/ja/` on a
+    // Japanese workstation while CI's en-US runners stayed green.
+    locale: 'en-US',
     actionTimeout: 30_000,
     navigationTimeout: 30_000,
     trace: 'retain-on-failure',

--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -36,6 +36,17 @@ export default defineConfig({
       description: 'あらゆる言語・環境・スケールに対応するバグ再現基盤。',
     },
   ],
+  route: {
+    // rspress 2.0.21 added a first-visit locale redirect that defaults
+    // to `auto`: a browser whose `navigator.language` differs from the
+    // page's locale is bounced to the matching locale once, keyed on
+    // `localStorage['rspress-visited']`. `auto` hijacks explicit links
+    // — a JA page shared with an EN reader lands them on the EN page —
+    // so the redirect is narrowed to one direction: only a visitor on
+    // the default-locale (EN) path gets moved to their own locale.
+    // `/ja/` URLs are always served as asked.
+    localeRedirect: 'only-default-lang',
+  },
   // Lower the breakpoint at which the nav's GitHub icon + theme toggle
   // collapse into the hamburger menu, so the docs nav matches the
   // reproduction-page nav (which keeps both icons inline at all widths).


### PR DESCRIPTION

rspress 2.0.21 (landed in #357) added a first-visit locale redirect,
`route.localeRedirect`, defaulting to `auto`: on the first page view of
a session it compares `navigator.language` against the current locale
and `location.replace()`s to the matching one, keyed on
`localStorage["rspress-visited"]`.

`auto` redirects in both directions, so an EN reader opening a shared
`/vivarium/ja/...` link is silently moved to the EN page — the link
stops meaning what the sender meant. It also broke the docs E2E lane on
main: all 36 JA smoke cases failed on Chromium with `response.text:
Protocol error ... Response body is not available for a response that
was navigated away from`, because the redirect fires between
`domcontentloaded` and the body read.

Narrow the redirect to `only-default-lang`: a visitor landing on the
default-locale (EN) path still gets moved to their own locale, and an
explicit `/ja/` URL is always served as asked.

The suite also now pins `use.locale` to `en-US`. rspress reads
`navigator.language`, so an unpinned locale makes the result depend on
the machine: the EN cases would redirect to `/ja/` on a Japanese
workstation while CI's en-US runners stayed green.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aletheia-works/vivarium/pull/358).
* #359
* __->__ #358