### PR TITLE
fix(ci): publish an unchanged recipe whose :latest is absent

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -119,6 +119,7 @@ jobs:
         env:
           IMAGE_OWNER: aletheia-works
           CHANGED_SLUGS: ${{ steps.layer2-changed.outputs.slugs }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -164,6 +165,28 @@ jobs:
             return 1
           }
 
+          published_state() {
+            manifest_accept='application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json'
+            token="$(curl -sS -u "${GITHUB_ACTOR}:${GITHUB_TOKEN}" \
+              "https://ghcr.io/token?service=ghcr.io&scope=repository:${IMAGE_OWNER}/vivarium-$1:pull" \
+              | jq -r '.token // empty' || true)"
+            if [ -z "$token" ]; then
+              echo "vivarium-$1: no registry token issued" >&2
+              echo unknown
+              return
+            fi
+            code="$(curl -sS -o /dev/null -w '%{http_code}' \
+              -H "Authorization: Bearer $token" \
+              -H "Accept: ${manifest_accept}" \
+              "https://ghcr.io/v2/${IMAGE_OWNER}/vivarium-$1/manifests/latest" || true)"
+            echo "vivarium-$1: manifest HTTP ${code}" >&2
+            case "$code" in
+              200) echo present ;;
+              404) echo absent ;;
+              *) echo unknown ;;
+            esac
+          }
+
           for dockerfile in src/layer2_docker/*/Dockerfile; do
             slug_dir="$(dirname "$dockerfile")"
             slug="$(basename "$slug_dir")"
@@ -172,16 +195,27 @@ jobs:
             tag_sha="ghcr.io/${IMAGE_OWNER}/vivarium-${slug}:${GITHUB_SHA}"
 
             if ! recipe_changed "$slug"; then
-              echo "Unchanged: ${slug} - capturing against the published ${tag_latest}"
-              if ! pull_published "$tag_latest"; then
-                echo "::error::Cannot pull ${tag_latest}. Refusing to rebuild an unchanged recipe: that would move :latest and force every visitor to re-pull. Re-run this workflow via workflow_dispatch to republish the catalogue."
-                exit 1
-              fi
-              bash scripts/capture_layer2_verdict.sh \
-                "$tag_latest" "${slug_dir}/verdict.json" \
-                --image-tag "$tag_latest" \
-                --image-digest "$(repo_digest "$tag_latest")"
-              continue
+              case "$(published_state "$slug")" in
+                present)
+                  echo "Unchanged: ${slug} - capturing against the published ${tag_latest}"
+                  if ! pull_published "$tag_latest"; then
+                    echo "::error::${tag_latest} is published but could not be pulled. Refusing to rebuild an unchanged recipe: that would move :latest and force every visitor to re-pull."
+                    exit 1
+                  fi
+                  bash scripts/capture_layer2_verdict.sh \
+                    "$tag_latest" "${slug_dir}/verdict.json" \
+                    --image-tag "$tag_latest" \
+                    --image-digest "$(repo_digest "$tag_latest")"
+                  continue
+                  ;;
+                absent)
+                  echo "::warning::${tag_latest} has never been published; publishing ${slug} now."
+                  ;;
+                *)
+                  echo "::error::Cannot tell whether ${tag_latest} is published. Refusing to rebuild an unchanged recipe: that would move :latest and force every visitor to re-pull."
+                  exit 1
+                  ;;
+              esac
             fi
 
             description="$(recipe_field "$slug" title)"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -233,16 +233,23 @@ jobs:
             )
 
             echo "Building Layer 2 image: ${slug}"
-            docker build "${labels[@]}" --tag "$tag_latest" --tag "$tag_sha" "$slug_dir"
+            docker build "${labels[@]}" --tag "$tag_latest" "$slug_dir"
 
-            echo "Pushing ${tag_latest} and ${tag_sha} to GHCR"
+            echo "Pushing ${tag_latest} to GHCR"
             docker push "$tag_latest"
-            docker push "$tag_sha"
+            verdict_tag="$tag_latest"
+
+            if recipe_changed "$slug"; then
+              echo "Pushing ${tag_sha} to GHCR"
+              docker tag "$tag_latest" "$tag_sha"
+              docker push "$tag_sha"
+              verdict_tag="$tag_sha"
+            fi
 
             bash scripts/capture_layer2_verdict.sh \
               "$tag_latest" "${slug_dir}/verdict.json" \
-              --image-tag "$tag_sha" \
-              --image-digest "$(repo_digest "$tag_sha")"
+              --image-tag "$verdict_tag" \
+              --image-digest "$(repo_digest "$verdict_tag")"
           done
 
       - name: Bundle Layer 1 reproductions alongside docs

--- a/src/layer2_docker/README.md
+++ b/src/layer2_docker/README.md
@@ -69,9 +69,12 @@ source and reports drift between the two.
 
 An untouched recipe with nothing published under `:latest` — a new
 package, or one somebody deleted — is built and pushed instead of
-failing the deploy. CI only takes that path when the registry
-positively reports the tag as absent; if it cannot tell, the deploy
-stops rather than risk moving a `:latest` that visitors already hold.
+failing the deploy. That path restores `:latest` alone and still
+mints no `:<git-sha>`, so the rule above holds without exception: a
+sha tag exists only for the recipes its commit changed. CI only takes
+the path when the registry positively reports the tag as absent; if
+it cannot tell, the deploy stops rather than risk moving a `:latest`
+that visitors already hold.
 
 Published images carry OCI metadata, so `docker inspect` on a pulled
 image says which bug it reproduces and where the page for it lives:

--- a/src/layer2_docker/README.md
+++ b/src/layer2_docker/README.md
@@ -67,6 +67,12 @@ that, so the snapshot describes the exact image a visitor receives.
 The weekly `repro-regression` run is the lane that rebuilds from
 source and reports drift between the two.
 
+An untouched recipe with nothing published under `:latest` — a new
+package, or one somebody deleted — is built and pushed instead of
+failing the deploy. CI only takes that path when the registry
+positively reports the tag as absent; if it cannot tell, the deploy
+stops rather than risk moving a `:latest` that visitors already hold.
+
 Published images carry OCI metadata, so `docker inspect` on a pulled
 image says which bug it reproduces and where the page for it lives:
 `title`, `description`, `url`, `documentation`, `source`, `revision`,


### PR DESCRIPTION
## What happened

Deleting the GHCR packages and then merging #381 failed the `deploy-docs` run ([33827125323](https://github.com/aletheia-works/vivarium/actions/runs/33827125323)):

```
Changed Layer 2 recipes: (none)
Unchanged: bash-local-shadows-exit
Error response from daemon: manifest unknown
::error::Cannot pull ...
```

The merge commit touched only `.github/workflows/deploy-docs.yml` and `src/layer2_docker/README.md`, neither of which yields a slug, so every recipe took the pull path and hit the deleted images. Recovery was a manual `workflow_dispatch`.

**Adding a new recipe was never affected** — worth stating plainly, since that was the worry that surfaced this. The commit that introduces a recipe also introduces `src/layer2_docker/<slug>/…`, so the slug lands in the changed set and the recipe takes the build-and-push path without ever consulting the registry:

| Commit | Extracted slugs | Path |
|---|---|---|
| Adds `src/layer2_docker/curl-retry-bug/{Dockerfile,repro.sh,…}` | `curl-retry-bug` | build + push |
| The merge above | *(none)* | pull → failed |

What this PR fixes is the neighbouring case: a recipe whose package was **deleted**, or whose first deploy never completed.

## Why the guard existed, and why it can now be relaxed

#381 deliberately removed a build fallback after Greptile pointed out that any failed `docker pull` fell through to rebuilding, so a transient registry blip could move `:latest` for a recipe nobody touched. That was correct: `docker pull`'s **exit status** cannot separate "never published" from "briefly unreachable".

The registry's **HTTP status** can. `published_state` asks it directly before deciding:

| Registry says | State | Action |
|---|---|---|
| `200` | published | pull and capture — unchanged from #381 |
| `404` (`MANIFEST_UNKNOWN`) | genuinely absent | **build and push**, with a `::warning::` |
| anything else, or no token issued | can't tell | stop the deploy, `:latest` untouched |

`403` stays in the "can't tell" bucket on purpose. It is what a real permission problem looks like, and treating it as absent would reintroduce exactly the failure mode #381 closed.

## Verification

No Docker locally (that sandbox has ~3.8 GB RAM, no swap). What is free was done here:

- `yaml.safe_load` + `bash -n` on every `run:` block — pass.
- **Status→state mapping**, stubbed curl: `200→present`, `404→absent`, `403→unknown`, `503→unknown`, `000→unknown`, no-token→`unknown`.
- **All five branch outcomes**, stubbed `docker`/capture: unchanged+present → pull and capture; unchanged+absent → warn then build+push; unchanged+unknown → exit 1; unchanged+present-but-unpullable → exit 1; changed → build+push without consulting the registry at all.
- **Live probe of the real registry** with the exact URL and `Accept` header the workflow sends: all four packages return `200`; an existing package with an unknown tag returns `404 MANIFEST_UNKNOWN`.
- `mise run markdown:check` — pass.

## One honest caveat

I could not test the authenticated-and-absent case directly — my token lacks `read:packages`, and anonymously a **nonexistent** package returns `403 {"code":"DENIED","message":"invalid token"}` rather than `404`, because the anonymous token endpoint will not grant pull scope on a package it cannot see.

The evidence that CI sees `404` there is the failed run above: docker was already logged in with `GITHUB_TOKEN` when it reported `manifest unknown`, which is the `404 MANIFEST_UNKNOWN` body.

If that turns out to be wrong and GHCR answers `403` to an authenticated request for an absent package, `published_state` returns `unknown` and the deploy stops — **precisely today's behaviour**. So this change can improve the outcome or leave it as-is; it cannot regress it. The first deploy after a recipe is added or a package is deleted will settle it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)