### PR TITLE
feat(layer2): track the latest base image instead of pinning back

### DIFF
--- a/.claude/rules/recipe-authoring.md
+++ b/.claude/rules/recipe-authoring.md
@@ -354,10 +354,20 @@ mise exec -- bun run test:unit
 
 **Pitfalls**:
 
-- **Pinning.** Pin the Docker base image to a major tag at minimum
-  (`node:26-slim`, not `node:latest`). The image digest is
-  captured in the CI-generated `verdict.json` for full
-  determinism.
+- **Base images track the latest release.** A Layer 2 recipe
+  claims a bug is reachable on current software, so the base moves
+  forward rather than staying where it was authored. Name a
+  concrete release tag (`node:26-slim`, `alpine:3.24`) and bump it
+  — never `:latest`, which would change the image with no commit
+  to point at and no verdict re-run. Dependabot's `docker`
+  ecosystem opens those bumps; the run that lands them is what
+  re-verifies the reproduction. The digest CI built from is
+  recorded in the generated `verdict.json`.
+- **A bump that flips the verdict is a result, not a breakage.**
+  The Playwright suite asserts `expected_verdict`, so a fixed
+  upstream shows up as a red check. Decide whether the recipe
+  moves to the last reproducing tag or the recipe is retired —
+  do not pin backwards to keep CI green without saying why.
 - **Verdict polarity.** Exit 0 means *the bug reproduces*
   (positive identification of the surprise). This is the Contract
   v1 convention — different from typical CI green/red framing.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,24 @@ updates:
           - "*"
     open-pull-requests-limit: 5
 
+  - package-ecosystem: "docker"
+    directories:
+      - "/src/layer2_docker/*"
+    schedule:
+      interval: "daily"
+    labels:
+      - "type: chore"
+      - "scope: docker"
+      - "ai: generated"
+    commit-message:
+      prefix: "chore(docker)"
+      include: "scope"
+    groups:
+      layer2-base-images:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+
   - package-ecosystem: "terraform"
     directory: "/infra/github"
     schedule:

--- a/src/layer2_docker/README.md
+++ b/src/layer2_docker/README.md
@@ -38,7 +38,7 @@ Each directory ships:
 
 | File | Role | Required? |
 | ---- | ---- | --------- |
-| `Dockerfile` | Pinned base image + dependency setup. **Pin everything**: base image by digest, package versions explicit. | ✅ |
+| `Dockerfile` | Base image + dependency setup. **Track the latest base image**: a recipe is a claim that the bug survives on current software, so the base moves forward and CI re-runs the reproduction against it. Use the newest release tag (`alpine:3.24`, `postgres:18-alpine`), never a floating `:latest`. Package versions stay explicit. | ✅ |
 | `repro.sh` | The reproduction script. Exits 0 on `reproduced` (bug reproduces) and 1 on `unreproduced` (bug does not reproduce, or runtime errored). Same verdict semantics as Layer 1's per-page `repro.<lang>`. | ✅ |
 | `README.md` | Bug description (with upstream issue link), the exact `docker run …` command, expected output, the CI-snapshot verdict, and any "why this bug" notes. | ✅ |
 | `.devcontainer/devcontainer.json` | *Optional.* References the GHCR image; sets `postStartCommand: ./repro.sh`. Adds the "Open in Codespaces" path; pages without one ship just the `docker run` path. | ⏳ |

--- a/src/layer2_docker/_template/Dockerfile
+++ b/src/layer2_docker/_template/Dockerfile
@@ -2,10 +2,9 @@
 #
 # Upstream issue: {{ISSUE_URL}}
 #
-# Pinned base: {{BASE_IMAGE}}. Pin a major tag (e.g. node:26-slim,
-# python:3.15-slim) so the image digest captured in the
-# CI-generated verdict.json is reproducible. See the recipe
-# README and src/layer2_docker/AGENTS.md for the full convention.
+# Name a concrete release tag for the base image, never
+# `:latest`, and bump it forward as new releases land — the
+# recipe claims the bug is reachable on current software.
 FROM {{BASE_IMAGE}}
 
 COPY repro.sh /repro.sh

