### PR TITLE
perf(wasm): run dateutil-1478 pyodide in a web worker

### DIFF
--- a/.claude/rules/recipe-authoring.md
+++ b/.claude/rules/recipe-authoring.md
@@ -232,8 +232,9 @@ one. Copy the block from
 - Three ways to fill the fix pane, in order of preference:
   1. **Fork wheel** — `fix-candidate.json` + the helpers in
      [`_shared/fix-candidate.ts`](../../src/layer1_wasm/_shared/fix-candidate.ts).
-     Pure-Python packages only; see `dateutil-1478` (main-thread) and
-     `lark-1585` (one Web Worker per variant).
+     Pure-Python packages only. `dateutil-1478` uses those helpers;
+     `lark-1585` fetches and resolves its own manifest inline. Both
+     install the resolved wheel into a Pyodide Web Worker.
   2. **A second artefact built from a fixed dependency version** —
      e.g. a second `wasm32-wasip1` binary, or a different runtime build.
   3. **No candidate** — when no fixed build can be executed in the
@@ -283,6 +284,15 @@ PRs 180 / 189 / 192.
 - **System calls.** Pyodide ships an MEMFS-like virtual FS, not
   the real one. Anything depending on real filesystem semantics,
   fork/exec, sockets, or signals → Layer 2.
+- **Pyodide belongs in a Web Worker.** Booting it and resolving a
+  micropip install are pure CPU work; on the main thread they land as
+  one task tens of seconds long and Chrome offers to kill the tab.
+  `dateutil-1478` measured 19.9 s of main-thread blocking with a
+  15.0 s worst task before the runtime moved into a worker, and 353 ms
+  after. A worker cannot import `_shared/verdict.ts`, `loader.ts` or
+  `runner.ts` — all three reach `_assets/chrome.js`, which touches
+  `document` at module-evaluation time — so it loads Pyodide itself and
+  posts results back. See `dateutil-1478/repro.worker.ts`.
 
 ---
 

--- a/src/layer1_wasm/_shared/README.md
+++ b/src/layer1_wasm/_shared/README.md
@@ -27,7 +27,7 @@ and runner — `bun install`, `bun run build`, `bun run typecheck`.
 | --- | --- | --- |
 | `verdict.ts` | `verdict.js` | `setVerdict()` / `setResult()` + `VivariumResultV1` interface. |
 | `loader.ts` | `loader.js` | `loadVivariumPyodide()` — Pyodide bootstrap with version pin and package preload. |
-| `fix-candidate.ts` | `fix-candidate.js` | `reinstallPyodidePackage()` / `fetchWheelManifest()` / `resolveFixCandidateSpec()` + `WheelManifest` interface — shared plumbing for recipes that render baseline + fix-candidate side-by-side on a single Pyodide instance (dateutil-1478). Worker-based recipes (lark-1585) keep their own per-variant flow. |
+| `fix-candidate.ts` | `fix-candidate.js` | `fetchWheelManifest()` / `resolveFixCandidateSpec()` + `WheelManifest` interface — resolves the CI-built wheel a recipe renders beside its baseline; installing it is the recipe's own job. `dateutil-1478` is the only consumer — `lark-1585` fetches and resolves its manifest inline instead. |
 | `runner.ts` | `runner.js` | `enableRunner()` — Edit/Run/Reset buttons that hand the (possibly edited) source back to the recipe's `captureRun`. |
 | `path_a.ts` | `path_a.js` | `PathACapturedRun` type + the Path A "fix URL?" UI panel. |
 | `_test/repro.ts` | `_test/repro.js` | Smoke test validating the contract-v1 surface (no Pyodide). |

--- a/src/layer1_wasm/_shared/fix-candidate.ts
+++ b/src/layer1_wasm/_shared/fix-candidate.ts
@@ -1,7 +1,3 @@
-export interface PyodideRuntime {
-  runPythonAsync(code: string): Promise<unknown>;
-}
-
 export interface WheelManifest {
   schema_version: number;
   package: string;
@@ -18,26 +14,6 @@ export interface WheelManifest {
   };
   upstream_pr?: string;
   fetched_at?: string;
-}
-
-export async function reinstallPyodidePackage(
-  runtime: PyodideRuntime,
-  args: {
-    pipPackageName: string;
-    pythonRootModule: string;
-    installSpec: string;
-  },
-): Promise<void> {
-  await runtime.runPythonAsync(`
-import micropip, sys
-try:
-    await micropip.uninstall(${JSON.stringify(args.pipPackageName)})
-except Exception:
-    pass
-for _name in [n for n in list(sys.modules) if n == ${JSON.stringify(args.pythonRootModule)} or n.startswith(${JSON.stringify(`${args.pythonRootModule}.`)})]:
-    del sys.modules[_name]
-await micropip.install(${JSON.stringify(args.installSpec)})
-`);
 }
 
 export type FetchWheelManifestOutcome =

--- a/src/layer1_wasm/_shared/loader.ts
+++ b/src/layer1_wasm/_shared/loader.ts
@@ -44,7 +44,7 @@ export const DEFAULT_PYODIDE_VERSION = "314.0.6";
 const SIZE_RUNTIME_MB = 12.0; // wasm + stdlib + lockfile combined
 const SIZE_PER_PACKAGE_MB = 0.6; // typical for sqlite3, pandas-light, etc.
 
