### PR TITLE
fix(wasm): ship the runner controls, and give every recipe the same script pane

### DIFF
--- a/docs/scripts/generate-repro-pages.ts
+++ b/docs/scripts/generate-repro-pages.ts
@@ -138,6 +138,7 @@ function fill(template: string, values: Record<string, string>): string {
   for (const [key, value] of Object.entries(values)) {
     out = out.replaceAll(`{{${key}}}`, value);
   }
+  out = out.replace(/\n[ \t]*\n(\s*<\/div>)/g, '\n$1');
   const leftover = out.match(/\{\{[A-Z_]+\}\}/);
   if (leftover && !Object.values(values).some((v) => v.includes(leftover[0]))) {
     throw new Error(`unfilled placeholder ${leftover[0]}`);
@@ -169,6 +170,40 @@ function reproCode(recipeDir: string, slug: string): string {
   if (!source) return '';
   unhighlighted.push(slug);
   return escapeHtml(source);
+}
+
+const RUNNER_BUTTONS: ReadonlyArray<readonly [string, string, string, string]> =
+  [
+    [
+      'edit',
+      'vh-runner__btn--ghost',
+      'Edit',
+      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/></svg>',
+    ],
+    [
+      'run',
+      'vh-runner__btn--primary',
+      'Run',
+      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="6 4 20 12 6 20 6 4"/></svg>',
+    ],
+    [
+      'reset',
+      'vh-runner__btn--ghost',
+      'Reset',
+      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>',
+    ],
+  ];
+
+function runnerActions(recipeDir: string): string {
+  const reproTs = join(recipeDir, 'repro.ts');
+  if (!existsSync(reproTs)) return '';
+  if (!readFileSync(reproTs, 'utf-8').includes('enableRunner(')) return '';
+  const buttons = RUNNER_BUTTONS.map(
+    ([key, variant, label, svg]) =>
+      `              <button type="button" class="vh-runner__btn ${variant}" data-vh-runner="${key}" disabled>` +
+      `<span aria-hidden="true">${svg}</span><span data-i18n="runner.${key}">${label}</span></button>`,
+  ).join('\n');
+  return `            <div class="vh-runner__actions">\n${buttons}\n            </div>`;
 }
 
 function fixChip(recipeDir: string): string {
@@ -255,6 +290,7 @@ function renderLayer1(): void {
       VERDICT_PENDING: shell.verdictPending,
       DRAWER_BODY: indent(slots['drawer-body'] ?? '', 8),
       FIX_CHIP: fixChip(dir),
+      RUNNER_ACTIONS: runnerActions(dir),
       REPRO_CODE: reproCode(dir, slug),
       FIX_PANE: indent(slots['fix-pane'] ?? '', 10),
       EXTRA_SECTIONS: slots.sections ? `\n${indent(slots.sections, 6)}\n` : '',

--- a/src/layer1_wasm/_shared/page.template.html
+++ b/src/layer1_wasm/_shared/page.template.html
@@ -56,7 +56,10 @@
 
       <div class="vh-main__cols">
         <section class="vh-main__col vh-main__col--script">
-          <h2 data-i18n="section.script.h2">{{SCRIPT_HEADING}}</h2>
+          <div class="vh-runner__head">
+            <h2 data-i18n="section.script.h2">{{SCRIPT_HEADING}}</h2>
+{{RUNNER_ACTIONS}}
+          </div>
           <pre><code id="repro-code">{{REPRO_CODE}}</code></pre>
         </section>
 

--- a/src/layer1_wasm/_shared/runner.ts
+++ b/src/layer1_wasm/_shared/runner.ts
@@ -140,49 +140,61 @@ export function enableRunner(opts: RunnerOptions): void {
   preParent.insertBefore(placeholder, preEl);
   viewport.append(preEl, textarea);
 
-  const editBtn = el(
-    'button',
-    {
-      type: 'button',
-      class: 'vh-runner__btn vh-runner__btn--ghost',
-      'aria-label': S.editAria,
-    },
-    el('span', { 'aria-hidden': 'true' }),
+  function button(
+    key: 'edit' | 'run' | 'reset',
+    variant: string,
+    label: string,
+    ariaLabel: string,
+    svg: string,
+  ): HTMLButtonElement {
+    const existing = colEl?.querySelector<HTMLButtonElement>(
+      `.vh-runner__btn[data-vh-runner="${key}"]`,
+    );
+    if (existing) {
+      existing.setAttribute('aria-label', ariaLabel);
+      return existing;
+    }
+    const made = el(
+      'button',
+      {
+        type: 'button',
+        class: `vh-runner__btn ${variant}`,
+        'data-vh-runner': key,
+        'aria-label': ariaLabel,
+      },
+      el('span', { 'aria-hidden': 'true' }),
+      el('span', {}, label),
+    ) as HTMLButtonElement;
+    made.firstElementChild!.innerHTML = svg;
+    return made;
+  }
+
+  const editBtn = button(
+    'edit',
+    'vh-runner__btn--ghost',
     S.edit,
-  ) as HTMLButtonElement;
-  editBtn.firstElementChild!.innerHTML = SVG_PENCIL;
-
-  const runBtn = el(
-    'button',
-    {
-      type: 'button',
-      class: 'vh-runner__btn vh-runner__btn--primary',
-      'aria-label': S.runAria,
-    },
-    el('span', { 'aria-hidden': 'true' }),
-    S.run,
-  ) as HTMLButtonElement;
-  runBtn.firstElementChild!.innerHTML = SVG_PLAY;
-
-  const resetBtn = el(
-    'button',
-    {
-      type: 'button',
-      class: 'vh-runner__btn vh-runner__btn--ghost',
-      'aria-label': S.resetAria,
-    },
-    el('span', { 'aria-hidden': 'true' }),
-    S.reset,
-  ) as HTMLButtonElement;
-  resetBtn.firstElementChild!.innerHTML = SVG_RESET;
-
-  const actions = el(
-    'div',
-    { class: 'vh-runner__actions' },
-    editBtn,
-    runBtn,
-    resetBtn,
+    S.editAria,
+    SVG_PENCIL,
   );
+  const runBtn = button(
+    'run',
+    'vh-runner__btn--primary',
+    S.run,
+    S.runAria,
+    SVG_PLAY,
+  );
+  const resetBtn = button(
+    'reset',
+    'vh-runner__btn--ghost',
+    S.reset,
+    S.resetAria,
+    SVG_RESET,
+  );
+
+  const staticActions = colEl?.querySelector<HTMLElement>('.vh-runner__actions');
+  const actions =
+    staticActions ??
+    el('div', { class: 'vh-runner__actions' }, editBtn, runBtn, resetBtn);
 
   const statusEl = el('p', {
     class: 'vh-runner__status',
@@ -190,13 +202,16 @@ export function enableRunner(opts: RunnerOptions): void {
     'aria-live': 'polite',
   });
 
-  if (h2El?.parentElement) {
-    const headRow = el('div', { class: 'vh-runner__head' });
-    h2El.parentElement.insertBefore(headRow, h2El);
-    headRow.append(h2El, actions);
-  } else {
-    viewport.parentElement?.insertBefore(actions, viewport);
+  if (!actions.isConnected) {
+    if (h2El?.parentElement) {
+      const headRow = el('div', { class: 'vh-runner__head' });
+      h2El.parentElement.insertBefore(headRow, h2El);
+      headRow.append(h2El, actions);
+    } else {
+      viewport.parentElement?.insertBefore(actions, viewport);
+    }
   }
+  for (const btn of [editBtn, runBtn, resetBtn]) btn.disabled = false;
 
   const shell = el(
     'div',

--- a/src/layer1_wasm/_shared/style.css
+++ b/src/layer1_wasm/_shared/style.css
@@ -949,6 +949,18 @@ main > footer code {
   box-shadow: 0 0 0 3px rgba(0, 212, 170, 0.12);
 }
 
+.vh-runner__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  min-height: 2rem;
+}
+
+.vh-runner__head h2 {
+  margin: 0;
+}
+
 .vh-runner__actions {
   display: flex;
   flex-wrap: wrap;
@@ -1334,8 +1346,15 @@ body.vh-drawer-open:has(#path-a-mount) {
     flex-direction: column;
   }
 
-  .vh-main__col--script > h2 {
+  .vh-main__col--script > h2,
+  .vh-main__col--script > .vh-runner__head {
     flex-shrink: 0;
+  }
+
+  .vh-main__col--script > pre {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
   }
 
   .vh-runner {

--- a/src/layer1_wasm/cpython-137205/i18n.ja.json
+++ b/src/layer1_wasm/cpython-137205/i18n.ja.json
@@ -21,6 +21,9 @@
     "verdict.pending": "Pyodide runtime を読み込み中…",
     "drawer.body.p1": "Python の {0} は、{2} で開いた接続では {1} を黙って捨てる。{3} で開いた別の接続では同じ PRAGMA が効くため、本来同じ FK 強制になるはずの 2 つの接続が食い違う。",
     "drawer.body.p2": "このページのスクリプトは両方の接続を開き、それぞれに同じ PRAGMA を発行して、結果の {0} を読み戻す。2 つの値が食い違えば、いま開いているタブの runtime で bug が再現している。",
-    "drawer.body.p3": "議論の全体（動機、再現のバリエーション、パッチの進捗など）は下の GitHub issue リンクを辿る。そのスレッドがこの bug の正典。"
+    "drawer.body.p3": "議論の全体（動機、再現のバリエーション、パッチの進捗など）は下の GitHub issue リンクを辿る。そのスレッドがこの bug の正典。",
+    "runner.edit": "編集",
+    "runner.run": "実行",
+    "runner.reset": "リセット"
   }
 }

--- a/src/layer1_wasm/dateutil-1478/i18n.ja.json
+++ b/src/layer1_wasm/dateutil-1478/i18n.ja.json
@@ -24,6 +24,9 @@
     "section.baseline.h2": "baseline の出力",
     "output.pending": "(待機中)",
     "section.fix.h2": "fix 候補の出力",
-    "output.waitingBaseline": "(baseline を待機中)"
+    "output.waitingBaseline": "(baseline を待機中)",
+    "runner.edit": "編集",
+    "runner.run": "実行",
+    "runner.reset": "リセット"
   }
 }

--- a/src/layer1_wasm/numpy-28287/i18n.ja.json
+++ b/src/layer1_wasm/numpy-28287/i18n.ja.json
@@ -21,6 +21,9 @@
     "verdict.pending": "Pyodide runtime を読み込み中…",
     "drawer.body.p1": "NumPy の {0} の順序付けは、値のひとつが {1} 単位を使っていると推移的でなくなる。{2}、{3}、{4} に対して NumPy は {5} と {6} を報告するのに {7} となる——組み込みの比較演算子における推移律の違反。",
     "drawer.body.p2": "このページのスクリプトはその 3 つの値を構築し、3 通りの pairwise 比較をすべて実行して、合成条件（{0} かつ {1} かつ {2}）が成り立つかを報告する。成り立てば、Pyodide が現在同梱する NumPy ビルドで bug が再現している。",
-    "drawer.body.p3": "議論の全体（動機、再現のバリエーション、fix の進捗）は下の GitHub issue スレッドにある。"
+    "drawer.body.p3": "議論の全体（動機、再現のバリエーション、fix の進捗）は下の GitHub issue スレッドにある。",
+    "runner.edit": "編集",
+    "runner.run": "実行",
+    "runner.reset": "リセット"
   }
 }

--- a/src/layer1_wasm/pandas-56679/i18n.ja.json
+++ b/src/layer1_wasm/pandas-56679/i18n.ja.json
@@ -21,6 +21,9 @@
     "verdict.pending": "Pyodide runtime を読み込み中…",
     "drawer.body.p1": "{0} は dtype {1} を返すのに、{2} は dtype {3} を返す。この 2 つのコンストラクタは、空の入力に対して一貫した dtype を返すべき。",
     "drawer.body.p2": "このページのスクリプトは両方の形を構築して dtype を比較する。dtype が食い違えば、Pyodide が現在同梱する pandas ビルドで bug が再現している。",
-    "drawer.body.p3": "議論の全体（動機、経緯、fix の進捗）は下の GitHub issue スレッドにある。"
+    "drawer.body.p3": "議論の全体（動機、経緯、fix の進捗）は下の GitHub issue スレッドにある。",
+    "runner.edit": "編集",
+    "runner.run": "実行",
+    "runner.reset": "リセット"
   }
 }

--- a/src/layer1_wasm/ruby-21709/i18n.ja.json
+++ b/src/layer1_wasm/ruby-21709/i18n.ja.json
@@ -21,6 +21,9 @@
     "verdict.pending": "Ruby.wasm runtime を読み込み中…",
     "drawer.body.p1": "Ruby の Regexp の式展開はエンコーディングの異なる断片を拒否するのに、String の式展開は黙って UTF-8 に昇格させる。{0} と {1} を使うと、{2} は {3} を送出する一方で {4} は UTF-8 の文字列を組み立てる。",
     "drawer.body.p2": "2 つの式展開は、エンコーディングの異なる断片をどう結合するかで一致すべき。このページのスクリプトは両方を試し、それぞれが例外を送出したかを記録して、verdict のロジックが reproduced か unreproduced かを決めるのに使う JSON サマリを返す。",
-    "drawer.body.p3": "議論の全体（動機、fix の進捗）は下の GitHub issue スレッドにある。"
+    "drawer.body.p3": "議論の全体（動機、fix の進捗）は下の GitHub issue スレッドにある。",
+    "runner.edit": "編集",
+    "runner.run": "実行",
+    "runner.reset": "リセット"
   }
 }


### PR DESCRIPTION
Two kinds of movement in the left column, both after the page had otherwise settled.

## 1. The controls appeared late

`enableRunner` built Edit / Run / Reset **after the baseline run**, and building them wrapped the section heading in a row that is 30px tall where a bare `<h2>` is 18px. Measured on cpython-137205 at 1440×900:

| | before | after |
|---|---|---|
| heading row | absent → **30px at t=5.6s** | **30px from first paint** |
| `<h2>` top | 85 → **91** at 5.6s | 91 throughout |
| code pane top | 120 → **124** at 5.6s | 124 throughout |

The controls now ship in the page **disabled**; `enableRunner` adopts them (`data-vh-runner="edit|run|reset"`) and enables them when the runtime is ready, instead of creating them.

## 2. Recipes disagreed about the pane

The heading row only existed where a runner did, so regex-779 and lark-1585 sat **12px higher** than the rest. And the pane itself differed much more: the runner wraps the `<pre>` in a viewport that fills the column, so a runner recipe went **490px → 742px** on mount while a recipe without one stayed at its content height — **289px** on regex-779.

Both are now uniform: the heading row is part of the template with or without controls in it, and the shell gives a bare `<pre>` in the script column the same flex treatment the runner's viewport gets.

| recipe | heading row | pane, first paint | pane, settled |
|---|---|---|---|
| cpython-137205 (runner) | 30px | 740 | 742 |
| regex-779 (no runner) | 30px | 741 | 741 |
| lark-1585 (no runner) | 30px | 738 | 738 |

## Localisation

The static labels carry `data-i18n` keys, with the strings added to the five runner recipes' `i18n.ja.json`, so a Japanese page reads 編集 / 実行 / リセット while loading rather than English until the runner takes over. The values match `runner.ts`'s own `STRINGS_JA`, which still drives the dynamic states (View, Running…).

## Verified

On chromium, locally: geometry identical across the three recipes from the first frame; the adopted buttons still work end to end — Edit opens the textarea and flips to View, Run re-runs (`reproduced`, fresh output), Reset restores the baseline. Layer 1 Playwright 15/15, `ci:lint` and docs unit clean.

Note for reviewers: a generated `index.ja.html` carries `<base href="/vivarium/repro/…">`, so it cannot be checked on a bare static server — its assets resolve into the deployed tree. The Japanese labels above were read from the DOM, not from a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)