### PR TITLE
perf(wasm): boot pyodide once for both dateutil-1478 variants

### DIFF
--- a/.claude/rules/recipe-authoring.md
+++ b/.claude/rules/recipe-authoring.md
@@ -293,6 +293,21 @@ PRs 180 / 189 / 192.
   `runner.ts` — all three reach `_assets/chrome.js`, which touches
   `document` at module-evaluation time — so it loads Pyodide itself and
   posts results back. See `dateutil-1478/repro.worker.ts`.
+- **One worker per page, not one per variant.** A second worker is a
+  second Pyodide — another download, another WASM compile, another
+  micropip. `dateutil-1478` shipped that for one release and the
+  fix-candidate pane took 45.5 s to appear; swapping the wheel inside
+  the one worker with `micropip.uninstall` + `install` (purging
+  `sys.modules` between, or the old module stays imported) brought it
+  to 2.8 s. Measure time-to-fix-pane, not just main-thread blocking —
+  the first version of that change measured only the latter and shipped
+  a regression.
+- **A worker cannot use the page's `rel="preload"`.** The preload cache
+  belongs to the document, so those tags download the runtime a second
+  time and Chrome warns that nothing used them.
+  `generate-repro-pages.ts` emits them only for recipes with no
+  `repro.worker.ts`; `preconnect` stays for everyone, since warming the
+  connection is per-origin.
 
 ---
 

--- a/docs/scripts/generate-repro-pages.ts
+++ b/docs/scripts/generate-repro-pages.ts
@@ -18,7 +18,8 @@ interface RecipeIndexEntry {
 }
 
 interface RuntimeShell {
-  head: string;
+  preconnect: string;
+  preload: string;
   kicker: string;
   verdictPending: string;
 }
@@ -34,9 +35,11 @@ function loaderConstant(file: string, name: string): string {
   return match[1] as string;
 }
 
