### PR TITLE
refactor(ci): point the review prompt at cross-cutting consistency

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -39,31 +39,49 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Review this pull request. The PR's files are checked out under
-            `pr-head/`; the base branch is at the workspace root.
+            Review this pull request. The PR's files are checked out
+            under `pr-head/`; the repository as it stands on the base
+            branch is at the workspace root. Search the workspace root
+            whenever you need to find code the PR did *not* touch.
 
-            Read AGENTS.md and .claude/rules/ first, and hold the diff to
-            what they require. This repository's own rules are the part a
-            generic reviewer misses, in particular:
+            Do the job the author could not. They saw the files they
+            edited; you have the whole repository. Weight your effort
+            accordingly.
 
-            - §4.13 comments: default is no comment. Flag narrative
-              comments, file-header tours, and pointers to other files.
-            - §4.8 SHA-pinned actions with a trailing version comment.
-            - §4.4 Conventional Commits, subject starting lowercase.
-            - §4.10 spec changes: an optional field is a same-page
-              revision with a dated revision-history line; anything else
-              is vN+1.
-            - §4.12 the `mise run ci:*` task matching each workflow the
-              diff triggers should have been run.
-            - Recipe pages are rendered from
-              src/layer1_wasm/_shared/page.template.html plus each
-              recipe's page.en.html; index.html is generated and
-              gitignored.
+            1. What else should have changed. For every symbol, file,
+               path, glob, tag, env var, workflow step, task or config
+               key the diff adds, removes, renames, moves or narrows,
+               search the base tree for its other references and check
+               each one. A trigger that no longer matches its consumer,
+               a doc still describing the old behaviour, a caller left
+               pointing at something that moved, a generated artefact
+               whose generator was not rerun. These are the findings
+               this review exists for.
 
-            Then review for correctness: bugs the tests would not catch,
-            broken assumptions, and changes that contradict the commit
-            message. Say when something is fine — do not invent findings.
+            2. Contradictions with what the repository already states.
+               Hold the diff against AGENTS.md, .claude/rules/, the
+               README.md nearest the changed code, and any spec page
+               under docs/site/*/spec/. Read the rules; do not work
+               from a list of the ones somebody remembered. If the
+               change breaks a rule or an invariant one of them states
+               in words, quote the sentence. Either side may be the
+               thing that is wrong — say which you think it is.
 
-            Report each finding as an inline review comment on the line it
-            concerns, with a one-line summary and the concrete failure it
-            causes. Skip style nits the linters already enforce.
+            3. Whether the implementation is correct. Bugs the tests
+               would not catch, edge cases, error paths, and changes
+               that do not do what the commit message or the PR
+               description says. Check the description's factual
+               claims against the files instead of trusting them.
+
+            Before reporting that something is unused, removable,
+            narrowable, or already covered elsewhere, enumerate its
+            consumers and name them in the finding. "Nothing else reads
+            this" is worth reporting only when you searched for readers
+            and can say what you searched. A confident finding built on
+            an unchecked assumption costs more than silence.
+
+            Report each finding on the line it concerns, with what
+            breaks and the evidence you gathered. Skip nits the linters
+            already enforce. Saying you found nothing is a fine answer
+            when the searches above came back empty — but it should
+            mean you ran them, not that the diff read fine.


### PR DESCRIPTION
## The record this is responding to

Across #381–#386, the two AI reviewers on the same PRs produced very different results:

| PR | Claude Review | Greptile |
|---|---|---|
| #381 | No blocking issues | **P1 real** — a failed pull rebuilt and moved `:latest` |
| #382 | No blocking issues | **P2 real** — README overstated where labels come from |
| #383 | No bugs found | **P1 real** — sha tag minted for a recipe the commit never touched |
| #384 | No findings | none |
| #385 | Findings: none | **P1 real** — the docs generators were missing from the trigger |
| #386 | 1 finding, **wrong** | **P2 real** — a new workflow violated §4.9 |

Every finding that required a fix came from the other reviewer. All six are the same shape: **the change contradicted something documented elsewhere in the repository, or failed to update something that should have moved with it.**

The one finding this reviewer did produce, on #386, proposed narrowing `docs/site/public/spec/**.schema.json` to `manifest.schema.json` on the premise that the Layer 3 build was the only consumer of `verdict.schema.json`. It is not — `repro-regression.yml:124` calls `scripts/capture_layer2_verdict.sh`, which validates against that schema at `capture_layer2_verdict.sh:46`. Acting on it would have opened a hole.

## Why the old prompt produced exactly that

**It enumerated rule numbers, and the enumeration was stale.** It named §4.13, §4.8, §4.4, §4.10 and §4.12 — five of the thirteen rules in AGENTS.md. **§4.9 was not among them, and §4.9 is what #386 violated.** A hand-maintained subset of the rules is a whitelist that silently becomes a blind spot.

**It never asked the reviewer to look outside the diff.** Nothing in it suggested searching for other references to what the change touched — which is where all six real findings lived.

**It pushed toward silence rather than verification.** "Say when something is fine — do not invent findings" discourages reporting, but does nothing to make a report *checked*. The result was five silent reviews and one confident wrong one.

## What the new prompt does

1. **What else should have changed** — leads the review. For every symbol, path, glob, tag, env var, workflow step, task or config key the diff adds, removes, renames, moves or narrows, search the base tree for its other references and check each. Named failure shapes: a trigger that no longer matches its consumer, a doc still describing the old behaviour, a caller left pointing at something that moved, a generated artefact whose generator was not rerun.
2. **Contradictions with what the repository already states** — against AGENTS.md, `.claude/rules/`, the nearest README, and spec pages, with an explicit instruction to *read the rules rather than work from a remembered subset*, and to quote the sentence. It also allows for the doc being the wrong side.
3. **Whether the implementation is correct** — bugs tests would not catch, edge cases, error paths, and claims in the description checked against the files.

Plus an anti-false-positive rule aimed squarely at the #386 miss:

> Before reporting that something is unused, removable, narrowable, or already covered elsewhere, enumerate its consumers and name them in the finding.

And silence is redefined as an outcome of having searched, not of the diff having read fine.

## On copying an existing prompt

The official [`examples/pr-review-comprehensive.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml) was read and deliberately not copied. It is a generic checklist — code quality, security, performance, testing, documentation — and none of its five headings would have surfaced any of the six findings above. A generic prompt produces a generic review, which is the failure being fixed.

## Scope

Prompt text only. `track_progress`, `github_token`, `claude_args`, the `if:` guard and the two-checkout layout are untouched.

## Verification

- `yaml.safe_load` — pass; the prompt parses as a 49-line block scalar.
- The claim about §4.9's absence was checked mechanically, not from memory: the old prompt matched `§4.10 §4.12 §4.13 §4.4 §4.8`, against `4.1 … 4.13` present in AGENTS.md.
- The real test is the next few PRs. If this reviewer keeps returning nothing while the other keeps finding contract violations, the honest conclusion is that the job is not paying for its runtime and should be dropped rather than tuned again.

## Follow-up, not here

The prompt has always asked for findings "as an inline review comment", but every review so far has landed as a single top-level comment. The action ships a `Post buffered inline comments` step, so this is likely a tool-permission question in `claude_args` rather than a prompt one. Worth its own change, since getting `--allowedTools` wrong would remove the search ability this PR depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)