--- a/src/layer2_docker/bash-local-shadows-exit/Dockerfile
+++ b/src/layer2_docker/bash-local-shadows-exit/Dockerfile
@@ -10,7 +10,7 @@
 # the standards trail), so the page is a "real-world surprise
 # you should know about" entry, not an "Open upstream issue"
 # entry.
-FROM bash:5.2
+FROM bash:5.3
 
 COPY repro.sh /repro.sh
 RUN chmod +x /repro.sh

--- a/src/layer2_docker/bash-local-shadows-exit/Dockerfile
+++ b/src/layer2_docker/bash-local-shadows-exit/Dockerfile
@@ -3,13 +3,9 @@
 # defeats `set -e` and causes silent failures in production
 # scripts.
 #
-# Pinned base image: `bash:5.2` — the documented surprise
-# survives every modern bash major; we pin to one specific
-# release so the snapshot is stable. The bash maintainer
-# considers this expected behaviour (see the page README for
-# the standards trail), so the page is a "real-world surprise
-# you should know about" entry, not an "Open upstream issue"
-# entry.
+# The bash maintainer considers this expected behaviour, so the
+# page is a "real-world surprise you should know about" entry
+# rather than an open upstream issue.
 FROM bash:5.3
 
 COPY repro.sh /repro.sh

--- a/src/layer2_docker/find-xargs-whitespace/Dockerfile
+++ b/src/layer2_docker/find-xargs-whitespace/Dockerfile
@@ -13,7 +13,7 @@
 # `-print0` flag (BusyBox `find` supports it on alpine 3.19+ as
 # well, but pinning the GNU version makes the verdict identical
 # across alpine and Debian-style distros).
-FROM alpine:3.19
+FROM alpine:3.24
 
 RUN apk add --no-cache findutils bash grep
 

--- a/src/layer2_docker/find-xargs-whitespace/Dockerfile
+++ b/src/layer2_docker/find-xargs-whitespace/Dockerfile
@@ -9,10 +9,9 @@
 # `find … -print0 | xargs -0 …` — is well-known but easy to
 # forget and impossible for `set -e` to catch.
 #
-# Pinned base: `alpine:3.19`. We install GNU findutils for the
-# `-print0` flag (BusyBox `find` supports it on alpine 3.19+ as
-# well, but pinning the GNU version makes the verdict identical
-# across alpine and Debian-style distros).
+# GNU findutils is installed for `-print0`. BusyBox `find`
+# supports it too, but using the GNU one keeps the verdict
+# identical across alpine and Debian-style distros.
 FROM alpine:3.24
 
 RUN apk add --no-cache findutils bash grep

--- a/src/layer2_docker/flock-is-advisory/Dockerfile
+++ b/src/layer2_docker/flock-is-advisory/Dockerfile
@@ -5,9 +5,8 @@
 # "protect" a file, then are surprised when `cat`, `grep`, `sed`,
 # or any other tool reads it freely while the lock is held.
 #
-# Pinned base: `alpine:3.19`. We add `util-linux` (which provides
-# the `flock(1)` CLI wrapper around `flock(2)`) and `bash` for
-# the wrapper script.
+# `util-linux` provides the `flock(1)` CLI wrapper around
+# `flock(2)`; `bash` is for the wrapper script.
 FROM alpine:3.24
 
 RUN apk add --no-cache util-linux bash

--- a/src/layer2_docker/flock-is-advisory/Dockerfile
+++ b/src/layer2_docker/flock-is-advisory/Dockerfile
@@ -8,7 +8,7 @@
 # Pinned base: `alpine:3.19`. We add `util-linux` (which provides
 # the `flock(1)` CLI wrapper around `flock(2)`) and `bash` for
 # the wrapper script.
-FROM alpine:3.19
+FROM alpine:3.24
 
 RUN apk add --no-cache util-linux bash
 

--- a/src/layer2_docker/postgres-lost-update/Dockerfile
+++ b/src/layer2_docker/postgres-lost-update/Dockerfile
@@ -1,11 +1,6 @@
 # Vivarium Layer 2 reproduction — PostgreSQL "lost update" under
 # default READ COMMITTED isolation.
 #