+const CDN_PRECONNECT =
+  '    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />';
+
 function modulePreload(href: string): string {
   return [
-    '    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />',
     '    <link',
     '      rel="modulepreload"',
     `      href="${href}"`,
@@ -66,7 +69,8 @@ function runtimeShells(): Record<string, RuntimeShell> {
   const pyodideBase = `https://cdn.jsdelivr.net/pyodide/v${pyodide}/full`;
   return {
     pyodide: {
-      head: [
+      preconnect: CDN_PRECONNECT,
+      preload: [
         `    <link rel="preload" href="${pyodideBase}/pyodide.asm.wasm" as="fetch" type="application/wasm" crossorigin />`,
         `    <link rel="preload" href="${pyodideBase}/python_stdlib.zip" as="fetch" crossorigin />`,
         `    <link rel="preload" href="${pyodideBase}/pyodide-lock.json" as="fetch" type="application/json" crossorigin />`,
@@ -76,21 +80,24 @@ function runtimeShells(): Record<string, RuntimeShell> {
       verdictPending: 'Loading Pyodide runtime…',
     },
     'php-wasm': {
-      head: modulePreload(
+      preconnect: CDN_PRECONNECT,
+      preload: modulePreload(
         `https://cdn.jsdelivr.net/npm/php-wasm@${php}/PhpWeb.mjs`,
       ),
       kicker: 'L1 · php-wasm',
       verdictPending: 'Loading php-wasm runtime…',
     },
     'ruby.wasm': {
-      head: modulePreload(
+      preconnect: CDN_PRECONNECT,
+      preload: modulePreload(
         `https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@${ruby}/dist/browser/+esm`,
       ),
       kicker: 'L1 · Ruby.wasm',
       verdictPending: 'Loading Ruby.wasm runtime…',
     },
     'rust-wasi': {
-      head: modulePreload(
+      preconnect: CDN_PRECONNECT,
+      preload: modulePreload(
         `https://cdn.jsdelivr.net/npm/@bjorn3/browser_wasi_shim@${wasi}/dist/index.js`,
       ),
       kicker: 'L1 · Rust wasm32-wasip1',
@@ -194,6 +201,11 @@ const RUNNER_BUTTONS: ReadonlyArray<readonly [string, string, string, string]> =
     ],
   ];
 
+function runtimeHead(recipeDir: string, shell: RuntimeShell): string {
+  if (existsSync(join(recipeDir, 'repro.worker.ts'))) return shell.preconnect;
+  return `${shell.preconnect}\n${shell.preload}`;
+}
+
 function runnerActions(recipeDir: string): string {
   const reproTs = join(recipeDir, 'repro.ts');
   if (!existsSync(reproTs)) return '';
@@ -279,7 +291,7 @@ function renderLayer1(): void {
       TITLE: entry.title,
       PROJECT: entry.title.split('#')[0] as string,
       ISSUE: String(entry.issue),
-      RUNTIME_HEAD: shell.head,
+      RUNTIME_HEAD: runtimeHead(dir, shell),
       RUNTIME_LABEL: expandVersions(
         slots['runtime-label'] ?? '',
         RUNTIME_VERSIONS,

--- a/src/layer1_wasm/dateutil-1478/repro.ts
+++ b/src/layer1_wasm/dateutil-1478/repro.ts
@@ -97,6 +97,13 @@ interface WorkerRunResult {
   pythonVersion: string;
 }
 
+interface WorkerInstalled {
+  type: 'installed';
+  id: number;
+  dateutilVersion: string;
+  pythonVersion: string;
+}
+
 interface WorkerError {
   type: 'error';
   id?: number;
@@ -107,6 +114,7 @@ type WorkerMessage =
   | WorkerProgress
   | WorkerReady
   | WorkerRunResult
+  | WorkerInstalled
   | WorkerError;
 
 type ProgressStage =
@@ -115,8 +123,6 @@ type ProgressStage =
   | 'loading-runtime'
   | 'installing-package'
   | 'ready';
-
-type Variant = 'baseline' | 'fix-candidate';
 
 interface CaptureResult {
   run: PathACapturedRun;
@@ -219,16 +225,15 @@ function evaluate(result: ReproOutput | null): {
   };
 }
 
-function spawnWorker(variant: Variant, spec: string): Worker {
+function spawnWorker(spec: string): Worker {
   const workerUrl = new URL('./repro.worker.js', import.meta.url);
-  workerUrl.searchParams.set('variant', variant);
   workerUrl.searchParams.set('spec', spec);
   workerUrl.searchParams.set('pyodide', DEFAULT_PYODIDE_VERSION);
   workerUrl.searchParams.set('packages', WORKER_PACKAGES.join(','));
   return new Worker(workerUrl, { type: 'module' });
 }
 
-function awaitReady(worker: Worker, variant: Variant): Promise<WorkerReady> {
+function awaitReady(worker: Worker): Promise<WorkerReady> {
   return new Promise<WorkerReady>((resolve, reject) => {
     const cleanup = (): void => {
       worker.removeEventListener('message', onMessage);
@@ -241,10 +246,8 @@ function awaitReady(worker: Worker, variant: Variant): Promise<WorkerReady> {
     const onMessage = (ev: MessageEvent<WorkerMessage>): void => {
       const msg = ev.data;
       if (msg.type === 'progress') {
-        if (variant === 'baseline') {
-          setVerdict('pending', S[msg.stage], 'loading');
-          emitProgress(msg.pct, msg.stage);
-        }
+        setVerdict('pending', S[msg.stage], 'loading');
+        emitProgress(msg.pct, msg.stage);
         return;
       }
       if (msg.type === 'ready') {
@@ -288,6 +291,34 @@ function runInWorker(worker: Worker, source: string): Promise<WorkerRunResult> {
     worker.addEventListener('message', onMessage);
     worker.addEventListener('error', onError);
     worker.postMessage({ type: 'run', id, source });
+  });
+}
+
+function installInWorker(
+  worker: Worker,
+  spec: string,
+): Promise<WorkerInstalled> {
+  const id = ++runId;
+  return new Promise<WorkerInstalled>((resolve, reject) => {
+    const cleanup = (): void => {
+      worker.removeEventListener('message', onMessage);
+      worker.removeEventListener('error', onError);
+    };
+    const onError = (ev: ErrorEvent): void => {
+      cleanup();
+      reject(new Error(ev.message));
+    };
+    const onMessage = (ev: MessageEvent<WorkerMessage>): void => {
+      const msg = ev.data;
+      if (msg.type !== 'installed' && msg.type !== 'error') return;
+      if (msg.id !== id) return;
+      cleanup();
+      if (msg.type === 'installed') resolve(msg);
+      else reject(new Error(msg.message));
+    };
+    worker.addEventListener('message', onMessage);
+    worker.addEventListener('error', onError);
+    worker.postMessage({ type: 'install', id, spec });
   });
 }
 
@@ -350,11 +381,11 @@ try {
   setVerdict('pending', S.init, 'loading');
   emitProgress(5, 'init');
 
-  const baselineWorker = spawnWorker('baseline', BASELINE_SPEC);
-  baselineReady = await awaitReady(baselineWorker, 'baseline');
+  const worker = spawnWorker(BASELINE_SPEC);
+  baselineReady = await awaitReady(worker);
 
   setVerdict('pending', 'Running reproduction script (baseline)…', 'running');
-  const baseline = await captureIn(baselineWorker, REPRO_CODE);
+  const baseline = await captureIn(worker, REPRO_CODE);
   baselineCapture = baseline.run;
   baselineParsed = baseline.parsed;
   outputBaselineEl.textContent = baselineCapture.stdout;
@@ -439,21 +470,26 @@ try {
           : ''),
       'pending',
     );
-    const fixWorker = spawnWorker('fix-candidate', manifestResult.wheelUrl);
     try {
-      const fixReady = await awaitReady(fixWorker, 'fix-candidate');
-      const fix = await captureIn(fixWorker, REPRO_CODE);
+      const installed = await installInWorker(worker, manifestResult.wheelUrl);
+      const fix = await captureIn(worker, REPRO_CODE);
       fixCapture = fix.run;
       fixParsed = fix.parsed;
-      fixDateutilVersion = fixReady.dateutilVersion;
+      fixDateutilVersion = installed.dateutilVersion;
       setFixPane(fixCapture.stdout, 'ok');
     } catch (err) {
       const errAny = err as { stack?: string; message?: string } | null;
       const message =
         (errAny && (errAny.stack ?? errAny.message)) ?? String(err);
       setFixPane(`Fix-candidate install/run failed: ${message}`, 'error');
-    } finally {
-      fixWorker.terminate();
+    }
+
+    try {
+      await installInWorker(worker, BASELINE_SPEC);
+    } catch {
+      console.warn(
+        'dateutil-1478: failed to restore the baseline install; Run will exercise the fix candidate.',
+      );
     }
   } else {
     setFixPane(manifestResult.reason, 'error');
@@ -465,7 +501,7 @@ try {
   enableRunner({
     slug: 'dateutil-1478',
     baselineSource: REPRO_CODE,
-    runFix: async (source) => (await captureIn(baselineWorker, source)).run,
+    runFix: async (source) => (await captureIn(worker, source)).run,
   });
 } catch (err: unknown) {
   console.error(err);

--- a/src/layer1_wasm/dateutil-1478/repro.worker.ts
+++ b/src/layer1_wasm/dateutil-1478/repro.worker.ts
@@ -7,11 +7,9 @@ const workerScope = self as unknown as {
   location: { href: string };
 };
 
-interface MainMessage {
-  type: 'run';
-  id: number;
-  source: string;
-}
+type MainMessage =
+  | { type: 'run'; id: number; source: string }
+  | { type: 'install'; id: number; spec: string };
 
 export interface CaseObservation {
   input: string;
@@ -41,6 +39,9 @@ interface PyodideModule {
     packages?: string[];
   }): Promise<PyodideRuntime>;
 }
+
+const PIP_PACKAGE = 'python-dateutil';
+const ROOT_MODULE = 'dateutil';
 
 const VERSION_QUERY =
   'import dateutil, sys; [dateutil.__version__, sys.version.split()[0]]';
@@ -91,6 +92,22 @@ async function readVersions(
   }
 }
 
+async function installSpec(
+  runtime: PyodideRuntime,
+  spec: string,
+): Promise<void> {
+  await runtime.runPythonAsync(`
+import micropip, sys
+try:
+    await micropip.uninstall(${JSON.stringify(PIP_PACKAGE)})
+except Exception:
+    pass
+for _name in [n for n in list(sys.modules) if n == ${JSON.stringify(ROOT_MODULE)} or n.startswith(${JSON.stringify(`${ROOT_MODULE}.`)})]:
+    del sys.modules[_name]
+await micropip.install(${JSON.stringify(spec)})
+`);
+}
+
 async function bootstrap(): Promise<PyodideRuntime> {
   progress(5, 'init');
   progress(18, 'fetching-module');
@@ -105,10 +122,7 @@ async function bootstrap(): Promise<PyodideRuntime> {
   });
 
   progress(70, 'installing-package');
-  await runtime.runPythonAsync(`
-import micropip
-await micropip.install(${JSON.stringify(INSTALL_SPEC)})
-`);
+  await installSpec(runtime, INSTALL_SPEC);
 
   progress(92, 'ready');
   return runtime;
@@ -154,14 +168,37 @@ async function runOnce(runtime: PyodideRuntime, id: number, source: string) {
   }
 }
 
+async function installOnce(
+  runtime: PyodideRuntime,
+  id: number,
+  spec: string,
+): Promise<void> {
+  try {
+    await installSpec(runtime, spec);
+    const versions = await readVersions(runtime);
+    workerScope.postMessage({
+      type: 'installed',
+      id,
+      dateutilVersion: versions?.dateutil ?? '',
+      pythonVersion: versions?.python ?? '',
+    });
+  } catch (err: unknown) {
+    fail(err instanceof Error ? err.message : String(err), id);
+  }
+}
+
 workerScope.addEventListener('message', (ev: MessageEvent<MainMessage>) => {
   const msg = ev.data;
-  if (msg?.type !== 'run') return;
+  if (msg?.type !== 'run' && msg?.type !== 'install') return;
   if (runtimeRef === null) {
-    fail('worker received a run request before the runtime was ready.', msg.id);
+    fail('worker received a request before the runtime was ready.', msg.id);
     return;
   }
-  void runOnce(runtimeRef, msg.id, msg.source);
+  if (msg.type === 'run') {
+    void runOnce(runtimeRef, msg.id, msg.source);
+  } else {
+    void installOnce(runtimeRef, msg.id, msg.spec);
+  }
 });
 
 if (!PYODIDE_VERSION || !INSTALL_SPEC) {


### PR DESCRIPTION
## Why

#403 moved the runtime off the main thread and gave the fix candidate **its own worker**. A second worker is a second Pyodide — another download, another WASM compile, another micropip. The code it replaced reused the running interpreter and only swapped the wheel.

I measured main-thread blocking (19.9 s → 0.35 s) and never measured **time to the fix-candidate pane**. That is the number the maintainer noticed, and it roughly doubled.

## After

Local, same machine, back to back:

```text
before   verdict  72.7 s    fix pane ok  118.2 s    (+45.5 s)
after    verdict 184.3 s    fix pane ok  187.1 s    (+2.8 s)
```

The absolute figures differ because the machine was busier during the second run — that leg boots the baseline identically in both builds. **The delta is the leg this PR changes: 45.5 s → 2.8 s.**

## One worker, wheel swapped inside it

`repro.worker.ts` gains an `install` message that runs what `reinstallPyodidePackage` used to before #403 deleted it:

```python
import micropip, sys
try:
    await micropip.uninstall("python-dateutil")
except Exception:
    pass
for _name in [n for n in list(sys.modules) if n == "dateutil" or n.startswith("dateutil.")]:
    del sys.modules[_name]
await micropip.install(<spec>)
```

The `sys.modules` purge is load-bearing — without it the old `dateutil` stays imported and the fix candidate reports the baseline's result.

`repro.ts` now spawns **one** worker: run the baseline in it → install the wheel into it → run again → restore the baseline so the Run button keeps exercising the buggy version. That is the pre-#403 flow, just off the main thread. A failed restore warns and continues rather than taking the page down.

The helper stays in the worker rather than going back into `_shared/fix-candidate.ts`: the worker is its only caller, and `fetchWheelManifest` remains on the main thread because it needs `document.baseURI` (#405).

## The `<head>` preloads went dead in the same release

A dedicated worker has its own fetch context and cannot use the document's preload cache. So since #403 the page has downloaded the runtime once for nobody, and Chrome said so:

```text
The resource .../pyodide.asm.wasm was preloaded using link preload
but not used within a few seconds from the window's load event.
```

`generate-repro-pages.ts` now splits each runtime shell into `preconnect` and `preload` and emits the preload half only for recipes with no `repro.worker.ts` — the same file-existence gate `runnerActions()` and `fixChip()` already use. `preconnect` stays for everyone: warming the connection is per-origin and does reach the worker.

Generated pages after the change:

```text
cpython-137205     main    preload=3  preconnect=1  modulepreload=1
dateutil-1478      worker  preload=0  preconnect=1  modulepreload=0
lark-1585          worker  preload=0  preconnect=1  modulepreload=0
numpy-28287        main    preload=3  preconnect=1  modulepreload=1
pandas-56679       main    preload=3  preconnect=1  modulepreload=1
regex-779          main    preload=0  preconnect=1  modulepreload=1
ruby-21709         main    preload=0  preconnect=1  modulepreload=1
```

`lark-1585` is worker-based too, so it is covered without naming it. Nothing asserts on these tags — `validate-page-slots.ts` checks the template's `<head>`, not rendered pages, and no test reads them.

## Unchanged

Main-thread blocking, the metric #403 did move, stays where it was. `__VIVARIUM_RESULT__` keeps the same `result` keys and the same `extras` including `python-dateutil_fix_candidate`, verified in-browser.

## Verification

`repro:typecheck`, `repro:build`, `repro:pages`, `repro:i18n`, `docs:check`, `markdown:check` and `docs` `test:unit` (110 pass / 0 fail) are clean.

In a browser, after the change:

1. Fix pane reaches `ok` **2.8 s** after the verdict, showing `0 of 4 UTC-prefixed offsets came back negated` against `0.1.dev1615+g1f30198`
2. Baseline pane shows all four rows flipped against `2.9.0.post0`
3. Envelope keys and `extras` identical to before
4. **Run reports `2.9.0.post0` with 4 flipped rows** — this is what proves the baseline restore landed, i.e. the visitor still edits against the buggy version
5. Edit → a script that never assigns `results` → `unreproduced — the script left no results list behind.`; Reset restores the baseline
6. `preloads: 0`, `preconnects: 3` on the rendered page

## Rules updated

`.claude/rules/recipe-authoring.md` gains two Layer 1 pitfalls: one worker per page rather than per variant, and that a worker cannot use the page's `rel="preload"`. The first one carries the lesson explicitly — measure time-to-fix-pane, not only main-thread blocking.

## Follow-ups

- `repro.spec.ts` builds every case from `page_url` and never opens `page_url_ja`, which is why #405's broken JA fix-pane survived so long
- The remaining main-thread recipes (`cpython-137205` / `pandas-56679` / `numpy-28287`); numpy blocks only 1.8 s, so the urgency differs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