-function totalEstimatedMB(packageCount: number): number {
+export function totalEstimatedMB(packageCount: number): number {
   return SIZE_RUNTIME_MB + packageCount * SIZE_PER_PACKAGE_MB;
 }
 

--- a/src/layer1_wasm/dateutil-1478/README.md
+++ b/src/layer1_wasm/dateutil-1478/README.md
@@ -39,11 +39,12 @@ signed-offset code path. Both the short (`-4`) and the long
 | File         | Role                                                              |
 | ------------ | ----------------------------------------------------------------- |
 | `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. Renders baseline + fix-candidate output panes side-by-side. |
-| `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. Drives the two-variant run (baseline `micropip` install → fix-candidate wheel install via `./wheels/manifest.json` → baseline restore for `enableRunner`). |
-| `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
+| `repro.ts`   | **Main-thread driver.** Spawns one Pyodide Web Worker per variant, relays their progress into the page's progress bar, and owns the verdict, the Contract v1 envelope and both output panes. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `repro.worker.ts` | **Worker source.** Loads Pyodide and installs the spec passed on the worker URL's query string (`python-dateutil==2.9.0.post0` for baseline, the wheel URL for the fix candidate), then runs the reproduction script and reports its stdout and its `results` list back. |
+| `repro.js` / `repro.worker.js` | Generated; gitignored. Loaded by `index.html` at runtime. |
 | `repro.py`   | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. See "Native verification" below. |
 | `fix-candidate.json` | **Tracked.** Single source of truth for the fix branch the page renders alongside the baseline (fork repo URL + branch ref). Read by `scripts/build-layer1-wheels.sh`. |
-| `wheels/`    | Generated; gitignored. `mise run repro:build:wheels` (`scripts/build-layer1-wheels.sh`) builds `python_dateutil-<version>-py2.py3-none-any.whl` from `fix-candidate.json` plus a `manifest.json` (filename + version + resolved commit + spec). `repro.ts` fetches the manifest at page load to install the fix candidate in the same Pyodide tab. |
+| `wheels/`    | Generated; gitignored. `mise run repro:build:wheels` (`scripts/build-layer1-wheels.sh`) builds `python_dateutil-<version>-py2.py3-none-any.whl` from `fix-candidate.json` plus a `manifest.json` (filename + version + resolved commit + spec). `repro.ts` fetches the manifest at page load, resolves the wheel URL, and hands it to a second worker. |
 | `roundtrip.json` | Tracked workflow state (round-trip schema_version 1). Updated as the recipe moves through verify → Vivarium PR → fork+fix → upstream PR. |
 
 Shared visual presentation lives in [`../_shared/style.css`](../_shared/style.css).
@@ -70,9 +71,9 @@ The page conforms to the contract canonicalised in
 
 The reproduction script is ordinary Python: it prints one row per
 input and leaves a `results` list behind. The output panes show that
-printed text verbatim — nothing on the page reformats it — and
-`repro.ts` reads `results` out of the Pyodide globals to build the
-envelope above.
+printed text verbatim — nothing on the page reformats it — and the
+worker reads `results` out of the Pyodide globals and hands it back so
+`repro.ts` can build the envelope above.
 
 A `reproduced` verdict means **every** `UTC±N` input landed on the
 negated offset — the sign-inversion bug is present end-to-end. An
@@ -95,6 +96,28 @@ python -m http.server -d dateutil-1478 8765
 
 Pyodide does **not** require COOP/COEP headers for this page (no
 `SharedArrayBuffer`, no threading), so a plain server is enough.
+
+## Why the runtime lives in a Web Worker
+
+Booting Pyodide and resolving a micropip install are pure CPU work. Run
+on the main thread they land as a single task tens of seconds long, and
+Chrome offers to kill the tab before it finishes — measured at 19.9 s of
+total main-thread blocking with a 15.0 s worst task on the deployed
+page. Moving both into a worker takes the same page to a few hundred
+milliseconds.
+
+There are two workers, and they differ in lifetime. The **baseline**
+worker is kept alive for the whole page, because `enableRunner`'s Run
+button re-runs the visitor's edited script inside it; it never has the
+fix-candidate wheel installed, so Run always exercises the buggy
+version. The **fix-candidate** worker is spawned after the baseline
+verdict settles and terminated as soon as its pane is filled.
+
+The worker imports nothing from `../_shared/`: `_shared/verdict.ts`
+pulls in `_assets/chrome.js`, which touches `document` at module
+evaluation time and would throw inside a worker. Everything DOM-bound —
+the verdict pill, the envelope, the panes, the progress bar, the i18n —
+stays in `repro.ts`.
 
 ## Native verification — same reproduction under a real CPython + dateutil
 

--- a/src/layer1_wasm/dateutil-1478/i18n.ja.json
+++ b/src/layer1_wasm/dateutil-1478/i18n.ja.json
@@ -19,7 +19,7 @@
     "drawer.body.p2": "{0} は {1} を返す（期待値は {2}）、{3} は {4} を返す（期待値は {5}）。素の ISO 8601 形式（{8} 接頭辞のない {6} / {7}）は正しく parse されるので、この反転は {9} と符号付きオフセットの組み合わせの code path に限定される。",
     "drawer.body.p3": "このページのスクリプトは 4 つの形（{0}、{1}、{2}、{3}）を試し、parse された {4} をそれぞれ期待値と比較する。形ごとに 1 行ずつ print し、出力ペインにはその print された文字列がそのまま出る。スクリプトが残す {5} リストをページが読んで verdict を決める。",
     "drawer.body.p4": "議論の全体（動機、経緯、fix の進捗）は下の GitHub issue スレッドにある。",
-    "drawer.body.p5": "fix 候補のブランチ（{0}）が {1} 配下の pure-Python wheel としてビルドされ、baseline の実行が終わったあとに同じ Pyodide タブへインストールされる。1 回のページ読み込みで before/after の verdict を比較できる。",
+    "drawer.body.p5": "fix 候補のブランチ（{0}）が {1} 配下の pure-Python wheel としてビルドされ、baseline の実行が終わったあとに 2 つ目の Pyodide worker へインストールされる。1 回のページ読み込みで before/after の verdict を比較できる。",
     "chip.fixCandidate": "{0} fix 候補ブランチ",
     "section.baseline.h2": "baseline の出力",
     "output.pending": "(待機中)",

--- a/src/layer1_wasm/dateutil-1478/page.en.html
+++ b/src/layer1_wasm/dateutil-1478/page.en.html
@@ -32,14 +32,14 @@
       A fix-candidate branch
       (<code>JamBalaya56562/dateutil@fix-1478-utc-gmt-offset-sign</code>)
       is built into a pure-Python wheel under <code>./wheels/</code>
-      and installed into the same Pyodide tab after the baseline
+      and installed into a second Pyodide worker after the baseline
       run completes, so visitors can compare the before/after
       verdict in one page load.
     </p>
   
 </template>
 
-<template data-slot="runtime-label">Pyodide v{{PYODIDE_VERSION}} + python-dateutil 2.9.0.post0 (micropip)</template>
+<template data-slot="runtime-label">Pyodide v{{PYODIDE_VERSION}} + python-dateutil 2.9.0.post0 (micropip, inside a Web Worker)</template>
 
 <template data-slot="fix-pane">
 <pre id="output-fix" class="vh-variant-output" data-i18n="output.waitingBaseline">(waiting for baseline)</pre>

--- a/src/layer1_wasm/dateutil-1478/repro.ts
+++ b/src/layer1_wasm/dateutil-1478/repro.ts
@@ -1,10 +1,13 @@
 import {
   fetchWheelManifest,
-  reinstallPyodidePackage,
   resolveFixCandidateSpec,
   type WheelManifest,
 } from '../_shared/fix-candidate.js';
-import { loadVivariumPyodide } from '../_shared/loader.js';
+import { pick } from '../_shared/i18n.js';
+import {
+  DEFAULT_PYODIDE_VERSION,
+  totalEstimatedMB,
+} from '../_shared/loader.js';
 import type { PathACapturedRun } from '../_shared/path_a.js';
 import { enableRunner } from '../_shared/runner.js';
 import {
@@ -71,25 +74,49 @@ interface ReproOutput {
   reproduced: boolean;
 }
 
-interface RuntimeVersions {
-  dateutil: string;
-  python: string;
+interface WorkerProgress {
+  type: 'progress';
+  pct: number;
+  stage: ProgressStage;
 }
 
-interface PyProxy {
-  toJs(opts: { dict_converter: typeof Object.fromEntries }): unknown;
-  destroy?(): void;
+interface WorkerReady {
+  type: 'ready';
+  pyodideVersion: string;
+  dateutilVersion: string;
+  pythonVersion: string;
 }
 
-interface PyodideRuntime {
-  runPythonAsync(code: string): Promise<unknown>;
-  setStdout(options: { batched: (text: string) => void }): void;
-  globals: {
-    get(name: string): unknown;
-    has(name: string): boolean;
-    delete(name: string): void;
-  };
+interface WorkerRunResult {
+  type: 'result';
+  id: number;
+  stdout: string;
+  cases: CaseObservation[] | null;
+  error: string | null;
+  dateutilVersion: string;
+  pythonVersion: string;
 }
+
+interface WorkerError {
+  type: 'error';
+  id?: number;
+  message: string;
+}
+
+type WorkerMessage =
+  | WorkerProgress
+  | WorkerReady
+  | WorkerRunResult
+  | WorkerError;
+
+type ProgressStage =
+  | 'init'
+  | 'fetching-module'
+  | 'loading-runtime'
+  | 'installing-package'
+  | 'ready';
+
+type Variant = 'baseline' | 'fix-candidate';
 
 interface CaptureResult {
   run: PathACapturedRun;
@@ -97,9 +124,26 @@ interface CaptureResult {
 }
 
 const BASELINE_SPEC = 'python-dateutil==2.9.0.post0';
+const WORKER_PACKAGES = ['micropip'];
+const ESTIMATED_MB = totalEstimatedMB(WORKER_PACKAGES.length);
 
-const VERSION_QUERY =
-  'import dateutil, sys; [dateutil.__version__, sys.version.split()[0]]';
+const STRINGS: Record<ProgressStage, string> = {
+  init: 'Starting Pyodide worker…',
+  'fetching-module': 'Fetching Pyodide module…',
+  'loading-runtime': 'Loading runtime + stdlib…',
+  'installing-package': 'Installing python-dateutil…',
+  ready: 'Runtime ready.',
+};
+
+const STRINGS_JA: Partial<Record<ProgressStage, string>> = {
+  init: 'Pyodide worker を起動中…',
+  'fetching-module': 'Pyodide モジュールを取得中…',
+  'loading-runtime': 'runtime と stdlib を読み込み中…',
+  'installing-package': 'python-dateutil をインストール中…',
+  ready: 'runtime の準備完了。',
+};
+
+const S = pick(STRINGS, STRINGS_JA);
 
 const outputBaselineEl = document.getElementById('output');
 const outputFixEl = document.getElementById('output-fix');
@@ -127,11 +171,17 @@ if (!reproCodeEl.firstChild) {
     .catch(() => {});
 }
 
-function isPyProxy(value: unknown): value is PyProxy {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as PyProxy).toJs === 'function'
+function emitProgress(pct: number, stage: ProgressStage): void {
+  const loaded = stage === 'ready' ? ESTIMATED_MB : 0;
+  document.dispatchEvent(
+    new CustomEvent('vh-progress', {
+      detail: {
+        pct,
+        label: S[stage],
+        bytes: `${loaded.toFixed(1)} MB / ${ESTIMATED_MB.toFixed(1)} MB`,
+        stage: stage === 'ready' ? 'packages' : 'runtime',
+      },
+    }),
   );
 }
 
@@ -143,32 +193,6 @@ function summarise(cases: CaseObservation[]): ReproOutput {
     case_count: cases.length,
     reproduced: cases.length > 0 && inverted === cases.length,
   };
-}
-
-function readResults(runtime: PyodideRuntime): ReproOutput | null {
-  const handle = runtime.globals.get('results');
-  if (!isPyProxy(handle)) return null;
-  try {
-    const rows = handle.toJs({ dict_converter: Object.fromEntries });
-    if (!Array.isArray(rows)) return null;
-    return summarise(rows as CaseObservation[]);
-  } finally {
-    handle.destroy?.();
-  }
-}
-
-async function readVersions(
-  runtime: PyodideRuntime,
-): Promise<RuntimeVersions | null> {
-  const handle = await runtime.runPythonAsync(VERSION_QUERY);
-  if (!isPyProxy(handle)) return null;
-  try {
-    const pair = handle.toJs({ dict_converter: Object.fromEntries });
-    if (!Array.isArray(pair) || pair.length !== 2) return null;
-    return { dateutil: String(pair[0]), python: String(pair[1]) };
-  } finally {
-    handle.destroy?.();
-  }
 }
 
 function evaluate(result: ReproOutput | null): {
@@ -195,32 +219,109 @@ function evaluate(result: ReproOutput | null): {
   };
 }
 
-async function captureRun(
-  runtime: PyodideRuntime,
-  source: string,
-): Promise<CaptureResult> {
-  const lines: string[] = [];
-  runtime.setStdout({
-    batched: (text) => {
-      lines.push(text);
-    },
+function spawnWorker(variant: Variant, spec: string): Worker {
+  const workerUrl = new URL('./repro.worker.js', import.meta.url);
+  workerUrl.searchParams.set('variant', variant);
+  workerUrl.searchParams.set('spec', spec);
+  workerUrl.searchParams.set('pyodide', DEFAULT_PYODIDE_VERSION);
+  workerUrl.searchParams.set('packages', WORKER_PACKAGES.join(','));
+  return new Worker(workerUrl, { type: 'module' });
+}
+
+function awaitReady(worker: Worker, variant: Variant): Promise<WorkerReady> {
+  return new Promise<WorkerReady>((resolve, reject) => {
+    const cleanup = (): void => {
+      worker.removeEventListener('message', onMessage);
+      worker.removeEventListener('error', onError);
+    };
+    const onError = (ev: ErrorEvent): void => {
+      cleanup();
+      reject(new Error(ev.message));
+    };
+    const onMessage = (ev: MessageEvent<WorkerMessage>): void => {
+      const msg = ev.data;
+      if (msg.type === 'progress') {
+        if (variant === 'baseline') {
+          setVerdict('pending', S[msg.stage], 'loading');
+          emitProgress(msg.pct, msg.stage);
+        }
+        return;
+      }
+      if (msg.type === 'ready') {
+        cleanup();
+        resolve(msg);
+      } else if (msg.type === 'error') {
+        cleanup();
+        reject(new Error(msg.message));
+      }
+    };
+    worker.addEventListener('message', onMessage);
+    worker.addEventListener('error', onError);
   });
-  // One Pyodide namespace spans every run: an edited script that never
-  // assigns `results` would otherwise be judged on the previous run's list.
-  if (runtime.globals.has('results')) runtime.globals.delete('results');
-  try {
-    await runtime.runPythonAsync(source);
-    const parsed = readResults(runtime);
-    const ev = evaluate(parsed);
+}
+
+let runId = 0;
+
+function runInWorker(worker: Worker, source: string): Promise<WorkerRunResult> {
+  const id = ++runId;
+  return new Promise<WorkerRunResult>((resolve, reject) => {
+    const cleanup = (): void => {
+      worker.removeEventListener('message', onMessage);
+      worker.removeEventListener('error', onError);
+    };
+    const onError = (ev: ErrorEvent): void => {
+      cleanup();
+      reject(new Error(ev.message));
+    };
+    const onMessage = (ev: MessageEvent<WorkerMessage>): void => {
+      const msg = ev.data;
+      if (msg.type !== 'result' && msg.type !== 'error') return;
+      if (msg.id !== id) return;
+      if (msg.type === 'result') {
+        cleanup();
+        resolve(msg);
+      } else if (msg.type === 'error') {
+        cleanup();
+        reject(new Error(msg.message));
+      }
+    };
+    worker.addEventListener('message', onMessage);
+    worker.addEventListener('error', onError);
+    worker.postMessage({ type: 'run', id, source });
+  });
+}
+
+function toCapture(result: WorkerRunResult): CaptureResult {
+  if (result.error !== null) {
     return {
       run: {
-        exitCode: parsed ? 0 : 1,
-        verdict: ev.verdict,
-        message: ev.message,
-        stdout: lines.join('\n'),
+        exitCode: 1,
+        verdict: 'unreproduced',
+        message: `runtime error: ${result.error}`,
+        stdout: result.stdout,
       },
-      parsed,
+      parsed: null,
     };
+  }
+  const parsed = result.cases ? summarise(result.cases) : null;
+  const ev = evaluate(parsed);
+  return {
+    run: {
+      exitCode: parsed ? 0 : 1,
+      verdict: ev.verdict,
+      message: ev.message,
+      stdout: result.stdout,
+    },
+    parsed,
+  };
+}
+
+async function captureIn(
+  worker: Worker,
+  source: string,
+): Promise<CaptureResult> {
+  try {
+    return toCapture(await runInWorker(worker, source));
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     return {
@@ -228,52 +329,38 @@ async function captureRun(
         exitCode: 1,
         verdict: 'unreproduced',
         message: `runtime error: ${message}`,
-        stdout: [...lines, message].join('\n'),
+        stdout: message,
       },
       parsed: null,
     };
   }
 }
 
-const reinstallDateutil = (
-  runtime: PyodideRuntime,
-  installSpec: string,
-): Promise<void> =>
-  reinstallPyodidePackage(runtime, {
-    pipPackageName: 'python-dateutil',
-    pythonRootModule: 'dateutil',
-    installSpec,
-  });
-
 const startedAt = new Date();
 
 let baselineCapture: PathACapturedRun | null = null;
 let baselineParsed: ReproOutput | null = null;
-let baselineVersions: RuntimeVersions | null = null;
+let baselineReady: WorkerReady | null = null;
 let fixCapture: PathACapturedRun | null = null;
 let fixParsed: ReproOutput | null = null;
-let fixVersions: RuntimeVersions | null = null;
+let fixDateutilVersion = '';
 let manifest: WheelManifest | null = null;
 
 try {
-  const { pyodide, version } = await loadVivariumPyodide({
-    packages: ['micropip'],
-    pendingText: 'Loading Pyodide runtime and micropip…',
-  });
-  const runtime = pyodide as PyodideRuntime;
+  setVerdict('pending', S.init, 'loading');
+  emitProgress(5, 'init');
 
-  setVerdict('pending', `Installing ${BASELINE_SPEC} from PyPI…`);
-  await reinstallDateutil(runtime, BASELINE_SPEC);
+  const baselineWorker = spawnWorker('baseline', BASELINE_SPEC);
+  baselineReady = await awaitReady(baselineWorker, 'baseline');
 
-  setVerdict('pending', 'Running reproduction script (baseline)…');
-  const baseline = await captureRun(runtime, REPRO_CODE);
+  setVerdict('pending', 'Running reproduction script (baseline)…', 'running');
+  const baseline = await captureIn(baselineWorker, REPRO_CODE);
   baselineCapture = baseline.run;
   baselineParsed = baseline.parsed;
-  baselineVersions = await readVersions(runtime);
   outputBaselineEl.textContent = baselineCapture.stdout;
 
   const buildEnvelope = (): VivariumResultV1 | null => {
-    if (!baselineParsed || !baselineCapture) return null;
+    if (!baselineParsed || !baselineCapture || !baselineReady) return null;
     const finishedAt = new Date();
     return {
       contract: 'v1',
@@ -284,12 +371,12 @@ try {
       },
       runtime: {
         name: 'pyodide',
-        version,
+        version: baselineReady.pyodideVersion,
         extras: {
-          python: baselineVersions?.python ?? '',
-          'python-dateutil': baselineVersions?.dateutil ?? '',
+          python: baselineReady.pythonVersion,
+          'python-dateutil': baselineReady.dateutilVersion,
           ...(fixParsed
-            ? { 'python-dateutil_fix_candidate': fixVersions?.dateutil ?? '' }
+            ? { 'python-dateutil_fix_candidate': fixDateutilVersion }
             : {}),
         },
       },
@@ -301,7 +388,7 @@ try {
         baseline: {
           spec: BASELINE_SPEC,
           verdict: baselineCapture.verdict,
-          dateutil_version: baselineVersions?.dateutil ?? '',
+          dateutil_version: baselineReady.dateutilVersion,
           cases: baselineParsed.cases,
           inverted_count: baselineParsed.inverted_count,
           case_count: baselineParsed.case_count,
@@ -312,7 +399,7 @@ try {
             ? {
                 spec: resolveFixCandidateSpec(manifest, 'python-dateutil'),
                 verdict: fixCapture.verdict,
-                dateutil_version: fixVersions?.dateutil ?? '',
+                dateutil_version: fixDateutilVersion,
                 cases: fixParsed.cases,
                 inverted_count: fixParsed.inverted_count,
                 case_count: fixParsed.case_count,
@@ -335,8 +422,9 @@ try {
   setVerdict(baselineCapture.verdict, baselineCapture.message);
 
   metaEl.textContent =
-    `Baseline python-dateutil ${baselineVersions?.dateutil ?? '?'} on Python ` +
-    `${baselineVersions?.python ?? '?'} via Pyodide v${version}.`;
+    `Baseline python-dateutil ${baselineReady.dateutilVersion || '?'} on Python ` +
+    `${baselineReady.pythonVersion || '?'} via Pyodide v${baselineReady.pyodideVersion} ` +
+    `(Web Worker).`;
 
   setFixPane('Fetching wheel manifest…', 'pending');
   const manifestResult = await fetchWheelManifest();
@@ -351,29 +439,24 @@ try {
           : ''),
       'pending',
     );
+    const fixWorker = spawnWorker('fix-candidate', manifestResult.wheelUrl);
     try {
-      await reinstallDateutil(runtime, manifestResult.wheelUrl);
-      const fix = await captureRun(runtime, REPRO_CODE);
+      const fixReady = await awaitReady(fixWorker, 'fix-candidate');
+      const fix = await captureIn(fixWorker, REPRO_CODE);
       fixCapture = fix.run;
       fixParsed = fix.parsed;
-      fixVersions = await readVersions(runtime);
+      fixDateutilVersion = fixReady.dateutilVersion;
       setFixPane(fixCapture.stdout, 'ok');
     } catch (err) {
       const errAny = err as { stack?: string; message?: string } | null;
       const message =
         (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
       setFixPane(`Fix-candidate install/run failed: ${message}`, 'error');
+    } finally {
+      fixWorker.terminate();
     }
   } else {
     setFixPane(manifestResult.reason, 'error');
-  }
-
-  try {
-    await reinstallDateutil(runtime, BASELINE_SPEC);
-  } catch {
-    console.warn(
-      'dateutil-1478: failed to restore baseline for the runner; runner.runFix will run against the fix-candidate.',
-    );
   }
 
   const finalEnvelope = buildEnvelope();
@@ -382,7 +465,7 @@ try {
   enableRunner({
     slug: 'dateutil-1478',
     baselineSource: REPRO_CODE,
-    runFix: async (source) => (await captureRun(runtime, source)).run,
+    runFix: async (source) => (await captureIn(baselineWorker, source)).run,
   });
 } catch (err: unknown) {
   console.error(err);

--- a/src/layer1_wasm/dateutil-1478/repro.worker.ts
+++ b/src/layer1_wasm/dateutil-1478/repro.worker.ts
@@ -1,0 +1,187 @@
+const workerScope = self as unknown as {
+  postMessage: (msg: unknown) => void;
+  addEventListener: (
+    type: 'message',
+    listener: (ev: MessageEvent<MainMessage>) => void,
+  ) => void;
+  location: { href: string };
+};
+
+interface MainMessage {
+  type: 'run';
+  id: number;
+  source: string;
+}
+
+export interface CaseObservation {
+  input: string;
+  expected_offset_seconds: number;
+  actual_offset_seconds: number;
+  inverted: boolean;
+}
+
+interface PyProxy {
+  toJs(opts: { dict_converter: typeof Object.fromEntries }): unknown;
+  destroy?(): void;
+}
+
+interface PyodideRuntime {
+  runPythonAsync(code: string): Promise<unknown>;
+  setStdout(options: { batched: (text: string) => void }): void;
+  globals: {
+    get(name: string): unknown;
+    has(name: string): boolean;
+    delete(name: string): void;
+  };
+}
+
+interface PyodideModule {
+  loadPyodide(opts: {
+    indexURL: string;
+    packages?: string[];
+  }): Promise<PyodideRuntime>;
+}
+
+const VERSION_QUERY =
+  'import dateutil, sys; [dateutil.__version__, sys.version.split()[0]]';
+
+const params = new URL(workerScope.location.href).searchParams;
+const PYODIDE_VERSION = params.get('pyodide') ?? '';
+const INSTALL_SPEC = params.get('spec') ?? '';
+const PACKAGES = (params.get('packages') ?? '').split(',').filter(Boolean);
+
+function progress(pct: number, stage: string): void {
+  workerScope.postMessage({ type: 'progress', pct, stage });
+}
+
+function fail(message: string, id?: number): void {
+  workerScope.postMessage({ type: 'error', message, ...(id ? { id } : {}) });
+}
+
+function isPyProxy(value: unknown): value is PyProxy {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as PyProxy).toJs === 'function'
+  );
+}
+
+function readResults(runtime: PyodideRuntime): CaseObservation[] | null {
+  const handle = runtime.globals.get('results');
+  if (!isPyProxy(handle)) return null;
+  try {
+    const rows = handle.toJs({ dict_converter: Object.fromEntries });
+    return Array.isArray(rows) ? (rows as CaseObservation[]) : null;
+  } finally {
+    handle.destroy?.();
+  }
+}
+
+async function readVersions(
+  runtime: PyodideRuntime,
+): Promise<{ dateutil: string; python: string } | null> {
+  const handle = await runtime.runPythonAsync(VERSION_QUERY);
+  if (!isPyProxy(handle)) return null;
+  try {
+    const pair = handle.toJs({ dict_converter: Object.fromEntries });
+    if (!Array.isArray(pair) || pair.length !== 2) return null;
+    return { dateutil: String(pair[0]), python: String(pair[1]) };
+  } finally {
+    handle.destroy?.();
+  }
+}
+
+async function bootstrap(): Promise<PyodideRuntime> {
+  progress(5, 'init');
+  progress(18, 'fetching-module');
+  const mod = (await import(
+    /* @vite-ignore */ `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/pyodide.mjs`
+  )) as PyodideModule;
+
+  progress(35, 'loading-runtime');
+  const runtime = await mod.loadPyodide({
+    indexURL: `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/`,
+    packages: PACKAGES,
+  });
+
+  progress(70, 'installing-package');
+  await runtime.runPythonAsync(`
+import micropip
+await micropip.install(${JSON.stringify(INSTALL_SPEC)})
+`);
+
+  progress(92, 'ready');
+  return runtime;
+}
+
+let runtimeRef: PyodideRuntime | null = null;
+
+async function runOnce(runtime: PyodideRuntime, id: number, source: string) {
+  const lines: string[] = [];
+  runtime.setStdout({
+    batched: (text) => {
+      lines.push(text);
+    },
+  });
+  // One Pyodide namespace spans every run: an edited script that never
+  // assigns `results` would otherwise be judged on the previous run's list.
+  if (runtime.globals.has('results')) runtime.globals.delete('results');
+
+  try {
+    await runtime.runPythonAsync(source);
+    const cases = readResults(runtime);
+    const versions = await readVersions(runtime);
+    workerScope.postMessage({
+      type: 'result',
+      id,
+      stdout: lines.join('\n'),
+      cases,
+      error: null,
+      dateutilVersion: versions?.dateutil ?? '',
+      pythonVersion: versions?.python ?? '',
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    workerScope.postMessage({
+      type: 'result',
+      id,
+      stdout: [...lines, message].join('\n'),
+      cases: null,
+      error: message,
+      dateutilVersion: '',
+      pythonVersion: '',
+    });
+  }
+}
+
+workerScope.addEventListener('message', (ev: MessageEvent<MainMessage>) => {
+  const msg = ev.data;
+  if (msg?.type !== 'run') return;
+  if (runtimeRef === null) {
+    fail('worker received a run request before the runtime was ready.', msg.id);
+    return;
+  }
+  void runOnce(runtimeRef, msg.id, msg.source);
+});
+
+if (!PYODIDE_VERSION || !INSTALL_SPEC) {
+  fail(
+    'worker URL is missing the `pyodide` or `spec` query parameter; the main thread owns both.',
+  );
+} else {
+  bootstrap()
+    .then(async (runtime) => {
+      runtimeRef = runtime;
+      const versions = await readVersions(runtime);
+      workerScope.postMessage({
+        type: 'ready',
+        pyodideVersion: PYODIDE_VERSION,
+        dateutilVersion: versions?.dateutil ?? '',
+        pythonVersion: versions?.python ?? '',
+      });
+    })
+    .catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      fail(`bootstrap failed: ${message}`);
+    });
+}


### PR DESCRIPTION
## Why

Chrome offered to kill the tab on [the dateutil-1478 page](https://aletheia-works.github.io/vivarium/repro/dateutil/1478/).

Booting Pyodide and resolving three micropip install cycles is pure CPU work. Run on the main thread it landed as **one uninterrupted 15-second task**, past the point where Chrome declares the renderer unresponsive. It is not download time — with a warm HTTP cache the 9.4 MB `pyodide.asm.wasm` arrives in 411 ms.

`PerformanceObserver` `longtask` totals on the deployed pages, fronted tab, quiet machine:

| page | Pyodide runs on | micropip cycles | total blocked | worst task |
|---|---|---|---|---|
| lark-1585 | **Web Worker ×2** | 3 | 302 ms | 166 ms |
| numpy-28287 | main thread | 0 (`loadPackage`) | 1.8 s | 1.5 s |
| **dateutil-1478 (before)** | **main thread** | **3** | **19.9 s** | **15.0 s** |

For the record, this is not fallout from #401 — an A/B of the two `repro.ts` versions served back to back on the same machine gave 11.5 s blocked before #401 and 4.4 s after it. #401 made the page block *less*. The 15-second task predates both.

## After

Same measurement on the local page with this change:

| | total blocked | worst task |
|---|---|---|
| before | 4.4 s | 1.3 s |
| **after** | **353 ms** | **185 ms** |

That is `lark-1585` territory, and it is what the fix borrows — without borrowing lark's two regressions.

## What lark gives up, and this does not

lark drops Edit / Run / Reset entirely and leaves the progress bar pinned at 0 % until the verdict lands. Both are kept here.

**The runner.** The baseline worker outlives its own run so `enableRunner`'s `runFix` can round-trip through it. Because that worker never receives the fix-candidate wheel, Run always exercises the buggy version — which also deletes the third micropip cycle that previously existed only to reinstall the baseline afterwards, along with its `console.warn` swallow when that reinstall failed. Three cycles become two. The fix-candidate worker is spawned after the baseline verdict settles and terminated once its pane is filled.

**The progress bar.** The worker posts a stage and a percentage; `repro.ts` localises the label and re-dispatches it as the `vh-progress` event the existing bar already listens for. The byte readout `_shared/loader.ts` showed was always an estimate rather than a measurement, so mirroring the estimate keeps the display identical. Observed live: `70 · Installing python-dateutil… · 0.0 MB / 12.6 MB` → `92 · Runtime ready. · 12.6 MB / 12.6 MB` → `done`, bar removed, `#output` revealed.

## Nothing shared moved

The worker imports nothing from `../_shared/`. `_shared/verdict.ts` starts with `import '../_assets/chrome.js'`, which touches `document` at module-evaluation time — any worker import graph reaching it dies before its own code runs. Everything DOM-bound stays in `repro.ts`, and so do the three strings the build tooling greps `repro.ts` for:

- `REPRO_CODE` — `scripts/highlight-repros.ts` and `generate-repro-pages.ts` read only `repro.ts`, and skip **silently** (exit 0) when it is absent
- `enableRunner(` — `generate-repro-pages.ts` emits the Edit/Run/Reset buttons on this substring
- `fetchWheelManifest` — `validate-page-slots.ts` **hard-fails the build** without it for any recipe carrying `fix-candidate.json`

The wheel manifest is therefore still fetched and resolved on the main thread; only the resolved URL crosses into the worker, as its `spec` query parameter. `tsconfig.json` picks up `repro.worker.ts` from `include: ["**/*.ts"]` and emits the `.js` beside it; `bundle-layer1-pages.sh` copies the recipe directory wholesale. No build or workflow change.

`__VIVARIUM_RESULT__` is unchanged — same `result` keys, same `cases[]` shape, same `baseline` / `fix_candidate` sub-objects, same `runtime.extras` including `python-dateutil_fix_candidate` — verified in-browser against the pre-change envelope.

## Review round 1

All four findings were correct and are fixed in place.

1. **`reinstallPyodidePackage` orphaned.** Verified independently — `dateutil-1478/repro.ts` was its only caller anywhere in the repo; every other Layer 1 recipe installs its own way. It and the `PyodideRuntime` interface that existed only for its signature are deleted from `_shared/fix-candidate.ts`, and `_shared/README.md`'s row for that module is rewritten. The `src/layer2_docker/_shared/` mirror follows automatically via `sync-layer2-assets` and is gitignored.
2. **Drawer copy contradicted the implementation.** `drawer.body.p5` said the wheel is installed "into the same Pyodide tab" / 「同じ Pyodide タブへ」. Both locales now say a second worker. Thank you for catching the JA side too — the key-parity check would not have flagged it.
3. **`ESTIMATED_MB` comment.** Removed, but the underlying problem was that `12.6` was a *restatement* of `loader.ts`'s `SIZE_RUNTIME_MB + n × SIZE_PER_PACKAGE_MB` — exactly the silent staleness §4.13 warns about. Rather than delete the comment and keep the copied number, `loader.ts` now exports its existing `totalEstimatedMB` and `repro.ts` calls it. The package list moved onto the worker URL alongside `pyodide` and `spec`, so the count feeding that call is the same list the worker loads, and the worker no longer hardcodes `['micropip']`.
4. **Dangling `error` listeners.** Real leak, and correctly scoped to this recipe — lark never re-invokes those helpers. Both `awaitReady` and `runInWorker` now remove the `message` and `error` listeners together through one `cleanup()` on every settle path. `runInWorker` also narrows on message type before reading `id`, since `progress` and `ready` carry none. Re-verified with three consecutive Run clicks against the long-lived baseline worker.

Re-checked after the fixes: envelope keys, `extras` including `python-dateutil_fix_candidate`, both panes' stdout, and the Run round-trip are all unchanged from the measurements above.

## Review round 2

Both findings were mine, both in doc prose this PR rewrote.

1. **`_shared/README.md:30` claimed lark uses these helpers.** It does not — `lark-1585/repro.ts` imports only from `../_shared/verdict.js` and fetches `./wheels/manifest.json` itself at line 365. The row now names `dateutil-1478` as the only consumer and says lark resolves its own.
2. **`.claude/rules/recipe-authoring.md:236` had a dangling "see below".** Rather than delete the pointer I gave it something to point at: the bullet is now accurate about who uses the helpers, and the Layer 1 **Pitfalls** list gains "Pyodide belongs in a Web Worker" with the before/after numbers and the `_assets/chrome.js` import trap that forces a worker to load Pyodide itself. Neither passage cross-references the other, so neither can dangle again.

Docs only — no code changed in this round.

## Review round 3

One finding, and it was a factual error in the pitfall I added last round: `path_a.ts` does **not** reach `_assets/chrome.js`. Verified rather than assumed —

```text
verdict  -> import '../_assets/chrome.js';
runner   -> import { pick } from './i18n.js';  import type { PathACapturedRun } from './path_a.js';  import { setVerdict } from './verdict.js';
loader   -> import { setVerdict } from "./verdict.js";  import { pick } from "./i18n.js";
path_a   -> import { pageLang } from "./i18n.js";
```

and `i18n.ts` guards its only DOM access with `typeof document === 'undefined'`. Importing `path_a.js` into a worker evaluates fine; it is `enablePathA()` that is DOM-bound, which is a different claim. The bullet now names only `verdict.ts`, `loader.ts` and `runner.ts`.

Docs only again — no code changed in this round.

## Verification

`repro:build` (incl. `validate-page-slots`), `repro:pages`, `repro:i18n`, `repro:typecheck` and `markdown:check` are clean, and `repro.worker.js` / `.js.map` are emitted.

In a real browser:

1. `longtask` total 353 ms / worst 185 ms, against 4.4 s / 1.3 s before
2. Both panes show the script's own stdout — baseline with `<-- sign flipped` on all four rows, fix candidate with none
3. Envelope keys and `extras` identical to before
4. **Run** re-runs through the baseline worker and still reports `reproduced` with the flip marks, confirming the fix wheel never reaches that worker
5. **Edit → Run** with a script that never assigns `results` gives `unreproduced — the script left no results list behind.` (the regression case from #401's review), and **Reset** restores the baseline
6. Progress bar advances and clears as described above

Playwright was left to CI.

## Found while verifying — separate bug, not in this PR

The **Japanese** page's fix-candidate pane has been broken on the deployed site, independently of this change. `_shared/fix-candidate.ts` builds the wheel URL from `window.location.href` rather than the document base URL, and `generate-repro-i18n.ts` injects a `<base href="…/repro/dateutil/1478/">` into the JA page while the page itself is served from `/vivarium/ja/repro/…`. So:

```text
/vivarium/repro/dateutil/1478/wheels/manifest.json          200   656 B   (relative fetch honours <base>)
/vivarium/ja/repro/dateutil/1478/wheels/…-none-any.whl      404  3532 B   (window.location.href ignores it)
```

micropip then installs the 404 HTML page and the pane ends at `data-fix-status="error"` with a `PythonError`. `document.baseURI` is correct in both locales and would be a one-word fix, but it is shared code on every wheel-based recipe, so it belongs in its own change.

## Follow-ups

- Roll the same worker migration out to `cpython-137205` / `numpy-28287` / `pandas-56679` — though numpy blocks only 1.8 s, so the urgency differs per recipe
- The service worker whose only job is caching the jsDelivr Pyodide runtime has never registered: `register('../_assets/sw.js', { scope: '/vivarium/repro/' })` asks for a scope broader than the script's own directory, which needs a `Service-Worker-Allowed` header GitHub Pages cannot send. `swRegistrations: 0`, `cacheKeys: []` on every recipe page. Serving `sw.js` from `/vivarium/repro/sw.js` makes the scope legal without a header
- The JA wheel-URL bug above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
