### PR TITLE
fix(ci): authenticate the review workflow with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,6 +31,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@833fb0f8c9f6686b33d963a8bae0a94f4936ab2a # v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           claude_args: "--add-dir pr-head"


### PR DESCRIPTION
Fixes the `review` check, which has failed on every run since the workflow landed in #376.

## Root cause

Every run failed at the same line, before Claude was ever reached:

```
Exchanging OIDC token for app token...
App token exchange failed: 401 Unauthorized - Invalid OIDC token
```

This is a known open upstream bug: **[anthropics/claude-code-action#713 — "OIDC token exchange rejects `pull_request_target` events"](https://github.com/anthropics/claude-code-action/issues/713)**. The Anthropic exchange endpoint validates the OIDC token's `event_name` claim against an allowlist that does not include `pull_request_target`.

That matches what this repository sees exactly — the run history splits on the event, not on the code:

| Event | Result |
|---|---|
| `pull_request` (one pre-#376 run) | success |
| `pull_request_target` (4 runs) | all failed at the exchange |

Ruled out along the way: the GitHub App **is** installed and its permissions were updated (no effect — the exchange fails before the App's grants are consulted); the OIDC subject claim is not customised (`use_default: true`); and GitHub mints OIDC tokens fine in this repository — `deploy-docs.yml` declares the same `id-token: write` and succeeds.

## Fix

Pass `github_token`. The action's own `action.yml` describes it as *"GitHub token with repo and pull request permissions (optional if using GitHub App)"* — it is the documented alternative to the App path, and supplying it skips the exchange entirely. The workflow already grants `pull-requests: write`, which is what the action needs to post its review.

```yaml
      - uses: anthropics/claude-code-action@833fb0f8c9f6686b33d963a8bae0a94f4936ab2a # v1
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
```

## What is deliberately unchanged

The two-checkout layout already matches, line for line, the pattern the action's [security guide](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md) prescribes for `pull_request_target`:

> **Do not check out an untrusted ref into the workspace root before this action.** […] check out the base ref at the workspace root (this action expects a git repo there), then check out the head ref into a subdirectory and pass it via `--add-dir`.

`allow-unsafe-pr-checkout: true` (added in #378) also stays. It is orthogonal to authentication: actions/checkout v7 requires it to fetch a fork head under `pull_request_target` at all, and the job's `if:` still restricts the workflow to PRs authored by the repository owner, so the code entering the trusted context is never a third party's.

## Consequences and caveats

- **Review comments will now be posted by `github-actions[bot]`** rather than the Claude App. That is the trade-off of not holding an App token.
- `id-token: write` is now unused by this job. Left in place rather than removed speculatively — worth a separate look.
- **`CLAUDE_CODE_OAUTH_TOKEN` is still unverified.** Every run so far died before Claude's own authentication was attempted, so this fix is what will first exercise that secret. If it has expired, the next failure will look different — an Anthropic auth error rather than an OIDC one.
- Because `pull_request_target` evaluates the workflow definition from the **base** branch, this PR's own `review` check will still fail. It takes effect from the next PR after merge.

## Upstream

`anthropics/claude-code-action#713` is open with no fix. If it is resolved, dropping `github_token` restores App-authored comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)