### PR TITLE
fix(wasm): stop the Path A panel from collapsing the recipe columns

### DIFF
--- a/src/layer1_wasm/_shared/style.css
+++ b/src/layer1_wasm/_shared/style.css
@@ -1303,6 +1303,25 @@ body.vh-drawer-open {
     flex-shrink: 0;
   }
 
+  body:has(#path-a-mount) {
+    height: auto;
+    overflow: visible;
+  }
+
+  body:has(#path-a-mount) > main.vh-main {
+    flex: 0 0 auto;
+    overflow: visible;
+  }
+
+  body:has(#path-a-mount) > main.vh-main > .vh-main__cols {
+    flex: 0 0 auto;
+    min-height: 60vh;
+  }
+
+  body:has(#path-a-mount) .vh-main__col {
+    overflow: visible;
+  }
+
   .vh-main__col {
     height: 100%;
     min-height: 0;

--- a/src/layer1_wasm/_shared/style.css
+++ b/src/layer1_wasm/_shared/style.css
@@ -1203,7 +1203,8 @@ main > footer code {
   height: 12px;
 }
 
-body.vh-drawer-open {
+body.vh-drawer-open,
+body.vh-drawer-open:has(#path-a-mount) {
   overflow: hidden;
 }
 


### PR DESCRIPTION
php-12167 renders with its reproduction script and both output panes at **zero height** — everything below the header is the "Try a fix" panel.

## Why

The app shell locks the page to the viewport (`body` is a 100vh flex column with `overflow: hidden`) and gives `.vh-main__cols` `flex: 1 1 0` — a zero basis that only grows into free space. The Path A section carries `flex-shrink: 0` so it cannot be squashed, so at 914px against an 828px `main` there is no free space left: the panel takes all of it and the columns resolve to 0px.

Measured on the live page at 1440×900:

| element | height |
|---|---|
| `main.vh-main` | 828px |
| `.vh-main__cols` | **0px** |
| `#path-a-mount` | 914px |

This predates the recent page work (the rule is older than #367) and php-12167 is the only recipe that mounts Path A, which is why it looks php-specific.

## Fix

A recipe that carries a Path A section opts out of the viewport lock: the page scrolls, the columns keep a 60vh floor, and the panel sits below them at its natural height.

The opt-out keys off the section **existing**, not off it being visible — so the page is in its final layout mode from first paint, and mounting the panel after the baseline run does not re-flow what is above it. Keying it off `:not([hidden])` instead measured CLS 0.166 from the mode switch.

## Numbers

| page | before | after |
|---|---|---|
| php-12167 | 0.006 (cheap only because nothing visible could move) | **0.064** |
| lark-1585 | 0.0006 | 0.0017 |
| ruby-21709 | — | 0.0039 |

What is left on php is the webfont swap plus the footer sliding below the fold when the panel mounts. Reserving the panel's height ahead of time would need `path_a.ts` to mount a skeleton before the baseline run — a behaviour change, not a stylesheet one; happy to follow up if wanted.

## Verification

Layer 1 Playwright 22/22 on chromium locally (php-12167 included), `mise run ci:lint` clean, and the page screenshotted before and after: the two columns are back, with the panel below them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)