### PR TITLE
fix(ci): stop the state artifact lease from lapsing

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -9,6 +9,10 @@ on:
       - '.github/workflows/terraform-apply.yml'
   workflow_dispatch:
 
+concurrency:
+  group: terraform-state
+  cancel-in-progress: false
+
 permissions:
   contents: read
   actions: write

--- a/.github/workflows/terraform-state-backup.yml
+++ b/.github/workflows/terraform-state-backup.yml
@@ -42,7 +42,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id || vars.LATEST_APPLY_RUN_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fall back to the newest state-backup release
+      - name: Report the missing artifact and stop
         if: steps.artifact.outcome != 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -50,14 +50,8 @@ jobs:
           set -euo pipefail
           tag="$(gh release list --limit 100 --json tagName,isPrerelease \
             --jq '[.[] | select(.isPrerelease and (.tagName | startswith("state-backup-")))][0].tagName')"
-          if [ -z "${tag}" ] || [ "${tag}" = "null" ]; then
-            echo "::error::The state artifact is gone and no state-backup release exists to fall back to."
-            exit 1
-          fi
-          echo "::warning::State artifact unavailable; falling back to release ${tag}."
-          mkdir -p ./state-backup
-          gh release download "${tag}" --pattern '*.tfstate' --dir ./state-backup
-          mv ./state-backup/terraform-*.tfstate ./state-backup/terraform.tfstate
+          echo "::error::The terraform-state artifact for run ${{ github.event.workflow_run.id || vars.LATEST_APPLY_RUN_ID }} could not be downloaded, so this run cannot publish a backup or renew the artifact lease. Newest release backup: ${tag:-none}. Restore with the Seed Terraform State workflow, then re-run this one."
+          exit 1
 
       - name: Verify state file present
         id: check

--- a/.github/workflows/terraform-state-backup.yml
+++ b/.github/workflows/terraform-state-backup.yml
@@ -16,7 +16,7 @@ permissions:
   actions: write  # Required to read artifacts and re-upload the renewed one.
 
 concurrency:
-  group: terraform-state-backup
+  group: terraform-state
   cancel-in-progress: false
 
 jobs:
@@ -32,6 +32,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Resolve the run holding the state
+        id: source
+        run: |
+          echo "run_id=${{ github.event.workflow_run.id || vars.LATEST_APPLY_RUN_ID }}" >> "$GITHUB_OUTPUT"
+
       - name: Download latest state artifact
         id: artifact
         continue-on-error: true
@@ -39,7 +44,7 @@ jobs:
         with:
           name: terraform-state
           path: ./state-backup/
