### PR TITLE
perf(ci): trim the Layer 3 apt layer and move it to ubuntu 26.04

### DIFF
--- a/src/layer3_thirdway/lost-update/Dockerfile
+++ b/src/layer3_thirdway/lost-update/Dockerfile
@@ -26,7 +26,7 @@
 # locally by the maintainer on the same host that recorded the
 # trace, then committed alongside this recipe.
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 RUN set -eux; \
     apt-get update -qq; \

--- a/src/layer3_thirdway/lost-update/Dockerfile
+++ b/src/layer3_thirdway/lost-update/Dockerfile
@@ -31,10 +31,6 @@ FROM ubuntu:24.04
 RUN set -eux; \
     apt-get update -qq; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
-      software-properties-common >/dev/null; \
-    add-apt-repository -y universe >/dev/null; \
-    apt-get update -qq; \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
       build-essential rr zstd ca-certificates >/dev/null; \
     rm -rf /var/lib/apt/lists/*; \
     rr --version

--- a/src/layer3_thirdway/lost-update/README.md
+++ b/src/layer3_thirdway/lost-update/README.md
@@ -75,7 +75,7 @@ not substitutes.
 | File          | Role                                                         |
 | ------------- | ------------------------------------------------------------ |
 | `repro.c`     | The two-thread reproducer. Exit 0 if the race did not fire (counter == 2*N), exit 1 if it did. |
-| `Dockerfile`  | `ubuntu:24.04` + `rr` + `build-essential`. Pulls the trace from the pinned release URL via `ADD` at build time. |
+| `Dockerfile`  | `ubuntu:26.04` + `rr` + `build-essential`. Pulls the trace from the pinned release URL via `ADD` at build time. |
 | `replay.sh`   | The visitor-facing entrypoint. Runs `rr replay --autopilot`, parses the recorded stderr for the race marker, exits 0 on `reproduced` (race re-fires) / 1 on `unreproduced`. |
 | `record.sh`   | Maintainer-only. Records a fresh trace on a Linux/x86_64 host with PMU, retrying under `--chaos` until a failing run is captured. Not invoked by CI or visitors. |
 | `trace.url`   | Pinned URL of the trace artifact (a GitHub Release asset on `aletheia-works/vivarium`). |
@@ -131,7 +131,7 @@ The three flags exist because `rr replay`:
    seccomp profile blocks — needs `seccomp=unconfined` (or a
    custom profile that allows the syscall).
 
-First-pull cost: ~140 MB (ubuntu:24.04 + rr + a 1.3 MB trace).
+First-pull cost: ~140 MB (ubuntu:26.04 + rr + a 1.3 MB trace).
 Run takes ~1 second (the recorded program is short; chaos-mode
 context switches add a few hundred milliseconds at replay time).
 

--- a/src/layer3_thirdway/lost-update/record.sh
+++ b/src/layer3_thirdway/lost-update/record.sh
@@ -16,7 +16,7 @@
 #   gh release create lost-update-trace-v1 out/lost-update-trace.tar.zst \
 #     --repo aletheia-works/vivarium \
 #     --title 'lost-update recipe trace v1' \
-#     --notes 'Recorded with rr --chaos on ubuntu:24.04; for src/layer3_thirdway/lost-update/'
+#     --notes 'Recorded with rr --chaos on ubuntu:26.04; for src/layer3_thirdway/lost-update/'
 #
 # After the release exists, rebuild the image and run it once on
 # this host to regenerate verdict.json (see README.md).
@@ -35,7 +35,7 @@ OUT_DIR="${OUT_DIR:-$RECIPE_DIR/out}"
 mkdir -p "$OUT_DIR"
 OUT_DIR="$(cd "$OUT_DIR" && pwd)"
 
-UBUNTU_TAG="${UBUNTU_TAG:-24.04}"
+UBUNTU_TAG="${UBUNTU_TAG:-26.04}"
 TARBALL_NAME="${TARBALL_NAME:-lost-update-trace.tar.zst}"
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-50}"
 

--- a/src/layer3_thirdway/lost-update/record.sh
+++ b/src/layer3_thirdway/lost-update/record.sh
@@ -67,10 +67,6 @@ docker run --rm \
 
     apt-get update -qq
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
-      software-properties-common >/dev/null
-    add-apt-repository -y universe >/dev/null
-    apt-get update -qq
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
       build-essential rr zstd >/dev/null
 
     sysctl -w kernel.perf_event_paranoid=1 >/dev/null || true


### PR DESCRIPTION
Step 2 of the three scoped for the Layer 3 build. Two commits, deliberately separable — the second carries a consequence the first does not.

## Commit 1 — drop the universe repository dance

`software-properties-common` + `add-apt-repository -y universe` cost **102s of the 229s** the apt layer took, measured from the per-command timestamps in the CI log of run [33835614113](https://github.com/aletheia-works/vivarium/actions/runs/33835614113):

| Segment | Time |
|---|---|
| `apt-get update` | 5s |
| `install software-properties-common` | **97s** |
| `add-apt-repository universe` + `apt-get update` | **6s** |
| `install build-essential rr zstd ca-certificates` | 121s |

`rr` really is in `universe` on both releases (Launchpad: `5.7.0-2ubuntu0.24.04.1 (universe)` on noble, `5.9.0-5 (universe)` on resolute), which is why the dance was written. The expectation is that the official `ubuntu` image already enables universe, making it redundant.

**Expected, not verified** — confirming it needs the image, and the sandbox this was written in does not run Docker. This PR's own check settles it: `layer3-build.yml` triggers on `src/layer3_thirdway/**`, and if universe is not enabled then `apt-get install rr` cannot resolve and the build fails outright rather than producing a subtly wrong image.

## Commit 2 — ubuntu 26.04, and what it obliges

**Both sides move together.** `record.sh` records inside a container built from `ubuntu:${UBUNTU_TAG}`, so the recording rr and the replay rr are the same build *by construction*. Bumping only the Dockerfile would have split them — which `README.md` already names as a way to break replay:

> their `rr` build / kernel diverges from the recording side enough to break replay

So `record.sh`'s default, its release-note template, and the two README references move with the `FROM` line. Grep confirms no `24.04` remains under `src/layer3_thirdway/`.

**The consequence, stated plainly: the published trace needs re-recording.**

| | rr |
|---|---|
| ubuntu 24.04 (noble) | **5.7.0** |
| ubuntu 26.04 (resolute) | **5.9.0** |

The trace behind `lost-update-trace-v1` was recorded under 5.7.0. rr refuses traces it considers incompatible, so it should be re-recorded under 5.9.0 and republished as a new release asset, with `trace.url` re-pinned, before the next image publish.

**CI cannot see this.** The Layer 3 job builds and never replays — deliberately, since hosted runners lack the CPUID faulting replay needs — and the image visitors pull is published out of band by the maintainer, not by CI. So a green check here says the image builds, not that the trace still replays.

Nothing breaks the moment this merges. It becomes real at the next maintainer republish, which is also the moment a local replay would catch it.

## If the re-record is not wanted right now

Drop commit 2. Commit 1 stands alone on `ubuntu:24.04`, keeps rr at 5.7.0, keeps the existing trace valid, and still takes the 102s. The remaining 121s (`build-essential rr zstd`) is what step 3's layer cache was always aimed at, and it is unaffected either way.

## Verification

- `bash -n` on `record.sh`, `mise run markdown:check` — pass.
- `grep -rn '24\.04' src/layer3_thirdway/` — no matches, so the record/replay coupling is not half-applied.
- rr versions and components read from the Ubuntu archive via the Launchpad API rather than assumed.
- The build itself is this PR's `layer3 build` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)