### PR TITLE
fix(wasm): resolve the fix-candidate wheel against the document base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ __pycache__/
 venv/
 env/
 
-target/
+target
 Cargo.lock
 
 node_modules/

--- a/src/layer1_wasm/_shared/fix-candidate.ts
+++ b/src/layer1_wasm/_shared/fix-candidate.ts
@@ -60,7 +60,7 @@ export async function fetchWheelManifest(opts?: {
   }
   const wheelUrl = new URL(
     `./wheels/${manifest.filename}`,
-    window.location.href,
+    document.baseURI,
   ).toString();
   return { ok: true, manifest, wheelUrl };
 }

--- a/src/layer1_wasm/lark-1585/repro.ts
+++ b/src/layer1_wasm/lark-1585/repro.ts
@@ -372,7 +372,7 @@ try {
     manifest = (await manifestRes.json()) as WheelManifest;
     const wheelUrl = new URL(
       `./wheels/${manifest.filename}`,
-      window.location.href,
+      document.baseURI,
     ).toString();
     setFixPane(
       `Installing ${manifest.filename} (${manifest.version})…\n` +


### PR DESCRIPTION
## Why

The fix-candidate pane has been broken on the **Japanese** page for as long as wheel-based recipes have existed.

`generate-repro-i18n.ts` serves the JA page from `/vivarium/ja/repro/<project>/<issue>/` while injecting a `<base href="/vivarium/repro/<project>/<issue>/">`. That is deliberate — only `index.ja.html` is bundled under `/ja/`, so every asset has to resolve back into the English recipe directory, which is where `wheels/` lives.

`fetchWheelManifest` fetched `./wheels/manifest.json` **relatively**, so the manifest resolved against `<base>` and came back fine. It then built the wheel URL from `window.location.href`, which ignores `<base>`. Measured on the deployed JA page:

```text
/vivarium/repro/dateutil/1478/wheels/manifest.json          200   656 B   ← honours <base>
/vivarium/ja/repro/dateutil/1478/wheels/…-py2.py3-none-any.whl  404  3532 B   ← ignores it
```

micropip then tried to install GitHub Pages' 3.5 KB 404 page as a wheel, and the pane ended at `data-fix-status="error"` with a `PythonError` traceback.

## The fix

`document.baseURI` in both places that build a wheel URL — `_shared/fix-candidate.ts` and `lark-1585/repro.ts`, which resolves its own manifest inline. That is the same base the relative manifest `fetch` was already using, so the two stop disagreeing.

`_shared/path_a.ts` deliberately keeps `window.location`: it reads the `?fix=` / `?fix_url=` query parameters, which belong to the address the visitor is actually on, not to the base.

## Verification

Served a tree mirroring the deployed layout — `/vivarium/repro/dateutil/1478/` plus `/vivarium/ja/repro/dateutil/1478/` — and loaded the JA page:

```json
{
  "url": "/vivarium/ja/repro/dateutil/1478/",
  "base": ".../vivarium/repro/dateutil/1478/",
  "fixStatus": "ok",
  "fixTail": "0 of 4 UTC-prefixed offsets came back negated. | python-dateutil 0.1.dev1615+g1f30198 / Python 3.14.2",
  "wheelRequests": ["/vivarium/repro/dateutil/1478/wheels/manifest.json", "…/wheels/python_dateutil-0.1.dev1615+g1f30198-py2.py3-none-any.whl"]
}
```

The wheel now resolves into the recipe directory and the pane reaches `ok` with the fix candidate's own output. `repro:typecheck`, `repro:build`, `repro:i18n` and `docs:check` are clean.

## Review round 1

One finding across three locations, and it was right: the comments I added described the change rather than the code.

I had argued myself into them as §4.13's second kind — someone simplifying `document.baseURI` back to `location.href` re-breaks the JA page and no test catches it. But the phrasing gives it away: "baseURI, **not** location.href" describes the diff, which is what `.claude/CLAUDE.md` §4 rules out outright (*"never in a comment next to the code"*). All three are gone; the diff is now one line per file.

The durable facts stay in the commit message and above. The home §4.13 actually names for this is **a test that demonstrates the behaviour** — and that is the real gap here: `repro.spec.ts` builds every case from `page_url` and never loads `page_url_ja`, which is why a broken JA fix-pane survived this long. Adding JA coverage to that suite is the follow-up worth doing, alongside the #403 performance repair.

## Also here: one `.gitignore` character

`target/` loses its trailing slash. mbx points a recipe's `target/` at its own cache with a **symlink**, and a directory-only rule does not match one:

```text
src/layer1_wasm/regex-779/fix/target: symbolic link to
  …/AppData/Local/mbx/targets/v1/6eb150c5…
```

so that path showed as untracked on every `sl status` while the real `regex-779/target` directory beside it was correctly ignored. Build output either way — it is not something to commit.

## Not fixed here — a performance regression from #403

While verifying this I confirmed a separate problem the maintainer also hit: **the fix-candidate pane is now very slow**, and so is the baseline on a cold load.

#403 moved Pyodide into a Web Worker and gave the fix candidate its **own** worker, which means a second complete Pyodide boot — download, WASM compile, micropip — where the pre-#403 code reused the already-running interpreter and only did `micropip.uninstall` + `install`. Measured on the deployed page just now:

```text
baseline: installing-package  t=67.3s
baseline: ready               t=71.9s
baseline: verdict             t=72.9s
fix worker spawned            t=73.2s
fix pane still pending        t=105.9s   (33 s in)
```

Chrome also reports the page's `<head>` preloads as dead weight, because a dedicated worker cannot use the document's preload cache:

```text
The resource …/pyodide.asm.wasm was preloaded using link preload but not used
within a few seconds from the window's load event.
```

So the page now pays for the runtime up to three times: an unused preload, the baseline worker, and the fix worker. I traded 15 s of main-thread blocking for roughly double the wall clock and never measured time-to-fix-pane — that is on me. The repair is to run both variants in **one** worker (the pre-#403 flow, just off the main thread) and drop the preloads for worker-based recipes. Separate PR, since this one is a correctness fix that should not wait on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
