### PR TITLE
chore(lint): target ruff at py314, and unblock Claude Review on fork PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr-head
+          allow-unsafe-pr-checkout: true
 
       - uses: anthropics/claude-code-action@833fb0f8c9f6686b33d963a8bae0a94f4936ab2a # v1
         with:

--- a/docs/site/en/guide/write-your-first-reproduction.mdx
+++ b/docs/site/en/guide/write-your-first-reproduction.mdx
@@ -135,7 +135,7 @@ python -m http.server -d src/layer1_wasm/<your-slug> 8765
   >
     <p>A reproduction observed via Pyodide / Ruby.wasm is more convincing when it also reproduces on a native CPython / MRI Ruby. For Python,{' '} <a href="https://docs.astral.sh/uv/">uv</a> + PEP 723 inline metadata gives you a single-file companion:</p>
     <pre><code>{`# /// script
-# requires-python = ">=3.13"
+# requires-python = ">=3.14"
 # dependencies = ["pandas==2.3.3"]
 # ///
 import pandas as pd

--- a/docs/site/ja/guide/write-your-first-reproduction.mdx
+++ b/docs/site/ja/guide/write-your-first-reproduction.mdx
@@ -135,7 +135,7 @@ python -m http.server -d src/layer1_wasm/<あなたの slug> 8765
   >
     <p>Pyodide / Ruby.wasm 経由で観測できたバグが、本物の CPython / MRI Ruby でも同じく再現することを示すと、レシピの説得力が上がります。 Python なら <a href="https://docs.astral.sh/uv/">uv</a> +{' '} PEP 723 inline metadata で 1 ファイル完結に書けます:</p>
     <pre><code>{`# /// script
-# requires-python = ">=3.13"
+# requires-python = ">=3.14"
 # dependencies = ["pandas==2.3.3"]
 # ///
 import pandas as pd

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,8 +1,8 @@
-target-version = "py313"
+target-version = "py314"
 
 line-length = 100
 
-include = ["src/layer1_wasm/*/repro.py", "docs/scripts/**/*.py"]
+include = ["src/layer1_wasm/*/*.py", "docs/scripts/**/*.py"]
 extend-exclude = [
   "**/node_modules/**",
   "**/dist/**",

--- a/scripts/build-layer1-wheels.sh
+++ b/scripts/build-layer1-wheels.sh
@@ -38,7 +38,7 @@ for src_json in "${sources[@]}"; do
 
   rm -f "$wheels_dir"/*.whl "$wheels_dir/manifest.json"
 
-  uv run --no-project --with pip --python 3.13 -- \
+  uv run --no-project --with pip --python 3.14 -- \
     python -m pip wheel --no-deps \
     --wheel-dir "$wheels_dir" \
     "$pip_spec"

--- a/src/layer1_wasm/lark-1585/verify_fix.py
+++ b/src/layer1_wasm/lark-1585/verify_fix.py
@@ -53,7 +53,7 @@ import subprocess
 import sys
 import textwrap
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 TIMEOUT_S = 8.0
 
@@ -108,7 +108,7 @@ def run_variant(variant: dict[str, str]) -> dict[str, object]:
                 "run",
                 "--no-project",
                 "--python",
-                "3.13",
+                "3.14",
                 "--with",
                 variant["spec"],
                 "--",
@@ -169,9 +169,9 @@ def run_variant(variant: dict[str, str]) -> dict[str, object]:
 
 
 def main() -> int:
-    started_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    started_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
     variants = [run_variant(v) for v in VARIANTS]
-    finished_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    finished_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
     baseline = next(v for v in variants if v["name"] == "baseline")
     fix = next(v for v in variants if v["name"] == "fix-candidate")

--- a/src/layer1_wasm/playwright.config.ts
+++ b/src/layer1_wasm/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
 
   webServer: [
     {
-      command: `uv run --no-project --python 3.13 python -m http.server ${LAYER1_PORT}`,
+      command: `uv run --no-project --python 3.14 python -m http.server ${LAYER1_PORT}`,
       url: `${LAYER1_BASE}/`,
       reuseExistingServer: !process.env["CI"],
       timeout: 30_000,
@@ -35,7 +35,7 @@ export default defineConfig({
       stderr: "pipe",
     },
     {
-      command: `uv run --no-project --python 3.13 python -m http.server ${LAYER2_PORT}`,
+      command: `uv run --no-project --python 3.14 python -m http.server ${LAYER2_PORT}`,
       cwd: "../layer2_docker",
       url: `${LAYER2_BASE}/`,
       reuseExistingServer: !process.env["CI"],


### PR DESCRIPTION
## What

Three commits: a Python-version sweep across the repo, and an unrelated CI unblock bundled at the maintainer's request.

**1. Align the Python tooling with the runtime the Layer 1 recipes reproduce against.**

- `ruff.toml`: `target-version` `py313` → `py314`; `include` `src/layer1_wasm/*/repro.py` → `src/layer1_wasm/*/*.py`.
- `src/layer1_wasm/lark-1585/verify_fix.py`: UP017 autofixes (4), probe subprocess `--python 3.13` → `3.14`.
- `src/layer1_wasm/playwright.config.ts`: both `webServer` commands `--python 3.13` → `3.14`.
- `scripts/build-layer1-wheels.sh`: `pip wheel` interpreter `--python 3.13` → `3.14`.
- `docs/site/{en,ja}/guide/write-your-first-reproduction.mdx`: PEP 723 sample `requires-python` `>=3.13` → `>=3.14`.

**2. Unblock the Claude Review workflow on fork PRs.**

- `.github/workflows/claude-review.yml`: `allow-unsafe-pr-checkout: true` on the `pr-head` checkout.

## Why

**(1)** `_shared/loader.ts` pins `DEFAULT_PYODIDE_VERSION = "314.0.6"` (Python 3.14.2) and `mise.toml`'s `repro:native:python` runs `uv run --python 3.14`, but ruff still resolved rules against py313, so the `UP` rules neither proposed 3.14-era idioms nor flagged constructs the runtime has moved past.

The `include` glob matched only `repro.py`, leaving `lark-1585/verify_fix.py` unlinted. Widening to `*.py` picks up every recipe-level script rather than naming files one at a time; it surfaced four `UP017` violations, fixed here — the script's PEP 723 block declares `requires-python = ">=3.14"`, so the `datetime.UTC` alias is available.

Two further pins sat outside `src/` and `.github/` and survived the first pass: the wheel builder could produce a fix-candidate wheel on an interpreter the recipe never reproduces against, and the guide's PEP 723 sample is copied verbatim into new recipes, which is how a stale floor propagates.

**(2)** actions/checkout v7 refuses to check out a fork's head SHA from a `pull_request_target` workflow, so Claude Review failed in 4s here — the first fork PR to reach it since #376 — and every fork PR would fail identically.

The "pwn request" hazard the refusal guards against does not apply to this job: its `if:` already restricts it to `github.event.pull_request.user.login == 'JamBalaya56562'`, so the code entering the trusted context is never a third party's. **That guard is what makes the opt-in safe; loosening or removing it would reintroduce the vulnerability.**

## Verification

- `mise run ci:lint` — pass.
- `mise run python:check` — 6 files formatted, all checks passed.
- `mise run repro:build:wheels` — both wheels (python-dateutil, lark) rebuilt under 3.14, exit 0.
- `uv run src/layer1_wasm/lark-1585/verify_fix.py` under Python 3.14.7 — verdict unchanged: baseline `reproduced` (hangs past 8s), fix-candidate `unreproduced` (361ms), `fix-candidate-confirmed`, exit 0.
- `uv run --no-project --python 3.14 python -m http.server` smoke-tested by hand (HTTP 200). The full Playwright suite was not run locally — left to CI.

## Known: `review` stays red on this PR

`pull_request_target` always evaluates the workflow definition from the **base** branch, so the `allow-unsafe-pr-checkout` fix cannot take effect until it is on `main`. `review` will fail on #378 no matter what; it should go green from the next PR onward. Splitting it into its own PR would not avoid that — the same red run happens there.

## Out of scope

`cpython-137205/repro.py` and its README mention Python 3.13 as the version the bug was *reported against* — statements of fact, not version pins, left untouched.

A follow-up worth its own issue: a single `.python-version` at the repo root would let all four `uv run --python` flags drop (verified: uv resolves it with `--no-project`, including from subdirectories), but ruff does not read it — ruff only infers `target-version` from a `pyproject.toml` `requires-python`. Neither mechanism reaches the docs sample, so a mechanical consistency check in `ci:lint` is the more complete fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)