### PR TITLE
ci: drop the ShellCheck severity floor back to the default

### DIFF
--- a/.github/workflows/project-fields.yml
+++ b/.github/workflows/project-fields.yml
@@ -87,6 +87,9 @@ jobs:
               ;;
           esac
 
+          # shellcheck disable=SC2016  # $owner / $number are GraphQL
+          # variables resolved by the server from the -f/-F flags above;
+          # letting the shell expand them would send an empty query.
           project_data=$(gh api graphql \
             -f owner="$PROJECT_OWNER" \
             -F number="$PROJECT_NUMBER" \
@@ -122,6 +125,7 @@ jobs:
             exit 1
           fi
 
+          # shellcheck disable=SC2016  # GraphQL variables, not shell ones.
           add_result=$(gh api graphql \
             -f projectId="$PROJECT_ID" \
             -f contentId="$CONTENT_ID" \
@@ -133,6 +137,7 @@ jobs:
               }')
           ITEM_ID=$(echo "$add_result" | jq -r '.data.addProjectV2ItemById.item.id')
 
+          # shellcheck disable=SC2016  # GraphQL variables, not shell ones.
           gh api graphql \
             -f projectId="$PROJECT_ID" \
             -f itemId="$ITEM_ID" \

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -43,9 +43,11 @@ jobs:
           version=$(jq -r .version package.json)
           name=$(jq -r .name package.json)
           jsr_name=$(jq -r .name jsr.json)
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "npm_name=$name" >> "$GITHUB_OUTPUT"
-          echo "jsr_name=$jsr_name" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=$version"
+            echo "npm_name=$name"
+            echo "jsr_name=$jsr_name"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Check if npm version is already published
         id: npm-check

--- a/.github/workflows/seed-state.yml
+++ b/.github/workflows/seed-state.yml
@@ -66,8 +66,10 @@ jobs:
 
       - name: Summary
         run: |
-          echo "### Seed complete" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- Artifact: \`terraform-state\` (uploaded from run \`${{ github.run_id }}\`)" >> $GITHUB_STEP_SUMMARY
-          echo "- \`LATEST_APPLY_RUN_ID\` set to \`${{ github.run_id }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Next Terraform Plan/Apply run will download this state." >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### Seed complete"
+            echo ""
+            echo "- Artifact: \`terraform-state\` (uploaded from run \`${{ github.run_id }}\`)"
+            echo "- \`LATEST_APPLY_RUN_ID\` set to \`${{ github.run_id }}\`"
+            echo "- Next Terraform Plan/Apply run will download this state."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/mise.toml
+++ b/mise.toml
@@ -368,12 +368,10 @@ description = "ShellCheck — scripts/ (read-only)"
 # Only scripts/. A recipe's repro.sh reproduces a shell footgun, so it
 # trips the check that detects that footgun — SC2155 and SC2038 are the
 # bugs two Layer 2 recipes exist to demonstrate.
-env = { SHELLCHECK_OPTS = "-S warning" }
 run = "shellcheck scripts/*.sh"
 
 [tasks."actions:check"]
 description = "actionlint — workflow syntax + ShellCheck over every run: block (read-only)"
-env = { SHELLCHECK_OPTS = "-S warning" }
 # Paths are explicit because actionlint finds workflows via `.git`,
 # which this repository does not have.
 run = "actionlint .github/workflows/*.yml"


### PR DESCRIPTION
`shell:check` and `actions:check` both pinned `SHELLCHECK_OPTS=-S
warning`, which suppresses everything ShellCheck classifies as info or
style. That floor made sense when the shell still lived inside
`mise.toml` strings and workflow YAML: the volume at default severity
was unmanageable, so #394 raised the gate to get the check landed at
all. #395 then moved the task bodies into real `.sh` files under
`scripts/`, which removed the reason.

Measured before changing anything: `scripts/` reports nothing extra at
the default severity — the floor is buying zero signal there — while
the workflows report ten findings the gate was hiding. All ten are now
fixed, so the default is a clean gate rather than a backlog:

  seed-state.yml     SC2086 x5, SC2129 x1 — five appends to an unquoted
                     $GITHUB_STEP_SUMMARY. Collapsed into one
                     `{ ... } >> "$GITHUB_STEP_SUMMARY"` block, which
                     answers both codes at once.
  publish-mcp.yml    SC2129 x1 — three consecutive appends to
                     $GITHUB_OUTPUT, same treatment.
  project-fields.yml SC2016 x3 — `$owner`, `$number`, `$projectId` and
                     friends inside single-quoted `gh api graphql -f
                     query='...'` strings. These are GraphQL variables
                     the server resolves from the -f/-F flags; letting
                     the shell expand them would send an empty query.
                     Suppressed per call site with a reason rather than
                     rewritten, since the code is correct as written.

What comes back with the floor removed is the info/style tier —
SC2012 (`ls` where `find` is meant) and its neighbours. That is the
class #394's gate was trading away, and the class most likely to bite
a shell script that walks the recipe tree.

Note for anyone verifying locally on Windows: both tasks pass a glob
(`scripts/*.sh`, `.github/workflows/*.yml`) that mise's default shell
does not expand there, so `mise run shell:check` / `actions:check` fail
with a path error before either tool starts. That predates this commit
— CI runs on Linux and is unaffected. Verification here went through
`mise exec -- bash -c '...'` instead.

Verified: every workflow clean at default severity except deploy-docs.yml,
which actionlint could not finish locally within ten minutes (each
`run:` block spawns a ShellCheck process, and process spawn on Windows
is slow); the ten findings above account for the full measured tally,
so it is expected to be clean, and CI confirms. `shellcheck scripts/*.sh`
clean. tombi clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
