### PR TITLE
refactor(ci): hold suggested fixes to the same bar as findings

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -41,52 +41,50 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Review this pull request. The PR's files are checked out
-            under `pr-head/`; the repository as it stands on the base
-            branch is at the workspace root. Search the workspace root
-            whenever you need to find code the PR did *not* touch.
-
-            Do the job the author could not. They saw the files they
-            edited; you have the whole repository. Weight your effort
-            accordingly.
+            Review this pull request. The PR's files are under
+            `pr-head/`; the base branch is at the workspace root —
+            search there for code the PR did not touch. You have the
+            whole repository; the author only saw the files they
+            edited. Weight your effort accordingly.
 
             1. What else should have changed. For every symbol, file,
                path, glob, tag, env var, workflow step, task or config
                key the diff adds, removes, renames, moves or narrows,
                search the base tree for its other references and check
-               each one. A trigger that no longer matches its consumer,
+               each one: a trigger that no longer matches its consumer,
                a doc still describing the old behaviour, a caller left
                pointing at something that moved, a generated artefact
-               whose generator was not rerun. These are the findings
-               this review exists for.
+               whose generator was not rerun.
 
             2. Contradictions with what the repository already states.
                Hold the diff against AGENTS.md, .claude/rules/, the
                README.md nearest the changed code, and any spec page
                under docs/site/*/spec/. Read the rules; do not work
-               from a list of the ones somebody remembered. If the
-               change breaks a rule or an invariant one of them states
-               in words, quote the sentence. Either side may be the
-               thing that is wrong — say which you think it is.
+               from a list of the ones somebody remembered. Quote the
+               sentence the change breaks. Either side may be the
+               wrong one — say which.
 
             3. Whether the implementation is correct. Bugs the tests
                would not catch, edge cases, error paths, and changes
                that do not do what the commit message or the PR
-               description says. Check the description's factual
-               claims against the files instead of trusting them.
+               description says. Check the description's claims
+               against the files rather than trusting them.
 
-            Before reporting that something is unused, removable,
-            narrowable, or already covered elsewhere, enumerate its
-            consumers and name them in the finding. "Nothing else reads
-            this" is worth reporting only when you searched for readers
-            and can say what you searched. A confident finding built on
-            an unchecked assumption costs more than silence.
+            Verify before you assert, in both directions. Before
+            calling something unused, removable, narrowable or covered
+            elsewhere, enumerate its consumers and name them in the
+            finding. Before proposing a fix, confirm the key, flag or
+            API you reach for does what you think here — one defined
+            under a different parent, or that behaves differently in
+            this mode, is not the one you want; if you narrow
+            something, re-run the consumer search against the narrowed
+            version. When you cannot confirm a remedy, report the
+            finding without one and say what you could not check.
 
             Report each finding as an inline comment on the line it
-            concerns, with what breaks and the evidence you gathered.
-            Keep the summary comment for what has no single line — a
-            missing update in a file the diff never touched belongs
-            there, with the path. Skip nits the linters already
-            enforce. Saying you found nothing is a fine answer when the
-            searches above came back empty — but it should mean you ran
-            them, not that the diff read fine.
+            concerns, with what breaks and the evidence. Keep the
+            summary for what has no single line — a missing update in
+            a file the diff never touched belongs there, with the
+            path. Skip nits the linters enforce. "I found nothing" is
+            a fine answer when the searches came back empty, but it
+            should mean you ran them.


### PR DESCRIPTION
Follow-up to #387, prompted by the same failure landing twice.

## The pattern

The reviewer has been **right about the problem and wrong about the repair**, in both cases confidently enough that the repair read as researched:

| PR | The finding — correct | The remedy — wrong |
|---|---|---|
| [#386](https://github.com/aletheia-works/vivarium/pull/386) | `docs/site/public/spec/**.schema.json` is wider than what the workflow reads | "narrow it to `manifest.schema.json`" — missed that `scripts/capture_layer2_verdict.sh:46` reads `verdict.schema.json`. Applying it would have stopped triggering on a schema the workflow validates against. |
| [#390](https://github.com/aletheia-works/vivarium/pull/390) | `/src/layer2_docker/*` also matches `_template/`, whose Dockerfile is `FROM {{BASE_IMAGE}}` | "use `exclude-patterns`" — that key lives under `groups` and excludes *dependencies* from a group. It does nothing for directories. Applying it as written would have added a no-op. |

Both findings were worth having. #386's led to #392, which narrowed the glob correctly — to **two** schemas, not one. #390's is still open as a question about what Dependabot does with an unparseable `FROM`.

That is the point: the findings paid for themselves and the remedies cost review time to disprove. A wrong remedy is more expensive than none, because it arrives with the credibility of the correct finding attached to it.

## What changed, and why it is shorter

#387 added "enumerate consumers before claiming something is unused". That rule is working — it is visible in the reviews — but it governs *findings* and never reaches the fix stapled to one.

Rather than append a third paragraph, this rewrites what was there. The prompt had grown by accretion: #387 rewrote it, #388 appended a paragraph, and the first draft of this PR appended another. The result stated "verify before you assert" **twice, in two separate paragraphs**, the second time behind three lines explaining why a wrong remedy is expensive. Both directions now share one paragraph, and the justification prose is gone — the instruction is the part that acts:

> Verify before you assert, in both directions. Before calling something unused, removable, narrowable or covered elsewhere, enumerate its consumers and name them in the finding. Before proposing a fix, confirm the key, flag or API you reach for does what you think here — one defined under a different parent, or that behaves differently in this mode, is not the one you want; if you narrow something, re-run the consumer search against the narrowed version. When you cannot confirm a remedy, report the finding without one and say what you could not check.

The three ways a remedy goes wrong are drawn from what actually happened: "under a different parent" is `exclude-patterns`; "re-run the consumer search against the narrowed version" is the `verdict.schema.json` miss; "behaves differently in this mode" is my own error on #388, where I argued from an upstream example running agent mode while this workflow runs tag mode.

**69 lines to 50, 3305 characters to 2340.** Every instruction survives — checked one by one rather than by eye:

| Instruction | |
|---|---|
| Search the base tree for what the PR did not touch | kept |
| Enumerate every identifier the diff adds/removes/renames/moves/narrows | kept |
| Read the rules, not a remembered subset | kept |
| Quote the sentence the change breaks; say which side is wrong | kept |
| Check the PR description's claims against the files | kept |
| Enumerate consumers before calling something unused | kept |
| Confirm a key/flag/API does what you think, three named traps | kept |
| Report a finding without a remedy when unconfirmed | kept |
| Inline vs summary placement | kept |
| Skip linter nits | kept |
| "Nothing" must mean you searched | kept |

What went is four sentences of justification — *"these are the findings this review exists for"*, *"a confident finding built on an unchecked assumption costs more than silence"*, the three-line explanation of why a wrong remedy is expensive, and *"naming the problem is the valuable half"*.

## Scope

Prompt text only — one paragraph inserted. `claude_args`, `track_progress`, `github_token`, the `if:` guard and the two-checkout layout are untouched.

## Verification

`yaml.safe_load` — pass; the prompt parses as a 69-line block scalar.

**This PR cannot test itself.** `pull_request_target` evaluates the workflow from the base branch, so the change takes effect on the first PR after merge. And the honest test is narrower than "does the next review look good": it is whether a *future* finding arrives either with a remedy that survives checking, or with no remedy and an explicit note about what could not be confirmed. A run of clean reviews proves nothing about this either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
