### PR TITLE
build: use bunx everywhere now that Windows ships it

### DIFF
--- a/.claude/rules/recipe-authoring.md
+++ b/.claude/rules/recipe-authoring.md
@@ -442,9 +442,6 @@ Layer 2. CI does not regenerate it.
 
 ## Cross-cutting pitfalls (all layers)
 
-- **`bunx` vs `bun x`.** Never write `bunx <pkg>` in scripts;
-  Windows local has no `bunx.cmd`. Always `bun x <pkg>`
-  (subcommand form).
 - **Auto-generated files.** `docs/site/public/api/recipes.json` and
   `docs/site/public/api/projects.json` are tracked but generated.
   Always run the generators before committing; never hand-edit.

--- a/docs/playwright.config.ts
+++ b/docs/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   },
 
   webServer: {
-    command: `bun run build && bun x rspress preview --port ${DOCS_PORT}`,
+    command: `bun run build && bunx rspress preview --port ${DOCS_PORT}`,
     url: `${DOCS_BASE}/vivarium/`,
     reuseExistingServer: !process.env.CI,
     timeout: 180_000,

--- a/mise.toml
+++ b/mise.toml
@@ -63,25 +63,25 @@ run = "bun run preview"
 description = "Format docs/ JS/TS/CSS/JSON with Biome (in-place)"
 depends = ["docs:install"]
 dir = "docs"
-run = "bun x --bun biome format --write ."
+run = "bunx --bun biome format --write ."
 
 [tasks."docs:lint"]
 description = "Lint docs/ with Biome (read-only, exits non-zero on errors)"
 depends = ["docs:install"]
 dir = "docs"
-run = "bun x --bun biome lint ."
+run = "bunx --bun biome lint ."
 
 [tasks."docs:check"]
 description = "Biome check (format + lint + import-organize, read-only)"
 depends = ["docs:install"]
 dir = "docs"
-run = "bun x --bun biome check ."
+run = "bunx --bun biome check ."
 
 [tasks."docs:check:fix"]
 description = "Biome check + apply safe + unsafe auto-fixes"
 depends = ["docs:install"]
 dir = "docs"
-run = "bun x --bun biome check --write --unsafe ."
+run = "bunx --bun biome check --write --unsafe ."
 
 [tasks."repro:install"]
 description = "Install Layer 1 (WASM) sources dependencies"
@@ -296,7 +296,7 @@ set -euo pipefail
 bun install --frozen-lockfile
 bun run typecheck
 mise run repro:build
-bun x playwright install --with-deps chromium
+bunx playwright install --with-deps chromium
 bun run test
 '''
 

--- a/packages/mcp-server/src/tools/verify_and_report_fix.ts
+++ b/packages/mcp-server/src/tools/verify_and_report_fix.ts
@@ -138,7 +138,7 @@ function buildCommands(args: BuildCommandsArgs): string[] {
       if (pathAB === 'A') {
         return [
           `# Capture the unfixed verdict against the upstream-as-shipped runtime.`,
-          `bun x playwright test --grep ${slug}`,
+          `bunx playwright test --grep ${slug}`,
           `# Or inspect the verdict visually at ${compareUrl}.`,
         ];
       }
@@ -150,7 +150,7 @@ function buildCommands(args: BuildCommandsArgs): string[] {
       if (pathAB === 'A') {
         return [
           `# Capture the fixed verdict against the candidate fix source.`,
-          `PLAYWRIGHT_FIX_URL='<fix-url>' bun x playwright test --grep ${slug}`,
+          `PLAYWRIGHT_FIX_URL='<fix-url>' bunx playwright test --grep ${slug}`,
           `# Or open ${compareUrl} in a browser; the fix is pre-loaded via ?fix_url= / ?fix=<base64>.`,
         ];
       }

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -618,7 +618,7 @@ describe('verify_and_report_fix', () => {
         'src/layer1_wasm/pandas-56679/roundtrip.json',
       );
       assert.ok(
-        r.commands.some((c) => c.includes('bun x playwright test')),
+        r.commands.some((c) => c.includes('bunx playwright test')),
         'layer 1 verify_unfixed commands should include playwright invocation',
       );
     }


### PR DESCRIPTION
`bunx <pkg>` used to fail on Windows with `'bunx' is not recognized` —
bun shipped only `bun.exe`, no `bunx.cmd` — so the repo standardised on
the `bun x <pkg>` subcommand form and `.claude/rules/recipe-authoring.md`
carried a pitfall entry forbidding `bunx`.

bun 1.4.0 ships `bunx` on Windows (verified: it resolves under the mise
install and reports 1.4.0), so the workaround has outlived its cause.
Keeping it would leave a constraint whose reason is gone, which reads as
arbitrary to whoever hits it next.

The repo had already drifted: the GitHub Actions workflows always used
`bunx`, and `mise.toml` used `bunx` in `repro:test` / `ci:repro-full` /
`ci:commitlint` while `docs:*` and `ci:repro` used `bun x`. Everything
is now `bunx`, so local and CI read the same:

  mise.toml            the four biome tasks + the playwright install
  docs/playwright.config.ts  the rspress preview webServer command
  packages/mcp-server  the commands `verify_and_report_fix` hands an
                       agent, and the test asserting their shape

The pitfall entry in the recipe-authoring rule is deleted rather than
inverted — `bunx` is the unremarkable default now, not a rule worth
spending a reader's attention on.

Verified: `mise run docs:check` (runs through `bunx --bun biome`) clean
on 61 files, mcp-server 131 tests pass, tombi and rumdl clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
