### PR TITLE
feat(ci): label published Layer 2 images with OCI metadata

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -123,6 +123,20 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
 
+          recipes_index=docs/site/public/api/recipes.json
+          built_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          recipe_field() {
+            value="$(jq -r --arg s "$1" \
+              ".recipes[] | select(.slug == \$s) | .$2" \
+              "$recipes_index")"
+            if [ -z "$value" ] || [ "$value" = 'null' ]; then
+              echo "::error::${1} has no ${2} in ${recipes_index}" >&2
+              return 1
+            fi
+            printf '%s' "$value"
+          }
+
           recipe_changed() {
             case "$CHANGED_SLUGS" in
               '*') return 0 ;;
@@ -170,8 +184,22 @@ jobs:
               continue
             fi
 
+            description="$(recipe_field "$slug" title)"
+            page_url="$(recipe_field "$slug" page_url)"
+            labels=(
+              --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}"
+              --label "org.opencontainers.image.revision=${GITHUB_SHA}"
+              --label "org.opencontainers.image.version=${GITHUB_SHA}"
+              --label "org.opencontainers.image.created=${built_at}"
+              --label "org.opencontainers.image.title=vivarium-${slug}"
+              --label "org.opencontainers.image.description=${description}"
+              --label "org.opencontainers.image.url=${page_url}"
+              --label "org.opencontainers.image.documentation=${page_url}"
+              --label "org.opencontainers.image.licenses=Apache-2.0"
+            )
+
             echo "Building Layer 2 image: ${slug}"
-            docker build --tag "$tag_latest" --tag "$tag_sha" "$slug_dir"
+            docker build "${labels[@]}" --tag "$tag_latest" --tag "$tag_sha" "$slug_dir"
 
             echo "Pushing ${tag_latest} and ${tag_sha} to GHCR"
             docker push "$tag_latest"

--- a/src/layer2_docker/README.md
+++ b/src/layer2_docker/README.md
@@ -67,6 +67,17 @@ that, so the snapshot describes the exact image a visitor receives.
 The weekly `repro-regression` run is the lane that rebuilds from
 source and reports drift between the two.
 
+Published images carry OCI metadata, so `docker inspect` on a pulled
+image says which bug it reproduces and where the page for it lives:
+`title`, `description`, `url`, `documentation`, `source`, `revision`,
+`version`, `created` and `licenses` under `org.opencontainers.image.*`.
+`description` and the two page links are read from
+`docs/site/public/api/recipes.json`, so they cannot drift from the
+gallery. The rest are the build's own facts — repository, commit,
+timestamp, recipe slug — or a constant. `image.source` is what links
+the GHCR package to this repository — that governs access inheritance and
+the repository listing, **not** whether the package is public.
+
 GHCR public images are free + unlimited (storage and bandwidth) at
 the time of writing; GitHub Actions on a public repo are free +
 unlimited (build minutes). Vivarium pays nothing recurring for


### PR DESCRIPTION
## Problem

The Layer 2 images the catalogue publishes to GHCR carry **no metadata at all** — a repo-wide grep for `opencontainers`, `LABEL` and `--label` returns zero hits in any Dockerfile, workflow or mise task. The package pages are bare, and `docker inspect` on a pulled image tells a visitor nothing about which bug it reproduces.

Modelled on `ghcr.io/openup-labtakizawa/dcrs`, whose published image config carries the standard set (read directly off the registry: `created`, `description`, `licenses`, `revision`, `source`, `title`, `url`, `version`).

## Labels

| Label | Value |
|---|---|
| `…image.source` | `https://github.com/${GITHUB_REPOSITORY}` |
| `…image.revision` | `${GITHUB_SHA}` |
| `…image.version` | `${GITHUB_SHA}` |
| `…image.created` | build timestamp, computed once per run |
| `…image.title` | `vivarium-<slug>` |
| `…image.description` | `recipes.json` → `.title` |
| `…image.url` | `recipes.json` → `.page_url` |
| `…image.documentation` | `recipes.json` → `.page_url` |
| `…image.licenses` | `Apache-2.0` |

