### PR TITLE
fix(wasm): ship the recipe page shell in the HTML

### DIFF
--- a/.claude/rules/recipe-authoring.md
+++ b/.claude/rules/recipe-authoring.md
@@ -200,8 +200,15 @@ one. Copy the block from
   <header class="vh-variant-head" data-variant="baseline">
     <h2 class="vh-variant-head__title" data-i18n="section.baseline.h2">Baseline output</h2>
   </header>
-  <div class="vh-variant-stage" data-variant="baseline">
-    <pre id="output" class="vh-variant-output" data-i18n="output.pending">(pending)</pre>
+  <div class="vh-variant-stage vh-output-section" data-variant="baseline">
+    <div class="vh-progress">
+      <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
+      <div class="vh-progress__row">
+        <span class="vh-progress__label">Initialising…</span>
+        <span class="vh-progress__bytes"></span>
+      </div>
+    </div>
+    <pre id="output" class="vh-variant-output vh-output" data-i18n="output.pending">(pending)</pre>
   </div>
 
   <header class="vh-variant-head vh-variant-head--secondary" data-variant="fix-candidate">
@@ -212,8 +219,8 @@ one. Copy the block from
 ```
 
 - `.vh-variant-stage` around `#output` is **required**.
-  [`_assets/chrome.js`](../../src/layer1_wasm/_assets/chrome.js) inserts
-  `<div class="vh-progress">` into `#output`'s parent; without the
+  [`_assets/chrome.js`](../../src/layer1_wasm/_assets/chrome.js) drives
+  `<div class="vh-progress">` inside `#output`'s parent; without the
   wrapper the loading overlay pushes the fix pane down the page.
 - All styling lives in
   [`_shared/style.css`](../../src/layer1_wasm/_shared/style.css)
@@ -271,6 +278,35 @@ PRs 180 / 189 / 192.
 - **System calls.** Pyodide ships an MEMFS-like virtual FS, not
   the real one. Anything depending on real filesystem semantics,
   fork/exec, sockets, or signals → Layer 2.
+
+---
+
+### Page shell — the chrome must ship in the HTML
+
+`chrome.js` fills the shell; it must never create it. Anything it has
+to create arrives after first paint and moves the page under the
+reader. Each recipe's `index.html` therefore ships, and
+`validate-output-panes.ts` enforces:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" />
+<link rel="stylesheet" href="../_shared/style.css" />
+<script type="module" src="../_assets/chrome.js"></script>
+...
+<body>
+  <header class="vh-topnav"></header>
+  <main class="vh-main">…</main>
+  <footer class="vh-footer"></footer>
+```
+
+The font stylesheet is linked from the page, never `@import`-ed from
+`style.css`: an `@import` is a second round trip that blocks first
+paint, and the page renders unstyled until it lands. The empty
+`vh-topnav` and `vh-footer` reserve their final height from CSS
+(`.vh-topnav` is a fixed height, `.vh-footer:empty::before` holds one
+line), so filling them shifts nothing.
 
 ---
 

--- a/src/layer1_wasm/_assets/chrome.js
+++ b/src/layer1_wasm/_assets/chrome.js
@@ -86,7 +86,9 @@ const T = CHROME_STRINGS[LANG];
 function injectChrome() {
   applyTheme();
 
-  const nav = document.createElement('header');
+  const nav =
+    document.querySelector('header.vh-topnav') ??
+    document.createElement('header');
   nav.className = 'vh-topnav';
 
   const navLinks = NAV_ITEMS[LANG].map(
@@ -112,7 +114,7 @@ function injectChrome() {
       <button class="vh-topnav__theme" type="button" aria-label="${T.themeAria}">${moon}</button>
     </div>
   `;
-  document.body.insertBefore(nav, document.body.firstChild);
+  if (!nav.isConnected) document.body.insertBefore(nav, document.body.firstChild);
 
   const outputEl = document.querySelector('#output');
   if (outputEl?.parentElement) {
@@ -128,26 +130,34 @@ function injectChrome() {
       head.appendChild(colH2);
     }
 
-    const progress = document.createElement('div');
-    progress.className = 'vh-progress';
-    progress.innerHTML = `
-      <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
-      <div class="vh-progress__row">
-        <span class="vh-progress__label">${T.initialising}</span>
-        <span class="vh-progress__bytes"></span>
-      </div>
-    `;
-    outputEl.parentElement.insertBefore(progress, outputEl);
+    const existingProgress = outputCol.querySelector(':scope > .vh-progress');
+    if (existingProgress) {
+      const label = existingProgress.querySelector('.vh-progress__label');
+      if (label) label.textContent = T.initialising;
+    } else {
+      const progress = document.createElement('div');
+      progress.className = 'vh-progress';
+      progress.innerHTML = `
+        <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
+        <div class="vh-progress__row">
+          <span class="vh-progress__label">${T.initialising}</span>
+          <span class="vh-progress__bytes"></span>
+        </div>
+      `;
+      outputEl.parentElement.insertBefore(progress, outputEl);
+    }
   }
 
