### PR TITLE
refactor(ci): log in to GHCR with docker/login-action

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -101,17 +101,11 @@ jobs:
 
       - name: Log in to GHCR (for Layer 2 image push)
         if: github.repository_owner == 'aletheia-works'
-        working-directory: ${{ github.workspace }}
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          dockerfiles=(src/layer2_docker/*/Dockerfile)
-          if [ ${#dockerfiles[@]} -eq 0 ]; then
-            echo "No src/layer2_docker/*/Dockerfile; skipping GHCR login."
-            exit 0
-          fi
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io \
-            -u "${{ github.actor }}" --password-stdin
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish changed Layer 2 images and snapshot every verdict
         if: github.repository_owner == 'aletheia-works'


### PR DESCRIPTION
First of the workflow-tidying steps. `deploy-docs.yml` is 71% shell by line count; this removes the one block that an action already in this repository does better.

## The duplication

`vivarium-verdict.yml:87` already logs in to GHCR with `docker/login-action`, SHA-pinned. `deploy-docs.yml` piped a token into `docker login` by hand to do the same thing. One registry login, written two ways in one repository.

```diff
       - name: Log in to GHCR (for Layer 2 image push)
         if: github.repository_owner == 'aletheia-works'
-        working-directory: ${{ github.workspace }}
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          dockerfiles=(src/layer2_docker/*/Dockerfile)
-          if [ ${#dockerfiles[@]} -eq 0 ]; then
-            echo "No src/layer2_docker/*/Dockerfile; skipping GHCR login."
-            exit 0
-          fi
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io \
-            -u "${{ github.actor }}" --password-stdin
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
```

5 insertions, 11 deletions.

## No new dependency, no version skew

Checked rather than assumed, per §4.8:

- `docker/login-action`'s current release is **v4.6.0** (`gh api /repos/docker/login-action/releases/latest`).
- The commit behind tag `v4.6.0` is `dbcb813823bdd20940b903addbd779551569679f`.
- That is byte-for-byte the SHA `vivarium-verdict.yml` already pins.

So this reuses an action the repository has already adopted, at its latest release, with both files converging on one pin instead of drifting apart.

## The dropped guard

The removed shell skipped the login when `src/layer2_docker/*/Dockerfile` matched nothing. That guard goes away, and it should: logging in with nothing to push is harmless, and the publish step already handles an empty catalogue — its `for` loop runs under `shopt -s nullglob`, so with no Dockerfiles it simply does not iterate.

## Verification

- `yaml.safe_load` on the workflow and `bash -n` on every remaining `run:` block — pass.
- Every `uses:` in the file is a 40-character SHA with a trailing version comment (§4.8) — re-checked after the edit.
- The runtime behaviour is CI's to confirm: the next `deploy-docs` run on `main` that pushes an image proves the login still works. Nothing else in the workflow changed, and the PR itself cannot exercise it — `deploy-docs` only runs on `main`.

## Next

The larger item from the same discussion — moving the long `run:` blocks out of the YAML into `scripts/`, which would also make them reachable by `shellcheck` (today `lint:check` covers docs/php/python/toml/markdown/rust, and shell is the one language with no checker) — is deliberately not here. It follows in its own PR once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)