-          run-id: ${{ github.event.workflow_run.id || vars.LATEST_APPLY_RUN_ID }}
+          run-id: ${{ steps.source.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Report the missing artifact and stop
@@ -50,7 +55,7 @@ jobs:
           set -euo pipefail
           tag="$(gh release list --limit 100 --json tagName,isPrerelease \
             --jq '[.[] | select(.isPrerelease and (.tagName | startswith("state-backup-")))][0].tagName')"
-          echo "::error::The terraform-state artifact for run ${{ github.event.workflow_run.id || vars.LATEST_APPLY_RUN_ID }} could not be downloaded, so this run cannot publish a backup or renew the artifact lease. Newest release backup: ${tag:-none}. Restore with the Seed Terraform State workflow, then re-run this one."
+          echo "::error::The terraform-state artifact for run ${{ steps.source.outputs.run_id }} could not be downloaded, so this run cannot publish a backup or renew the artifact lease. Newest release backup: ${tag:-none}. Restore with the Seed Terraform State workflow, then re-run this one."
           exit 1
 
       - name: Verify state file present
@@ -125,24 +130,30 @@ jobs:
 
       - name: Point LATEST_APPLY_RUN_ID at this run
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SOURCE_RUN_ID: ${{ steps.source.outputs.run_id }}
         with:
           github-token: ${{ secrets.TF_TOKEN_GITHUB }}
           script: |
-            try {
-              await github.rest.actions.createRepoVariable({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: 'LATEST_APPLY_RUN_ID',
-                value: '${{ github.run_id }}',
-              });
-            } catch (e) {
-              await github.rest.actions.updateRepoVariable({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: 'LATEST_APPLY_RUN_ID',
-                value: '${{ github.run_id }}',
-              });
+            const expected = process.env.SOURCE_RUN_ID;
+            const { data } = await github.rest.actions.getRepoVariable({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'LATEST_APPLY_RUN_ID',
+            });
+            if (data.value !== expected) {
+              core.warning(
+                `LATEST_APPLY_RUN_ID moved to ${data.value} while this run was reading ${expected}; ` +
+                  'a newer apply owns the state, so the lease is left alone.',
+              );
+              return;
             }
+            await github.rest.actions.updateRepoVariable({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'LATEST_APPLY_RUN_ID',
+              value: '${{ github.run_id }}',
+            });
 
       - name: Cleanup old backups (keep last 12)
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/terraform-state-backup.yml
+++ b/.github/workflows/terraform-state-backup.yml
@@ -13,7 +13,7 @@ on:
 
 permissions:
   contents: write # Required to create releases.
-  actions: read   # Required to read artifacts.
+  actions: write  # Required to read artifacts and re-upload the renewed one.
 
 concurrency:
   group: terraform-state-backup
@@ -33,6 +33,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download latest state artifact
+        id: artifact
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: terraform-state
@@ -40,11 +42,32 @@ jobs:
           run-id: ${{ github.event.workflow_run.id || vars.LATEST_APPLY_RUN_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Fall back to the newest state-backup release
+        if: steps.artifact.outcome != 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="$(gh release list --limit 100 --json tagName,isPrerelease \
+            --jq '[.[] | select(.isPrerelease and (.tagName | startswith("state-backup-")))][0].tagName')"
+          if [ -z "${tag}" ] || [ "${tag}" = "null" ]; then
+            echo "::error::The state artifact is gone and no state-backup release exists to fall back to."
+            exit 1
+          fi
+          echo "::warning::State artifact unavailable; falling back to release ${tag}."
+          mkdir -p ./state-backup
+          gh release download "${tag}" --pattern '*.tfstate' --dir ./state-backup
+          mv ./state-backup/terraform-*.tfstate ./state-backup/terraform.tfstate
+
       - name: Verify state file present
         id: check
         run: |
           if [ ! -f ./state-backup/terraform.tfstate ]; then
             echo "::error::Expected ./state-backup/terraform.tfstate after artifact download but the file is missing."
+            exit 1
+          fi
+          if ! jq -e '.resources | length > 0' ./state-backup/terraform.tfstate >/dev/null 2>&1; then
+            echo "::error::State has no resources. Refusing to publish it as a backup or renew the artifact from it."
             exit 1
           fi
           echo "state_size=$(stat -c%s ./state-backup/terraform.tfstate)" >> $GITHUB_OUTPUT
@@ -56,9 +79,9 @@ jobs:
           echo "datetime=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
           echo "tag=state-backup-$(date -u +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
 
-      - name: Rename state file with timestamp
+      - name: Copy state file under its timestamped name
         run: |
-          mv ./state-backup/terraform.tfstate \
+          cp ./state-backup/terraform.tfstate \
              ./state-backup/terraform-${{ steps.timestamp.outputs.date }}.tfstate
 
       - name: Create Release with state backup
@@ -93,10 +116,39 @@ jobs:
           NOTES
 
           gh release create "${TAG}" \
-            ./state-backup/*.tfstate \
+            "./state-backup/terraform-${DATE}.tfstate" \
             --title "State Backup ${DATE}" \
             --notes-file release_notes.md \
             --prerelease
+
+      - name: Renew the terraform-state artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: terraform-state
+          path: ./state-backup/terraform.tfstate
+          retention-days: 90
+          overwrite: true
+
+      - name: Point LATEST_APPLY_RUN_ID at this run
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.TF_TOKEN_GITHUB }}
+          script: |
+            try {
+              await github.rest.actions.createRepoVariable({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'LATEST_APPLY_RUN_ID',
+                value: '${{ github.run_id }}',
+              });
+            } catch (e) {
+              await github.rest.actions.updateRepoVariable({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'LATEST_APPLY_RUN_ID',
+                value: '${{ github.run_id }}',
+              });
+            }
 
       - name: Cleanup old backups (keep last 12)
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
Diagnosis for #365. The apply failure has nothing to do with the commit it was filed against — the state had already been gone for two weeks.

## What happened

`infra/github`'s state lives in an **Actions artifact**, carried run to run through the `LATEST_APPLY_RUN_ID` repo variable. Artifacts expire after 90 days.

| | |
|---|---|
| Last successful apply | **2026-05-19** (run 26068559101, state 6,129 bytes) |
| That artifact expired | ~**2026-08-17** (90 days) |
| Weekly backup started failing | **2026-08-17** — `Unable to download artifact(s): Artifact has expired` |
| Newest surviving release backup | **2026-08-10** |
| Apply triggered by #364 landing | **2026-09-03** → failed |

With no state, OpenTofu planned to create everything and died on the first resource:

```
Error: POST https://api.github.com/orgs/aletheia-works/repos: 422
  Repository creation failed. [name already exists on this account]
```

The failed run then uploaded a **336-byte** state (a real one is ~6 KB) and pointed `LATEST_APPLY_RUN_ID` at itself, so the next apply would fail the same way.

**Why the weekly backup did not save it:** the backup reads the *same* artifact. When the artifact expired, the backup began failing (08-17, 08-24, 08-31) and stopped producing releases. Backup and apply shared one point of failure.

## This PR

`terraform-state-backup.yml` stops letting the artifact age out, and stops failing silently when it has:

- after publishing, it re-uploads the state as a fresh `terraform-state` artifact and points `LATEST_APPLY_RUN_ID` at the backup run — the weekly run rolls the 90-day window forward whether or not an apply happened, so a quiet quarter cannot strand the state again
- it refuses to publish or renew from a state with no resources — the guard `seed-state.yml` already applies, and it is what would stop today's 336-byte state from being blessed
- when the artifact cannot be downloaded it reports the run it wanted, names the newest release backup, points at the Seed Terraform State workflow, and fails

A release fallback was in the first revision of this PR and came out after review: sourcing state from a release makes an *older* state canonical, and a transient download failure right after an apply would be enough to trigger it. Freshness cannot be established from the release chain, because the newer state is precisely what failed to download. Publishing and renewal now only ever run on state read from the artifact.

## Recovering the current state (human action)

`seed-state.yml` already exists for exactly this. The newest backup validates: `serial 35`, 6 resource blocks, 24,539 bytes — and its base64 is 32,720 characters, inside the 65,535-character `workflow_dispatch` input limit.

```bash
gh release download state-backup-20260810-044107 --repo aletheia-works/vivarium \
  --pattern '*.tfstate' --dir /tmp
gh workflow run seed-state.yml --repo aletheia-works/vivarium \
  -f state_b64="$(base64 -w0 /tmp/terraform-2026-08-10.tfstate)"
gh workflow run terraform-apply.yml --repo aletheia-works/vivarium   # re-run once seeded
```

Merge order does not matter: this PR changes no state and reads none. Before the seed, the weekly backup fails either way — today on the empty-state guard instead of on a missing artifact. After the seed, merging this makes the following weekly run start rolling the lease forward.

Left alone deliberately: state seeding and `tofu apply` against production state are human operations per AGENTS.md §2.

## Also worth knowing

The cleanup step keeps the last 12 backups. Once weekly backups resume, the 2026-08-10 copy leaves that window in about 12 weeks — so the seed above is worth doing before then.

Verified with `actionlint` (clean) and `mise run ci:lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)