-  const footer = document.createElement('footer');
+  const footer =
+    document.querySelector('footer.vh-footer') ??
+    document.createElement('footer');
   footer.className = 'vh-footer';
   footer.innerHTML = `
     <p class="vh-footer__msg">
       ${FOOTER_MESSAGE_HTML.replace('<a ', '<a target="_blank" rel="noreferrer" ')}
     </p>
   `;
-  document.body.appendChild(footer);
+  if (!footer.isConnected) document.body.appendChild(footer);
 
   const toggleBtn = nav.querySelector('.vh-topnav__theme');
   function refreshIcon() {

--- a/src/layer1_wasm/_shared/style.css
+++ b/src/layer1_wasm/_shared/style.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap");
-
 :root {
   color-scheme: light;
 
@@ -246,6 +244,16 @@ main {
   pointer-events: none;
 }
 
+.vh-output-section--snapshot .vh-progress,
+.vh-output-section--snapshot .vh-output {
+  min-height: 15rem;
+}
+
+.vh-output-section--snapshot .vh-output {
+  max-height: 15rem;
+  overflow: auto;
+}
+
 .vh-output.is-revealed {
   opacity: 1;
   pointer-events: auto;
@@ -478,6 +486,10 @@ pre code {
   border: 1px solid var(--vh-terminal-border);
 }
 
+.meta:empty {
+  min-height: 1.4em;
+}
+
 .meta {
   margin: 0.85rem 0 0;
   font-size: 0.85rem;
@@ -512,11 +524,17 @@ main > footer code {
   font-family: "Inter", sans-serif;
 }
 
-.vh-footer__msg {
+.vh-footer__msg,
+.vh-footer:empty::before {
   margin: 0;
   text-align: center;
   font-size: 0.85rem;
   color: var(--vh-text-dim);
+}
+
+.vh-footer:empty::before {
+  content: "\00a0";
+  display: block;
 }
 
 .vh-footer__msg a {
@@ -1264,6 +1282,7 @@ body.vh-drawer-open {
 
   body:has(main.vh-main) > main.vh-main {
     flex: 1 1 0;
+    width: 100%;
     min-height: 0;
     overflow: hidden;
     display: flex;
@@ -1374,7 +1393,8 @@ body.vh-drawer-open {
     flex-shrink: 0;
   }
 
-  body:has(main.vh-main) > .vh-footer .vh-footer__msg {
+  body:has(main.vh-main) > .vh-footer .vh-footer__msg,
+  body:has(main.vh-main) > .vh-footer:empty::before {
     line-height: 1.2;
   }
 

--- a/src/layer1_wasm/cpython-137205/index.html
+++ b/src/layer1_wasm/cpython-137205/index.html
@@ -15,7 +15,11 @@
       href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.mjs"
       crossorigin
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" />
     <link rel="stylesheet" href="../_shared/style.css" />
+    <script type="module" src="../_assets/chrome.js"></script>
     <template id="bug-context">
       <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
       <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
@@ -56,6 +60,7 @@
     </template>
   </head>
   <body>
+    <header class="vh-topnav"></header>
     <main class="vh-main">
       <header class="vh-main__header">
         <div class="vh-main__header-text">
@@ -107,8 +112,15 @@
               Baseline output
             </h2>
           </header>
-          <div class="vh-variant-stage" data-variant="baseline">
-            <pre id="output" class="vh-variant-output" data-i18n="output.pending">(pending)</pre>
+          <div class="vh-variant-stage vh-output-section" data-variant="baseline">
+            <div class="vh-progress">
+              <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
+              <div class="vh-progress__row">
+                <span class="vh-progress__label">Initialising…</span>
+                <span class="vh-progress__bytes"></span>
+              </div>
+            </div>
+            <pre id="output" class="vh-variant-output vh-output" data-i18n="output.pending">(pending)</pre>
           </div>
 
           <header class="vh-variant-head vh-variant-head--secondary" data-variant="fix-candidate">
@@ -126,6 +138,8 @@
       </div>
 
     </main>
+
+    <footer class="vh-footer"></footer>
 
     <script type="module" src="./repro.js"></script>
   </body>

--- a/src/layer1_wasm/dateutil-1478/index.html
+++ b/src/layer1_wasm/dateutil-1478/index.html
@@ -15,7 +15,11 @@
       href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.mjs"
       crossorigin
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" />
     <link rel="stylesheet" href="../_shared/style.css" />
+    <script type="module" src="../_assets/chrome.js"></script>
     <template id="bug-context">
       <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
       <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
@@ -69,6 +73,7 @@
     </template>
   </head>
   <body>
+    <header class="vh-topnav"></header>
     <main class="vh-main">
       <header class="vh-main__header">
         <div class="vh-main__header-text">
@@ -134,8 +139,15 @@
           <header class="vh-variant-head" data-variant="baseline">
             <h2 class="vh-variant-head__title" data-i18n="section.baseline.h2">Baseline output</h2>
           </header>
-          <div class="vh-variant-stage" data-variant="baseline">
-            <pre id="output" class="vh-variant-output" data-i18n="output.pending">(pending)</pre>
+          <div class="vh-variant-stage vh-output-section" data-variant="baseline">
+            <div class="vh-progress">
+              <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
+              <div class="vh-progress__row">
+                <span class="vh-progress__label">Initialising…</span>
+                <span class="vh-progress__bytes"></span>
+              </div>
+            </div>
+            <pre id="output" class="vh-variant-output vh-output" data-i18n="output.pending">(pending)</pre>
           </div>
 
           <header class="vh-variant-head vh-variant-head--secondary" data-variant="fix-candidate">
@@ -146,6 +158,8 @@
       </div>
 
     </main>
+
+    <footer class="vh-footer"></footer>
 
     <script type="module" src="./repro.js"></script>
   </body>

--- a/src/layer1_wasm/lark-1585/index.html
+++ b/src/layer1_wasm/lark-1585/index.html
@@ -15,7 +15,11 @@
       href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.mjs"
       crossorigin
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" />
     <link rel="stylesheet" href="../_shared/style.css" />
+    <script type="module" src="../_assets/chrome.js"></script>
     <template id="bug-context">
       <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
       <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
@@ -65,6 +69,7 @@
     </template>
   </head>
   <body>
+    <header class="vh-topnav"></header>
     <main class="vh-main">
       <header class="vh-main__header">
         <div class="vh-main__header-text">
@@ -99,8 +104,15 @@
           <header class="vh-variant-head" data-variant="baseline">
             <h2 class="vh-variant-head__title" data-i18n="section.baseline.h2">Baseline output</h2>
           </header>
-          <div class="vh-variant-stage" data-variant="baseline">
-            <pre id="output" class="vh-variant-output" data-i18n="output.pending">(pending)</pre>
+          <div class="vh-variant-stage vh-output-section" data-variant="baseline">
+            <div class="vh-progress">
+              <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
+              <div class="vh-progress__row">
+                <span class="vh-progress__label">Initialising…</span>
+                <span class="vh-progress__bytes"></span>
+              </div>
+            </div>
+            <pre id="output" class="vh-variant-output vh-output" data-i18n="output.pending">(pending)</pre>
           </div>
 
           <header class="vh-variant-head vh-variant-head--secondary" data-variant="fix-candidate">
@@ -111,6 +123,8 @@
       </div>
 
     </main>
+
+    <footer class="vh-footer"></footer>
 
     <script type="module" src="./repro.js"></script>
   </body>

--- a/src/layer1_wasm/numpy-28287/index.html
+++ b/src/layer1_wasm/numpy-28287/index.html
@@ -15,7 +15,11 @@
       href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.mjs"
       crossorigin
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" />
     <link rel="stylesheet" href="../_shared/style.css" />
+    <script type="module" src="../_assets/chrome.js"></script>
     <template id="bug-context">
       <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
       <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
@@ -55,6 +59,7 @@
     </template>
   </head>
   <body>
+    <header class="vh-topnav"></header>
     <main class="vh-main">
       <header class="vh-main__header">
         <div class="vh-main__header-text">
@@ -105,8 +110,15 @@
               Baseline output
             </h2>
           </header>
-          <div class="vh-variant-stage" data-variant="baseline">
-            <pre id="output" class="vh-variant-output" data-i18n="output.pending">(pending)</pre>
+          <div class="vh-variant-stage vh-output-section" data-variant="baseline">
+            <div class="vh-progress">
+              <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
+              <div class="vh-progress__row">
+                <span class="vh-progress__label">Initialising…</span>
+                <span class="vh-progress__bytes"></span>
+              </div>
+            </div>
+            <pre id="output" class="vh-variant-output vh-output" data-i18n="output.pending">(pending)</pre>
           </div>
 
           <header class="vh-variant-head vh-variant-head--secondary" data-variant="fix-candidate">
@@ -124,6 +136,8 @@
       </div>
 
     </main>
+
+    <footer class="vh-footer"></footer>
 
     <script type="module" src="./repro.js"></script>
   </body>

--- a/src/layer1_wasm/pandas-56679/index.html
+++ b/src/layer1_wasm/pandas-56679/index.html
@@ -15,7 +15,11 @@
       href="https://cdn.jsdelivr.net/pyodide/v0.29.3/full/pyodide.mjs"
       crossorigin
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" />
     <link rel="stylesheet" href="../_shared/style.css" />
+    <script type="module" src="../_assets/chrome.js"></script>
     <template id="bug-context">
       <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
       <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
@@ -50,6 +54,7 @@
     </template>
   </head>
   <body>
+    <header class="vh-topnav"></header>
     <main class="vh-main">
       <header class="vh-main__header">
         <div class="vh-main__header-text">
@@ -94,8 +99,15 @@
               Baseline output
             </h2>
           </header>
-          <div class="vh-variant-stage" data-variant="baseline">
-            <pre id="output" class="vh-variant-output" data-i18n="output.pending">(pending)</pre>
+          <div class="vh-variant-stage vh-output-section" data-variant="baseline">
+            <div class="vh-progress">
+              <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
+              <div class="vh-progress__row">
+                <span class="vh-progress__label">Initialising…</span>
+                <span class="vh-progress__bytes"></span>
+              </div>
+            </div>
+            <pre id="output" class="vh-variant-output vh-output" data-i18n="output.pending">(pending)</pre>
           </div>
 
           <header class="vh-variant-head vh-variant-head--secondary" data-variant="fix-candidate">
@@ -113,6 +125,8 @@
       </div>
 
     </main>
+
+    <footer class="vh-footer"></footer>
 
     <script type="module" src="./repro.js"></script>
   </body>

--- a/src/layer1_wasm/php-12167/index.html
+++ b/src/layer1_wasm/php-12167/index.html
@@ -12,7 +12,11 @@
       href="https://cdn.jsdelivr.net/npm/php-wasm@0.0.8/PhpWeb.mjs"
       crossorigin
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" />
     <link rel="stylesheet" href="../_shared/style.css" />
+    <script type="module" src="../_assets/chrome.js"></script>
     <template id="bug-context">
       <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
       <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
@@ -57,6 +61,7 @@
     </template>
   </head>
   <body>
+    <header class="vh-topnav"></header>
     <main class="vh-main">
       <header class="vh-main__header">
         <div class="vh-main__header-text">
@@ -100,8 +105,15 @@
               Baseline output
             </h2>
           </header>
-          <div class="vh-variant-stage" data-variant="baseline">
-            <pre id="output" class="vh-variant-output" data-i18n="output.pending">(pending)</pre>
+          <div class="vh-variant-stage vh-output-section" data-variant="baseline">
+            <div class="vh-progress">
+              <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
+              <div class="vh-progress__row">
+                <span class="vh-progress__label">Initialising…</span>
+                <span class="vh-progress__bytes"></span>
+              </div>
+            </div>
+            <pre id="output" class="vh-variant-output vh-output" data-i18n="output.pending">(pending)</pre>
           </div>
 
           <header class="vh-variant-head vh-variant-head--secondary" data-variant="fix-candidate">
@@ -121,6 +133,8 @@
       <section id="path-a-mount" hidden></section>
 
     </main>
+
+    <footer class="vh-footer"></footer>
 
     <script type="module" src="./repro.js"></script>
   </body>

--- a/src/layer1_wasm/regex-779/index.html
+++ b/src/layer1_wasm/regex-779/index.html
@@ -12,7 +12,11 @@
       href="https://cdn.jsdelivr.net/npm/@bjorn3/browser_wasi_shim@0.4.2/dist/index.js"
       crossorigin
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" />
     <link rel="stylesheet" href="../_shared/style.css" />
+    <script type="module" src="../_assets/chrome.js"></script>
     <template id="bug-context">
       <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
       <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
@@ -60,6 +64,7 @@
     </template>
   </head>
   <body>
+    <header class="vh-topnav"></header>
     <main class="vh-main">
       <header class="vh-main__header">
         <div class="vh-main__header-text">
@@ -102,8 +107,15 @@
               Baseline output
             </h2>
           </header>
-          <div class="vh-variant-stage" data-variant="baseline">
-            <pre id="output" class="vh-variant-output" data-i18n="output.pending">(pending)</pre>
+          <div class="vh-variant-stage vh-output-section" data-variant="baseline">
+            <div class="vh-progress">
+              <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
+              <div class="vh-progress__row">
+                <span class="vh-progress__label">Initialising…</span>
+                <span class="vh-progress__bytes"></span>
+              </div>
+            </div>
+            <pre id="output" class="vh-variant-output vh-output" data-i18n="output.pending">(pending)</pre>
           </div>
 
           <header class="vh-variant-head vh-variant-head--secondary" data-variant="fix-candidate">
@@ -121,6 +133,8 @@
       </div>
 
     </main>
+
+    <footer class="vh-footer"></footer>
 
     <script type="module" src="./repro.js"></script>
   </body>

--- a/src/layer1_wasm/ruby-21709/index.html
+++ b/src/layer1_wasm/ruby-21709/index.html
@@ -12,7 +12,11 @@
       href="https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.8.1/dist/browser/+esm"
       crossorigin
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" />
     <link rel="stylesheet" href="../_shared/style.css" />
+    <script type="module" src="../_assets/chrome.js"></script>
     <template id="bug-context">
       <p class="vh-drawer__eyebrow" data-i18n="drawer.eyebrow">// BUG CONTEXT</p>
       <h2 class="vh-drawer__heading" data-i18n="drawer.heading">Why this reproduction page exists</h2>
@@ -52,6 +56,7 @@
     </template>
   </head>
   <body>
+    <header class="vh-topnav"></header>
     <main class="vh-main">
       <header class="vh-main__header">
         <div class="vh-main__header-text">
@@ -111,8 +116,15 @@
               Baseline output
             </h2>
           </header>
-          <div class="vh-variant-stage" data-variant="baseline">
-            <pre id="output" class="vh-variant-output" data-i18n="output.pending">(pending)</pre>
+          <div class="vh-variant-stage vh-output-section" data-variant="baseline">
+            <div class="vh-progress">
+              <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
+              <div class="vh-progress__row">
+                <span class="vh-progress__label">Initialising…</span>
+                <span class="vh-progress__bytes"></span>
+              </div>
+            </div>
+            <pre id="output" class="vh-variant-output vh-output" data-i18n="output.pending">(pending)</pre>
           </div>
 
           <header class="vh-variant-head vh-variant-head--secondary" data-variant="fix-candidate">
@@ -130,6 +142,8 @@
       </div>
 
     </main>
+
+    <footer class="vh-footer"></footer>
 
     <script type="module" src="./repro.js"></script>
   </body>

--- a/src/layer1_wasm/scripts/validate-output-panes.ts
+++ b/src/layer1_wasm/scripts/validate-output-panes.ts
@@ -87,16 +87,19 @@ const REQUIRED_MARKUP: ReadonlyArray<readonly [string, string]> = [
     'the static `<footer class="vh-footer">` placeholder is missing, so the footer appears only once chrome.js runs.',
   ],
   [
-    'src="../_assets/chrome.js"',
-    'the page does not load `../_assets/chrome.js` from `<head>`, so the chrome arrives one module hop behind repro.js.',
-  ],
-  [
     'class="vh-progress"',
     'the static `.vh-progress` panel is missing, so the loading overlay only appears once chrome.js has built it.',
   ],
+];
+
+const REQUIRED_HEAD_MARKUP: ReadonlyArray<readonly [RegExp, string]> = [
   [
-    'fonts.googleapis.com',
-    'the page does not link the font stylesheet itself; loading it through an `@import` inside style.css blocks first paint on a second round trip.',
+    /<script[^>]+type="module"[^>]+src="\.\.\/_assets\/chrome\.js"/,
+    'the page does not load `../_assets/chrome.js` from `<head>` as a module; loaded from the body, or reached through repro.js, the chrome arrives after first paint.',
+  ],
+  [
+    /<link[^>]+rel="stylesheet"[^>]+fonts\.googleapis\.com/,
+    'the page does not link the font stylesheet from `<head>`; reaching Google Fonts through an `@import` inside style.css blocks first paint on a second round trip.',
   ],
 ];
 
@@ -115,6 +118,18 @@ for (const slug of slugs) {
   recipesChecked++;
 
   const indexBody = readFileSync(indexPath, 'utf-8');
+  const headEnd = indexBody.indexOf('</head>');
+  const indexHead = headEnd === -1 ? '' : indexBody.slice(0, headEnd);
+  for (const [needle, reason] of REQUIRED_HEAD_MARKUP) {
+    check(
+      slug,
+      indexPath,
+      indexHead,
+      needle,
+      reason,
+      'Copy the `<head>` block from src/layer1_wasm/dateutil-1478/index.html — the font links and the chrome module are identical in every recipe.',
+    );
+  }
   for (const [needle, reason] of REQUIRED_MARKUP) {
     check(
       slug,
@@ -164,6 +179,23 @@ for (const slug of slugs) {
       });
     }
   }
+}
+
+const sharedStylePath = join(LAYER1_DIR, '_shared', 'style.css');
+if (
+  existsSync(sharedStylePath) &&
+  /@import[^;]*fonts\.googleapis\.com/.test(
+    readFileSync(sharedStylePath, 'utf-8'),
+  )
+) {
+  failures.push({
+    slug: '_shared',
+    path: relative(REPO_ROOT, sharedStylePath),
+    reason:
+      'style.css reaches Google Fonts through `@import`, which the browser will not paint through — every recipe page renders unstyled until that second round trip lands.',
+    remedy:
+      'Drop the `@import` and link the font stylesheet from each page\'s `<head>`, as src/layer1_wasm/dateutil-1478/index.html does.',
+  });
 }
 
 if (failures.length === 0) {

--- a/src/layer1_wasm/scripts/validate-output-panes.ts
+++ b/src/layer1_wasm/scripts/validate-output-panes.ts
@@ -78,6 +78,26 @@ const REQUIRED_MARKUP: ReadonlyArray<readonly [string, string]> = [
     'id="output-fix"',
     '`<pre id="output-fix">` is missing — there is nowhere to render the fix-candidate output.',
   ],
+  [
+    '<header class="vh-topnav"></header>',
+    'the static `<header class="vh-topnav">` placeholder is missing, so the nav chrome.js injects lands on an unreserved page and pushes every element down after first paint.',
+  ],
+  [
+    '<footer class="vh-footer"></footer>',
+    'the static `<footer class="vh-footer">` placeholder is missing, so the footer appears only once chrome.js runs.',
+  ],
+  [
+    'src="../_assets/chrome.js"',
+    'the page does not load `../_assets/chrome.js` from `<head>`, so the chrome arrives one module hop behind repro.js.',
+  ],
+  [
+    'class="vh-progress"',
+    'the static `.vh-progress` panel is missing, so the loading overlay only appears once chrome.js has built it.',
+  ],
+  [
+    'fonts.googleapis.com',
+    'the page does not link the font stylesheet itself; loading it through an `@import` inside style.css blocks first paint on a second round trip.',
+  ],
 ];
 
 const RETIRED_MARKUP: ReadonlyArray<readonly [string, string]> = [

--- a/src/layer2_docker/_template/index.html
+++ b/src/layer2_docker/_template/index.html
@@ -6,9 +6,14 @@
     <meta name="vivarium-contract" content="v1" />
     <title data-i18n="page.title">Vivarium · Reproducing {{TITLE}}</title>
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" />
     <link rel="stylesheet" href="../_shared/style.css" />
+    <script type="module" src="../_assets/chrome.js"></script>
   </head>
   <body>
+    <header class="vh-topnav"></header>
     <main>
       <header>
         <p class="kicker">Vivarium · Layer 2 · Docker (catalogue)</p>
@@ -37,9 +42,16 @@
         </p>
       </section>
 
-      <section>
+      <section class="vh-output-section vh-output-section--snapshot">
         <h2 data-i18n="section.snapshot.h2">CI snapshot output</h2>
-        <pre id="output" data-i18n="output.placeholder">(loading…)</pre>
+        <div class="vh-progress">
+          <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
+          <div class="vh-progress__row">
+            <span class="vh-progress__label">Initialising…</span>
+            <span class="vh-progress__bytes"></span>
+          </div>
+        </div>
+        <pre id="output" class="vh-output" data-i18n="output.placeholder">(loading…)</pre>
       </section>
 
       <footer>
@@ -50,6 +62,8 @@
         </p>
       </footer>
     </main>
+
+    <footer class="vh-footer"></footer>
 
     <script type="module">
       import { renderVerdictSnapshot } from "../_layer2-shared/layer2.js";

--- a/src/layer2_docker/bash-local-shadows-exit/index.html
+++ b/src/layer2_docker/bash-local-shadows-exit/index.html
@@ -6,9 +6,14 @@
     <meta name="vivarium-contract" content="v1" />
     <title data-i18n="page.title">Vivarium · Reproducing bash `local` shadows command-substitution exit code</title>
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" />
     <link rel="stylesheet" href="../_shared/style.css" />
+    <script type="module" src="../_assets/chrome.js"></script>
   </head>
   <body>
+    <header class="vh-topnav"></header>
     <main>
       <header>
         <p class="kicker">Vivarium · Layer 2 · Docker (catalogue)</p>
@@ -44,9 +49,16 @@
         </p>
       </section>
 
-      <section>
+      <section class="vh-output-section vh-output-section--snapshot">
         <h2 data-i18n="section.snapshot.h2">CI snapshot output</h2>
-        <pre id="output" data-i18n="output.placeholder">(loading…)</pre>
+        <div class="vh-progress">
+          <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
+          <div class="vh-progress__row">
+            <span class="vh-progress__label">Initialising…</span>
+            <span class="vh-progress__bytes"></span>
+          </div>
+        </div>
+        <pre id="output" class="vh-output" data-i18n="output.placeholder">(loading…)</pre>
       </section>
 
       <footer>
@@ -57,6 +69,8 @@
         </p>
       </footer>
     </main>
+
+    <footer class="vh-footer"></footer>
 
     <script type="module">
       import { renderVerdictSnapshot } from "../_layer2-shared/layer2.js";

--- a/src/layer2_docker/find-xargs-whitespace/index.html
+++ b/src/layer2_docker/find-xargs-whitespace/index.html
@@ -6,9 +6,14 @@
     <meta name="vivarium-contract" content="v1" />
     <title data-i18n="page.title">Vivarium · Reproducing find | xargs whitespace splitting</title>
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" />
     <link rel="stylesheet" href="../_shared/style.css" />
+    <script type="module" src="../_assets/chrome.js"></script>
   </head>
   <body>
+    <header class="vh-topnav"></header>
     <main>
       <header>
         <p class="kicker">Vivarium · Layer 2 · Docker (catalogue)</p>
@@ -46,9 +51,16 @@
         </p>
       </section>
 
-      <section>
+      <section class="vh-output-section vh-output-section--snapshot">
         <h2 data-i18n="section.snapshot.h2">CI snapshot output</h2>
-        <pre id="output" data-i18n="output.placeholder">(loading…)</pre>
+        <div class="vh-progress">
+          <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
+          <div class="vh-progress__row">
+            <span class="vh-progress__label">Initialising…</span>
+            <span class="vh-progress__bytes"></span>
+          </div>
+        </div>
+        <pre id="output" class="vh-output" data-i18n="output.placeholder">(loading…)</pre>
       </section>
 
       <footer>
@@ -59,6 +71,8 @@
         </p>
       </footer>
     </main>
+
+    <footer class="vh-footer"></footer>
 
     <script type="module">
       import { renderVerdictSnapshot } from "../_layer2-shared/layer2.js";

--- a/src/layer2_docker/flock-is-advisory/index.html
+++ b/src/layer2_docker/flock-is-advisory/index.html
@@ -6,9 +6,14 @@
     <meta name="vivarium-contract" content="v1" />
     <title data-i18n="page.title">Vivarium · Reproducing flock(2) is advisory only</title>
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" />
     <link rel="stylesheet" href="../_shared/style.css" />
+    <script type="module" src="../_assets/chrome.js"></script>
   </head>
   <body>
+    <header class="vh-topnav"></header>
     <main>
       <header>
         <p class="kicker">Vivarium · Layer 2 · Docker (catalogue)</p>
@@ -45,9 +50,16 @@
         </p>
       </section>
 
-      <section>
+      <section class="vh-output-section vh-output-section--snapshot">
         <h2 data-i18n="section.snapshot.h2">CI snapshot output</h2>
-        <pre id="output" data-i18n="output.placeholder">(loading…)</pre>
+        <div class="vh-progress">
+          <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
+          <div class="vh-progress__row">
+            <span class="vh-progress__label">Initialising…</span>
+            <span class="vh-progress__bytes"></span>
+          </div>
+        </div>
+        <pre id="output" class="vh-output" data-i18n="output.placeholder">(loading…)</pre>
       </section>
 
       <footer>
@@ -58,6 +70,8 @@
         </p>
       </footer>
     </main>
+
+    <footer class="vh-footer"></footer>
 
     <script type="module">
       import { renderVerdictSnapshot } from "../_layer2-shared/layer2.js";

--- a/src/layer2_docker/postgres-lost-update/index.html
+++ b/src/layer2_docker/postgres-lost-update/index.html
@@ -6,9 +6,14 @@
     <meta name="vivarium-contract" content="v1" />
     <title data-i18n="page.title">Vivarium · Reproducing PostgreSQL lost update under READ COMMITTED</title>
     <script>(function(){try{var s=localStorage.getItem('rspress-theme-appearance'),m=window.matchMedia('(prefers-color-scheme: dark)').matches,d=!s||s==='auto'?m:s==='dark';document.documentElement.classList.toggle('dark',d);document.documentElement.classList.toggle('rp-dark',d);document.documentElement.style.colorScheme=d?'dark':'light'}catch(e){}})()</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500;700&amp;display=swap" />
     <link rel="stylesheet" href="../_shared/style.css" />
+    <script type="module" src="../_assets/chrome.js"></script>
   </head>
   <body>
+    <header class="vh-topnav"></header>
     <main>
       <header>
         <p class="kicker">Vivarium · Layer 2 · Docker (catalogue)</p>
@@ -43,9 +48,16 @@
         </p>
       </section>
 
-      <section>
+      <section class="vh-output-section vh-output-section--snapshot">
         <h2 data-i18n="section.snapshot.h2">CI snapshot output</h2>
-        <pre id="output" data-i18n="output.placeholder">(loading…)</pre>
+        <div class="vh-progress">
+          <div class="vh-progress__bar"><div class="vh-progress__fill"></div></div>
+          <div class="vh-progress__row">
+            <span class="vh-progress__label">Initialising…</span>
+            <span class="vh-progress__bytes"></span>
+          </div>
+        </div>
+        <pre id="output" class="vh-output" data-i18n="output.placeholder">(loading…)</pre>
       </section>
 
       <footer>
@@ -56,6 +68,8 @@
         </p>
       </footer>
     </main>
+
+    <footer class="vh-footer"></footer>
 
     <script type="module">
       import { renderVerdictSnapshot } from "../_layer2-shared/layer2.js";


### PR DESCRIPTION
Recipe pages rendered unstyled for the first ~700 ms and then rebuilt themselves under the reader — the black output panes came up tall, a scrollbar flashed, the nav pushed everything down 44 px, and the footer only existed once `chrome.js` had appended it.

## Measured

Chromium, 4× CPU throttle, 1440×760, cache disabled. Live page → this branch:

| Page | before | after |
|---|---|---|
| `/repro/lark/1585/` | 0.030 | **0.002** |
| `/ja/repro/lark/1585/` | 0.065 | **0.000** |
| `/repro/cpython/137205/` | 0.063 | **0.005** |
| `/repro/flock/is-advisory/` (Layer 2) | 0.163 | **0.094** |

## Three causes

**1. The font `@import` blocked first paint.** `style.css` opened with `@import url(fonts.googleapis.com/…)` — a second round trip the browser will not paint through, so the page sat *unstyled* until Google Fonts answered (~700–900 ms throttled). That is the tall panes and the scrollbar flash: unstyled content is full-width and tall. The font stylesheet is now a `<link>` in each page's head with a preconnect to `fonts.gstatic.com`, and `style.css` starts at `:root`.

**2. `main.vh-main` was shrink-to-fit.** It is a flex item with `margin: 0 auto`, so its width came from the intrinsic width of its own text — the webfont swap then resized the whole two-column grid sideways. It now takes `width: 100%` inside the app shell; the 6fr/4fr columns no longer depend on font metrics. Visible effect: on wide screens the content now uses the full 1280 px max-width instead of stopping at its text width.

**3. `chrome.js` created the nav, footer and loading panel.** All three now ship in `index.html` — the two placeholders empty (CSS holds their height: `.vh-topnav` is a fixed 44/60 px, `.vh-footer:empty::before` holds one line), the progress panel with its markup — and `chrome.js` fills what it finds, creating only if a page lacks it. It is also loaded straight from `<head>` instead of arriving three module hops behind `repro.js`.

Layer 2 pages get the same shell plus a 15 rem reserved output box and `.meta:empty` reserving the verdict line.

## Not fixed here

The 0.094 left on the Layer 2 page is the webfont swap reflowing a long single-column document by ~2 px per element. `&display=optional` in the font URL takes it to zero, at the cost of the first paint rendering in the fallback stack on a cold cache — a typography call rather than a bug fix, so it is left out.

## Guards

`validate-output-panes.ts` now requires the shell markup on every recipe, and `.claude/rules/recipe-authoring.md` documents it, so a new recipe cannot regress to the JS-built shell.

## Verification

Layer 1 Playwright 22/22 on chromium locally (Layer 2 cases need the Docker-captured `verdict.json` CI produces), docs unit 113/113, `mise run ci:lint` clean. Browser E2E for all three engines runs here in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)