### PR TITLE
fix(wasm): stop lark-1585 native repro crashing on windows

### DIFF
--- a/scripts/run-layer1-python.sh
+++ b/scripts/run-layer1-python.sh
@@ -2,11 +2,22 @@
 set -euo pipefail
 shopt -s nullglob
 matched=0
+failed=()
 for f in src/layer1_wasm/*/repro.py; do
   matched=1
   echo "== $f =="
-  mise exec uv -- uv run "$f"
+  code=0
+  mise exec uv -- uv run "$f" || code=$?
+  if [ "$code" -ne 0 ]; then
+    echo "[repro:native:python] $f exited $code" >&2
+    failed+=("$f")
+  fi
 done
 if [ "$matched" -eq 0 ]; then
   echo "[repro:native:python] no src/layer1_wasm/*/repro.py found — nothing to run" >&2
+fi
+if [ "${#failed[@]}" -ne 0 ]; then
+  echo "[repro:native:python] ${#failed[@]} script(s) did not exit 0:" >&2
+  printf '  %s\n' "${failed[@]}" >&2
+  exit 1
 fi

--- a/src/layer1_wasm/lark-1585/README.md
+++ b/src/layer1_wasm/lark-1585/README.md
@@ -112,7 +112,7 @@ mise exec uv -- uv run src/layer1_wasm/lark-1585/repro.py
 #   "python_version": "3.14.x",
 #   "outcome": "timeout",
 #   "exit_code": null,
-#   "stderr_tail": [...],
+#   "stderr_tail": ["1.3.1 3.14.x"],
 #   "elapsed_ms": 8000.x,
 #   "timeout_ms": 8000.0,
 #   "reproduced": true