Three of these — `description`, `url` and `documentation` — are read from `docs/site/public/api/recipes.json`, which `mise run docs:build` regenerates earlier in the same job, so they cannot drift from the gallery. The other six are the build's own facts (repository, commit, timestamp, recipe slug) or a constant. `recipe_field` reuses the `jq --arg s` idiom and the `null`/empty guard that the bundling step further down this file already uses — a slug missing from the index fails the deploy rather than publishing an image labelled `null`.

## Design notes

**`docker build --label`, not `LABEL` in the Dockerfiles.** `title`, `description` and `url` differ per recipe, so Dockerfile labels would scatter them across four files plus `_template/` and duplicate `recipes.json` — a second source of truth that rots. `revision` and `created` are only knowable at build time and cannot live in a Dockerfile at all. `dcrs` reached the same conclusion: it has no `LABEL` either.

**`docker/metadata-action` deliberately not adopted.** `dcrs` is one repo → one image, so its repo-derived defaults are correct as-is. Vivarium is one repo → four images: the defaults would label all four `title=vivarium`, so every useful field would need overriding anyway. Adding `setup-buildx` + `metadata-action` + `build-push-action` means three new actions to SHA-pin (§4.8) for the same result a list of flags gives (§3.4, §3.5).

**Only the publish path is labelled.** Of the six `docker build` call sites, four never leave the machine (`docker:build`, `recipes:verify`, and both `repro-regression.yml` builds — that workflow is explicitly "no push"), so registry metadata there would be noise. `mise.toml`'s `branch-fix:publish` does push, but to a *contributor's* own `ghcr.io/<user>/vivarium-<slug>-fix` namespace, where this repository is not the provenance. Layer 3 is out of scope: no workflow pushes it — the real images are published out-of-band because rr replay needs an exposed PMU that hosted runners do not provide.

**Only the *changed* branch gains the flags.** The unchanged branch (added in #381) pulls an image that was already labelled when it was built.

## Verification

Docker builds were not run locally — that sandbox has ~3.8 GB RAM and no swap. What is free was done here:

- `yaml.safe_load` on the workflow and `bash -n` on every `run:` block — pass.
- **Quoting test, the one that actually mattered.** Recipe titles contain markdown inline code and non-ASCII. The label construction was replayed against the real `recipes.json` with a stubbed `docker` printing its argv, for all four recipes. Every value arrives as a single argument, literally:
  ```
  |org.opencontainers.image.description=bash `local` shadows command-substitution exit code|
  |org.opencontainers.image.description=`find … | xargs cmd` is unsafe for whitespace in filenames|
  ```
  Backticks are not re-parsed as command substitution and the embedded `|` does not split the argument.
- **Guard test**: `recipe_field` with an absent slug emits `::error::` and aborts under `set -e` (exit 1) rather than continuing with an empty value.
- `mise run markdown:check` — pass.

CI covers the rest: `test-lint-check.yml` for the YAML, `repro-regression.yml` for the recipes (it never pushes, so this PR cannot disturb published tags).

After merge, on the first deploy that rebuilds a recipe, the labels can be read back off the registry with the same anonymous probe used to inspect `dcrs` — anon token from `ghcr.io/token`, GET the manifest, then the config blob, check `.config.Labels`.

## Not in this PR

- **The public-visibility check.** Held back deliberately: the org currently forbids creating public packages at all, so the check would fire on every recipe with nothing anyone could act on. Worth revisiting once that org policy is resolved.
- **Package visibility itself** — blocked by that same policy, and there is no org-level API for it regardless (the org package endpoints are `GET`/`DELETE`/`restore` only). `image.source` links the package to the repository, which governs access inheritance and the repository listing, but not public visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