-# Pinned base image: postgres:16-alpine. The Postgres team rolls
-# new patch tags into this stream; pin to the major+os to keep
-# the image reasonably stable while still picking up security
-# fixes that don't change isolation semantics.
-#
 # We override the standard postgres entrypoint with `repro.sh`,
 # which (i) starts the bundled postgres in the background using
 # its own entrypoint, (ii) waits for the server to become ready,

--- a/src/layer2_docker/postgres-lost-update/Dockerfile
+++ b/src/layer2_docker/postgres-lost-update/Dockerfile
@@ -12,7 +12,7 @@
 # (iii) runs two concurrent application-side increments under
 # READ COMMITTED, and (iv) exits 0 if the lost-update anomaly
 # reproduces, 1 otherwise.
-FROM postgres:16-alpine
+FROM postgres:18-alpine
 
 # Standard postgres image expects these to be set on first boot.
 # `vivarium` is a literal placeholder; nothing else uses the DB.


### PR DESCRIPTION
## Correction first

I told you the Dockerfiles violated the convention. They did not — **the README did.**

Two documents disagreed:

| Where | What it said |
|---|---|
| `src/layer2_docker/README.md:41` | "**Pin everything**: base image by digest" |
| `.claude/rules/recipe-authoring.md:356` | "Pin the base image to a **major tag at minimum** (`node:26-slim`, not `node:latest`). The image digest is captured in the CI-generated `verdict.json` for full determinism." |

The recipes follow the rules file. So `alpine:3.19` was never a violation; the README was the outlier, and my earlier framing was wrong.

And neither document said the base should ever **move**. That is the gap this PR closes.

## The rule

A Layer 2 recipe is a claim that a bug is reachable on **current** software. A base frozen at authoring time quietly turns that claim into a historical note. Both documents now say: name a concrete release tag and bump it forward.

`:latest` is still ruled out, and worth being explicit about why — it would change the image with **no commit to point at and no verdict re-run**, which also breaks the "unchanged recipe is not republished" invariant from #381: source unchanged, contents different.

## The bumps

| Recipe | Before | After |
|---|---|---|
| `bash-local-shadows-exit` | `bash:5.2` | `bash:5.3` |
| `flock-is-advisory` | `alpine:3.19` | `alpine:3.24` |
| `find-xargs-whitespace` | `alpine:3.19` | `alpine:3.24` |
| `postgres-lost-update` | `postgres:16-alpine` | `postgres:18-alpine` |

Latest tags read from the registry API, not assumed — `alpine` 3.x tops out at 3.24, `bash` at 5.3, `postgres` at 18.

## Making the rule mechanical

A rule with no mechanism rots — that is how the two documents drifted apart in the first place. Dependabot had **no `docker` ecosystem at all**, so base bumps were entirely manual. Added:

```yaml
  - package-ecosystem: "docker"
    directories:
      - "/src/layer2_docker/*"
```

`directories` with a glob means recipes added later are covered without another entry. Grouped into one PR, labelled `scope: docker` to match `.github/labeler.yml:68-76`.

**Layer 3 is deliberately excluded.** Its build cannot verify a replay, so an automated base bump there would be a change nothing can check — precisely the situation #389 left us in.

## Verification

**I am not asserting the bugs still reproduce. This PR's own CI is that assertion.**

`src/layer1_wasm/tests/repro.spec.ts:75-88` asserts `expected_verdict`, and `repro-regression.yml` builds and runs every Layer 2 image, so a base bump that fixed a bug upstream shows up as a red check here rather than as a silently wrong gallery entry.

That is the interesting case, so worth saying in advance how to read it: **a flipped verdict is a result, not a breakage.** If `bash:5.3` fixed the `local` exit-code shadowing, or `postgres:18` changed the READ COMMITTED behaviour, the honest response is to record that — move the recipe to the last reproducing tag *with a note*, or retire it — not to pin backwards to get green. Both documents now say so.

Locally: `mise run markdown:check` and `toml:check` pass, and `dependabot.yml` parses with the new entry in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)