--- a/src/layer1_wasm/lark-1585/repro.py
+++ b/src/layer1_wasm/lark-1585/repro.py
@@ -43,6 +43,13 @@ Lark('start.1: "a" | start start*', parser='lalr').parse('aa')
 """
 
 
+def as_text(stream) -> str:
+    # TimeoutExpired.stderr is str on Windows and bytes on POSIX, even under text=True.
+    if isinstance(stream, (bytes, bytearray)):
+        return stream.decode(errors="replace")
+    return stream or ""
+
+
 def main() -> int:
     started = time.perf_counter()
     try:
@@ -79,14 +86,16 @@ def main() -> int:
         return 1
     except subprocess.TimeoutExpired as exc:
         elapsed_ms = (time.perf_counter() - started) * 1000
+        # The child flushes its version banner to stderr before it hangs.
+        stderr_str = as_text(exc.stderr)
+        child_meta = stderr_str.strip().splitlines()[-1] if stderr_str.strip() else ""
+        lark_version, _, python_version = child_meta.partition(" ")
         result = {
-            "lark_version": "1.3.1",
-            "python_version": sys.version.split()[0],
+            "lark_version": lark_version or "unknown",
+            "python_version": python_version or sys.version.split()[0],
             "outcome": "timeout",
             "exit_code": None,
-            "stderr_tail": (exc.stderr.decode(errors="replace") if exc.stderr else "").splitlines()[
-                -5:
-            ],
+            "stderr_tail": stderr_str.splitlines()[-5:],
             "elapsed_ms": elapsed_ms,
             "timeout_ms": TIMEOUT_S * 1000,
             "reproduced": True,

--- a/src/layer1_wasm/lark-1585/verify_fix.py
+++ b/src/layer1_wasm/lark-1585/verify_fix.py
@@ -90,6 +90,13 @@ PROBE = textwrap.dedent(
 ).strip()
 
 
+def as_text(stream) -> str:
+    # TimeoutExpired.stderr is str on Windows and bytes on POSIX, even under text=True.
+    if isinstance(stream, (bytes, bytearray)):
+        return stream.decode(errors="replace")
+    return stream or ""
+
+
 def run_variant(variant: dict[str, str]) -> dict[str, object]:
     """Run the probe inside an ephemeral uv venv with *spec* installed."""
     print(f"\n--- {variant['name']} :: {variant['label']} ---", file=sys.stderr)
@@ -144,12 +151,12 @@ def run_variant(variant: dict[str, str]) -> dict[str, object]:
         return record
     except subprocess.TimeoutExpired as exc:
         elapsed_ms = (time.perf_counter() - started) * 1000
-        stderr_str = exc.stderr.decode(errors="replace") if exc.stderr else ""
+        stderr_str = as_text(exc.stderr)
         child_meta = stderr_str.strip().splitlines()[-1] if stderr_str.strip() else ""
         lark_version, _, python_version = child_meta.partition(" ")
         record.update(
             {
-                "lark_version": lark_version or "1.3.1",
+                "lark_version": lark_version or "unknown",
                 "python_version": python_version or sys.version.split()[0],
                 "outcome": "timeout",
                 "exit_code": None,


### PR DESCRIPTION
## Why

`mise run repro:native:python` aborts on Windows. Spotted while working on #401.

```text
== src/layer1_wasm/cpython-137205/repro.py ==   ok
== src/layer1_wasm/dateutil-1478/repro.py ==    ok
== src/layer1_wasm/lark-1585/repro.py ==
subprocess.TimeoutExpired: ... timed out after 8.0 seconds

During handling of the above exception, another exception occurred:
  File "src/layer1_wasm/lark-1585/repro.py", line 87, in main
    "stderr_tail": (exc.stderr.decode(errors="replace") if exc.stderr else "")...
AttributeError: 'str' object has no attribute 'decode'
```

`numpy-28287` and `pandas-56679` sort after `lark-1585`, so they never ran at all.

## The `.decode()` bug

`subprocess.run(..., text=True)` does **not** make `TimeoutExpired.stderr` a `str` everywhere:

| | `TimeoutExpired.stderr` | why |
|---|---|---|
| POSIX | `bytes` | the exception is built inside `Popen._communicate` from the raw partial chunks (`b"".join(...)`); `run()` only calls `wait()` afterwards |
| Windows | **`str`** | `run()` kills the child and calls `communicate()` a **second** time to drain the reader threads, which goes through the text-mode decode, and assigns the result onto the exception |

The timeout handler was the one bytes-assuming line in a file whose success path already treats the same stream as `str`. And timing out *is* the reproduction signal for this recipe, so on Windows the crash fired on every **successful** run.

`verify_fix.py:147` carried the identical line and the identical assumption. Both now decode only when the stream is actually bytes:

```python
def as_text(stream) -> str:
    # TimeoutExpired.stderr is str on Windows and bytes on POSIX, even under text=True.
    if isinstance(stream, (bytes, bytearray)):
        return stream.decode(errors="replace")
    return stream or ""
```

Nothing caught this because `repro:native:python` is referenced by no workflow — and on the Linux runners it would have stayed green regardless.

## The sweep no longer truncates

`scripts/run-layer1-python.sh` runs under `set -e` with the recipe invocation as a bare command, so the first non-zero exit ended the loop. It now collects each exit code, keeps going, and names the failures before exiting non-zero.

Exit 1 still fails the task. A flipped verdict is a result to act on, the same way the Playwright suite treats `expected_verdict` — the change here is only that one recipe's outcome no longer hides the rest.

## Version literal removed

The timeout path hardcoded `"lark_version": "1.3.1"`, duplicating the PEP 723 pin somewhere a version bump could not reach. The child flushes its version banner to stderr *before* it hangs, so both files now parse it out of the captured stderr exactly as their success paths do, falling back to `"unknown"` rather than to a literal. In `verify_fix.py` that literal was also actively wrong for the fix-candidate variant, which is not 1.3.1.

## Verification

`lark-1585` alone on Windows — no traceback, exit 0, and `lark_version` / `python_version` now come from the child rather than from a literal and the parent:

```json
{
  "lark_version": "1.3.1",
  "python_version": "3.14.6",
  "outcome": "timeout",
  "exit_code": null,
  "stderr_tail": ["1.3.1 3.14.6"],
  "elapsed_ms": 8293.0866999086,
  "timeout_ms": 8000.0,
  "reproduced": true
}
```

The full sweep now runs all five, `numpy-28287` and `pandas-56679` included, and exits 0.

The `set -e` behaviour was checked against stub recipes — a crashing script in the middle no longer stops the ones after it, and the run still fails:

```text
== src/layer1_wasm/a-1/repro.py ==
A ok
== src/layer1_wasm/b-2/repro.py ==
[repro:native:python] src/layer1_wasm/b-2/repro.py exited 1
== src/layer1_wasm/c-3/repro.py ==
C ok
[repro:native:python] 1 script(s) did not exit 0:
  src/layer1_wasm/b-2/repro.py
sweep exit=1
```

`as_text` was exercised directly in both modules against `bytes`, `str`, `bytearray` with invalid UTF-8, `None`, and empty — the POSIX path is covered even though this machine is Windows. `shellcheck` (default/style, per #397), `python:check` (ruff) and `markdown:check` are clean.

## Follow-ups, not in this PR

- `repro:native:python` is wired into no workflow. Connecting it would catch general breakage, but since exit 1 means `unreproduced`, CI would go red the moment any of these five bugs is fixed upstream. Worth deciding separately — it would not have caught this Windows-only bug either way.
- Rolling #401's shape (ordinary Python printing real stdout) out to `cpython-137205` / `numpy-28287` / `pandas-56679` / `lark-1585` / `ruby-21709` / `regex-779`, plus recording the convention in `.claude/rules/recipe-authoring.md`. `lark-1585` needs its own design there: the browser variant has no script stdout to show, because a hung Web Worker is terminated and the JSON is synthesised on the main thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
