### PR TITLE
fix(ci): page through releases when trimming old backups

### DIFF
--- a/.github/workflows/terraform-state-backup.yml
+++ b/.github/workflows/terraform-state-backup.yml
@@ -159,11 +159,14 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const { data: releases } = await github.rest.repos.listReleases({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              per_page: 100,
-            });
+            const releases = await github.paginate(
+              github.rest.repos.listReleases,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              },
+            );
 
             // Only target prereleases with the state-backup- tag prefix.
             const backups = releases


### PR DESCRIPTION
Carry-over from the review on [aletheia-works/.github#43](https://github.com/aletheia-works/.github/pull/43), which found the same defect in the copy of this workflow there.

The keep-last-12 cleanup lists **one page** of releases before filtering by the `state-backup-` prefix:

```js
const { data: releases } = await github.rest.repos.listReleases({ per_page: 100 });
```

Weekly backups plus every other release in the repo eventually push matching backups past that first page. Once a backup is off it, the filter never sees it again and it is never deleted — the cap quietly stops holding and old state assets accumulate.

`github.paginate` walks the full list instead. Nothing else changes: same filter, same retention, same deletion path.

Verified with `actionlint` (clean) and `mise run ci:lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)