### PR TITLE
docs(agents): default to writing no comments

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -46,3 +46,18 @@ force-push to `main`, create or rotate secrets, run `tofu apply`
 against production state, or pivot scope without human
 confirmation. End the loop at natural stopping points rather than
 inventing filler tasks.
+
+## 4. Comments
+
+`AGENTS.md` §4.13 is the rule; these are the agent-specific failure
+modes it exists to stop.
+
+- Do not annotate your own work. Why you chose an approach, what you
+  changed, and what you verified belong in the commit message body and
+  the PR description — never in a comment next to the code.
+- When you touch a region that already carries a comment, delete the
+  comment unless it passes one of §4.13's two tests. A half-true
+  comment beside an edited line is worse than either keeping or
+  removing the whole thing.
+- Do not restore a comment an earlier pass removed.
+- Docstrings and JSDoc are comments. The same two tests apply.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,6 +295,48 @@ its `run:` steps from the YAML and execute them by hand. **When CI
 catches something local missed**, extend the matching `ci:*` task —
 local and CI should converge on the same surface in both directions.
 
+### 4.13 Comments
+
+**Default: no comment.** Names, small functions, and types carry the
+explanation. A comment is a second source of truth that no test, type
+checker, or linter validates — when the code it describes moves, the
+comment silently becomes a lie. This repository has already been
+there: comments pointed at `infra/github/labels.tf`,
+`test-docs-build.yml`, and `.github/workflows/ruff-autofix.yml` long
+after those files stopped existing.
+
+Write a comment only when it is one of these two:
+
+| Kind | Test | Example |
+|---|---|---|
+| **Functional** | The file does not work without it | PEP 723 `# /// script` blocks, `// biome-ignore`, `// eslint-disable-next-line`, the `# v6.0.2` version note every SHA pin requires (§4.8) |
+| **Non-recoverable why** | The obvious reading of the code invites a "fix" that would break it, and nothing else records why | `# =1.8.4 — last release before the NFA compiler fixed #779` |
+
+A non-recoverable why is one or two lines. If it needs a paragraph, it
+is not a comment — it is a docs page or a commit message.
+
+Delete rather than write:
+
+- Restatements of the next line.
+- File-header tours: what the module is for, who calls it, what the
+  workflow's three lanes are.
+- Pointers to other files, functions, workflows, or config keys. These
+  rot first. A map that is worth maintaining belongs in `docs/`, where
+  it is a page with an owner.
+- Rationale for the change being made. That is the commit message
+  (§4.4) and the PR body. Code records what is true now, not how it
+  got that way.
+- Section banners (`// ─── Repository ───`), TODOs, changelog notes,
+  and commented-out code.
+
+Where the explanation goes instead: a name (extract a well-named
+function or constant), a type, a test that demonstrates the behaviour,
+the commit message, or a docs page.
+
+This applies to every file the repository builds from — TypeScript,
+Python, Rust, shell, workflow YAML, OpenTofu, TOML configs, CSS, and
+recipe HTML. Markdown and MDX are prose and are out of scope.
+
 ## 5. Three-layer architecture (reference)
 
 Product-level technology choices are framed by these three layers. Do not


### PR DESCRIPTION
## What

Adds `AGENTS.md` §4.13 (Comments) and `.claude/CLAUDE.md` §4, making "no comment" the repository default for every file the project builds from.

## Why

Comments here are a second source of truth that no test, type checker, or linter validates, and the cross-file ones have already rotted:

| Comment | Points at | Reality |
|---|---|---|
| `mago.toml:9-10` | `test-php-check.yml`, `mago-autofix.yml` | neither exists |
| `ruff.toml:6-7` | `test-python-check.yml`, `ruff-autofix.yml` | neither exists |
| `.rumdl.toml:5-6` | `test-markdown-check.yml`, `rumdl-autofix.yml` | neither exists |
| `claude-implement.yml:32` | `infra/github/labels.tf` | folded into `main.tf` |
| `project-fields.yml:21` | `infra/github/milestones.tf` | folded into `main.tf` |
| `test-docs.yml:14` | `test-docs-build.yml` | deleted — the comment says so itself |
| `generate-recipes-index.ts:32` | `docs/site/_data/recipe-facets.json` | retired |

Measured across the tracked build inputs (ts/tsx/js/py/rs/sh/yml/tf/toml/css/html): **5,214 comment lines to 27,430 code lines, 16%**. `.github/workflows/` runs at 37%, `infra/` 32%, `mago.toml` 77%.

## The rule

Two exceptions survive:

- **Functional** — the file does not work without it: PEP 723 `# /// script` blocks, `// biome-ignore`, `// eslint-disable-next-line`, and the `# v6.0.2` version note every SHA pin already requires under §4.8.
- **Non-recoverable why** — one or two lines, where the obvious reading of the code invites a fix that would break it.

Everything else becomes a name, a type, a test, a commit message, or a `docs/` page.

Markdown and MDX are prose and stay out of scope.

## Next

The sweep that applies this to the existing ~5,200 comment lines follows in a separate PR, split by area (workflows / `src` / `docs` / `packages`+`infra`+configs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)