### PR TITLE
fix(ci): give the reviewer the inline-comment tool

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,7 +36,7 @@ jobs:
           track_progress: true
           claude_args: >-
             --add-dir pr-head
-            --allowedTools "mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "Glob,Grep,LS,Read,mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -34,7 +34,9 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
-          claude_args: "--add-dir pr-head"
+          claude_args: >-
+            --add-dir pr-head
+            --allowedTools "mcp__github_inline_comment__create_inline_comment"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -80,8 +82,11 @@ jobs:
             and can say what you searched. A confident finding built on
             an unchecked assumption costs more than silence.
 
-            Report each finding on the line it concerns, with what
-            breaks and the evidence you gathered. Skip nits the linters
-            already enforce. Saying you found nothing is a fine answer
-            when the searches above came back empty — but it should
-            mean you ran them, not that the diff read fine.
+            Report each finding as an inline comment on the line it
+            concerns, with what breaks and the evidence you gathered.
+            Keep the summary comment for what has no single line — a
+            missing update in a file the diff never touched belongs
+            there, with the path. Skip nits the linters already
+            enforce. Saying you found nothing is a fine answer when the
+            searches above came back empty — but it should mean you ran
+            them, not that the diff read fine.


### PR DESCRIPTION
Follow-up to #387. The prompt has asked for inline comments since #376 and every review has arrived as a single top-level comment instead.

## The cause, from our own run log

The action prints the `allowedTools` it assembles. From run [33841994851](https://github.com/aletheia-works/vivarium/actions/runs/33841994851):

```json
"allowedTools": [
  "Glob", "Grep", "LS", "Read",
  "mcp__github_comment__update_claude_comment",
  "mcp__github_ci__get_ci_status",
  "mcp__github_ci__get_workflow_run_details",
  "mcp__github_ci__download_job_log",
  "Bash(git add:*)", "Bash(git commit:*)",
  "Bash(…/git-push.sh:*)", "Bash(git rm:*)"
]
```

`mcp__github_inline_comment__create_inline_comment` is absent. The tool did not exist, so no prompt wording could have produced an inline comment, and the `Post buffered inline comments` step reported **"No buffered inline comments"** on every run.

## Why it is absent, and why naming it is the fix

It is opt-in, not missing. The MCP server that provides it is installed only when the requested tools ask for it. The condition is quoted in [anthropics/claude-code-action#635](https://github.com/anthropics/claude-code-action/issues/635):

```ts
if (isEntityContext(context) && context.isPR && (hasGitHubMcpTools || hasInlineCommentTools))
```

So `hasInlineCommentTools` — naming the tool in `--allowedTools` — is what turns the server on.

```yaml
          claude_args: >-
            --add-dir pr-head
            --allowedTools "mcp__github_inline_comment__create_inline_comment"
```

**On the risk I flagged in #387** — that `--allowedTools` might *replace* the base set. The review on this PR showed my original evidence for "it appends" was invalid, so the list no longer relies on the answer.

The upstream [`pr-review-comprehensive.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml) passes `mcp__github_inline_comment__create_inline_comment` plus three `gh` commands and **no `Glob`/`Grep`/`Read`** — it reads through `gh pr diff`, so it working proves nothing about a second `--allowedTools`. It also runs agent mode, where user args are the only source of tools. This workflow sets `track_progress: true`, and our run log confirms `Auto-detected mode: tag`, where the action emits its own `--allowedTools` and appends ours after it.

So the list names every tool the review needs. It is correct either way: a subset of the base under union, complete on its own under last-wins.

```yaml
          claude_args: >-
            --add-dir pr-head
            --allowedTools "Glob,Grep,LS,Read,mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log"
```

The action's base also carries `Bash(git add:*)`, `Bash(git commit:*)`, `Bash(git rm:*)` and its `git-push.sh`. Those are deliberately not carried over: the job has `contents: read`, so they could never have worked, and a reviewer has no business committing.

## Prompt change

One paragraph: which findings go inline and which stay in the summary. A missing update in a file the diff never touched has no line to attach to, so it belongs in the summary with the path — and that is the category #387 is trying to elicit.

## Verification, and its limit

`yaml.safe_load` confirms `claude_args` folds to the single line the action expects.

**This PR cannot test itself.** `pull_request_target` evaluates the workflow from the *base* branch, so the change takes effect on the first PR opened after merge. What to look for there:

- the `allowedTools` line in the run log contains `mcp__github_inline_comment__create_inline_comment`;
- `Post buffered inline comments` reports a count instead of "No buffered inline comments".

An earlier draft claimed a regression here would be "loud and immediate". That was wrong, and the review on this PR caught it: under last-wins the tool lost is `mcp__github_comment__update_claude_comment`, the only one that posts anything, so the run would go **green having said nothing**. Naming the full list is what removes that failure mode; if the review comment appears at all, the list took effect.

## Known upstream caveats, worth knowing before trusting the green check

- [#1679](https://github.com/anthropics/claude-code-action/issues/1679) — `post-buffered-inline-comments` exits 0 after failing to post every comment; "Posted 0/N" still goes green. A passing `review` check is not proof the comments landed.
- [#1667](https://github.comth/anthropics/claude-code-action/issues/1667) — one malformed buffer line discards *all* buffered comments.
- [#1641](https://github.com/anthropics/claude-code-action/issues/1641) / [#731](https://github.com/anthropics/claude-code-action/issues/731) — the tool cannot reply to an existing review comment thread, so follow-up discussion still happens in the summary comment.

None of these block adopting it; they mean the summary comment stays the reliable channel and inline is the improvement on top.