### PR TITLE
test(wasm): run the japanese pages in the regression suite

### DIFF
--- a/.claude/rules/recipe-authoring.md
+++ b/.claude/rules/recipe-authoring.md
@@ -99,6 +99,19 @@ Rules:
 - `recipes.json` gains `page_url_ja` **only** for recipes that ship
   `i18n.ja.json`. Its absence is the signal that no Japanese page
   exists, so never derive that URL by inserting `/ja/`.
+- **The Japanese page is executed by the regression suite**, not just
+  key-checked. `tests/repro-ja.spec.ts` opens every `page_url_ja` and
+  asserts the verdict settles, the fix pane settles, and that nothing
+  under `/repro/` 404s. It is served by `docs/scripts/serve-repro.ts`,
+  which reproduces the deployed shape: the `/ja/` tree holds the page
+  and nothing else, so every asset has to resolve through the page's
+  `<base>` back into the English directory. A broken `<base>` shows up
+  as a 404, which is how a wheel that resolved into `/ja/` went
+  unnoticed until it was looked for.
+- The suite therefore needs `mise run repro:i18n` to have run —
+  `index.ja.html` is gitignored and is not built by `repro:build`.
+  `ci:repro` and `repro-regression.yml` both run it, after
+  `repro:build` so the Shiki inlining is already in place.
 
 `recipe.json` is the single source of truth for the gallery facets
 (`language` / `symptom` / `severity` / `tags`) and the regression

--- a/.github/workflows/repro-regression.yml
+++ b/.github/workflows/repro-regression.yml
@@ -39,7 +39,7 @@ jobs:
   regression:
     name: regression (${{ matrix.browser }})
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -109,6 +109,7 @@ jobs:
         run: |
           mise run repro:typecheck
           mise run repro:build
+          mise run repro:i18n
 
       - name: Build, run, and snapshot Layer 2 Docker reproductions (no push)
         working-directory: ${{ github.workspace }}

--- a/docs/scripts/serve-repro.ts
+++ b/docs/scripts/serve-repro.ts
@@ -1,0 +1,67 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http';
+
+import { setupReproDevMiddleware } from './repro-dev-middleware';
+import { SITE_BASE } from './site-paths';
+
+type Next = () => void;
+type Handler = (req: IncomingMessage, res: ServerResponse, next: Next) => void;
+
+const JA_PREFIX = `${SITE_BASE}ja/repro/`;
+
+const port = Number(process.argv[2] ?? 8769);
+const handlers: Handler[] = [];
+
+setupReproDevMiddleware({
+  middlewares: {
+    use(handler: Handler): void {
+      handlers.push(handler);
+    },
+  },
+});
+
+// The deployed /ja/ tree holds one file per recipe — the page itself. Every
+// other asset is reached through its <base>, which points back at the English
+// directory. Serving more here would hide a page whose <base> is wrong.
+function servedByPages(pathname: string): boolean {
+  if (!pathname.startsWith(JA_PREFIX)) return true;
+  return pathname.endsWith('/') || pathname.endsWith('/index.html');
+}
+
+function notFound(res: ServerResponse, url: string): void {
+  res.statusCode = 404;
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.end(`404: ${url}\n`);
+}
+
+createServer((req, res) => {
+  const url = req.url ?? '';
+  const { pathname } = new URL(url, 'http://localhost');
+  if (!servedByPages(pathname)) {
+    notFound(res, url);
+    return;
+  }
+
+  let index = 0;
+  const next: Next = () => {
+    const handler = handlers[index];
+    index += 1;
+    if (handler) {
+      handler(req, res, next);
+      return;
+    }
+    if (url === '/') {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+      res.end('vivarium repro server\n');
+      return;
+    }
+    notFound(res, url);
+  };
+  next();
+}).listen(port, () => {
+  process.stdout.write(`vivarium repro server on http://localhost:${port}\n`);
+});

--- a/mise.toml
+++ b/mise.toml
@@ -296,6 +296,7 @@ set -euo pipefail
 bun install --frozen-lockfile
 bun run typecheck
 mise run repro:build
+mise run repro:i18n
 bunx playwright install --with-deps chromium
 bun run test
 '''

--- a/src/layer1_wasm/playwright.config.ts
+++ b/src/layer1_wasm/playwright.config.ts
@@ -2,8 +2,10 @@ import { defineConfig, devices } from "@playwright/test";
 
 export const LAYER1_PORT = 8767;
 export const LAYER2_PORT = 8768;
+export const DEPLOYED_SHAPE_PORT = 8769;
 export const LAYER1_BASE = `http://localhost:${LAYER1_PORT}`;
 export const LAYER2_BASE = `http://localhost:${LAYER2_PORT}`;
+export const DEPLOYED_SHAPE_BASE = `http://localhost:${DEPLOYED_SHAPE_PORT}`;
 
 export default defineConfig({
   testDir: "./tests",
@@ -38,6 +40,15 @@ export default defineConfig({
       command: `uv run --no-project python -m http.server ${LAYER2_PORT}`,
       cwd: "../layer2_docker",
       url: `${LAYER2_BASE}/`,
+      reuseExistingServer: !process.env["CI"],
+      timeout: 30_000,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+    {
+      command: `bun run scripts/serve-repro.ts ${DEPLOYED_SHAPE_PORT}`,
+      cwd: "../../docs",
+      url: `${DEPLOYED_SHAPE_BASE}/`,
       reuseExistingServer: !process.env["CI"],
       timeout: 30_000,
       stdout: "pipe",

--- a/src/layer1_wasm/tests/repro-ja.spec.ts
+++ b/src/layer1_wasm/tests/repro-ja.spec.ts
@@ -1,0 +1,131 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { expect, test } from '@playwright/test';
+
+const JA_BASE = 'http://localhost:8769';
+
+const SUPPORTED_VERDICTS = ['reproduced', 'unreproduced'] as const;
+const SUPPORTED_RUNTIMES = [
+  'pyodide',
+  'ruby.wasm',
+  'php-wasm',
+  'rust-wasi',
+] as const;
+
+type ExpectedVerdict = (typeof SUPPORTED_VERDICTS)[number];
+type ExpectedRuntimeName = (typeof SUPPORTED_RUNTIMES)[number];
+
+interface RecipeEntry {
+  slug: string;
+  layer: 1 | 2 | 3;
+  expected_verdict?: string;
+  expected_runtime?: string;
+  page_url_ja?: string;
+}
+
+interface RecipesIndex {
+  recipes: RecipeEntry[];
+}
+
+interface JaCase {
+  slug: string;
+  url: string;
+  expectedVerdict: ExpectedVerdict;
+  expectedRuntimeName: ExpectedRuntimeName;
+}
+
+function isExpectedVerdict(value: unknown): value is ExpectedVerdict {
+  return SUPPORTED_VERDICTS.some((v) => v === value);
+}
+
+function isExpectedRuntimeName(value: unknown): value is ExpectedRuntimeName {
+  return SUPPORTED_RUNTIMES.some((v) => v === value);
+}
+
+function loadJaCases(): JaCase[] {
+  const indexPath = resolve(
+    import.meta.dirname,
+    '../../..',
+    'docs/site/public/api/recipes.json',
+  );
+  const parsed = JSON.parse(readFileSync(indexPath, 'utf-8')) as RecipesIndex;
+  return parsed.recipes
+    .filter((r) => r.layer === 1 && typeof r.page_url_ja === 'string')
+    .map((r) => {
+      if (!isExpectedVerdict(r.expected_verdict)) {
+        throw new Error(
+          `${r.slug}: expected_verdict must be one of ${SUPPORTED_VERDICTS.join(', ')}`,
+        );
+      }
+      if (!isExpectedRuntimeName(r.expected_runtime)) {
+        throw new Error(
+          `${r.slug}: expected_runtime must be one of ${SUPPORTED_RUNTIMES.join(', ')}`,
+        );
+      }
+      return {
+        slug: r.slug,
+        url: `${JA_BASE}${new URL(r.page_url_ja as string).pathname}`,
+        expectedVerdict: r.expected_verdict,
+        expectedRuntimeName: r.expected_runtime,
+      };
+    })
+    .sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+function timeoutForRuntime(name: ExpectedRuntimeName): number {
+  return name === 'pyodide' ? 120_000 : 75_000;
+}
+
+const cases = loadJaCases();
+
+for (const c of cases) {
+  test(`${c.slug} japanese page produces ${c.expectedVerdict}`, async ({
+    page,
+  }) => {
+    test.setTimeout(timeoutForRuntime(c.expectedRuntimeName) + 15_000);
+
+    const notFound: string[] = [];
+    page.on('response', (response) => {
+      if (response.status() < 400) return;
+      const { pathname } = new URL(response.url());
+      if (!pathname.includes('/repro/')) return;
+      notFound.push(`${response.status()} ${pathname}`);
+    });
+
+    await page.goto(c.url);
+
+    const lang = await page.locator('html').getAttribute('lang');
+    expect.soft(lang, 'html[lang]').toBe('ja');
+
+    await page.waitForFunction(
+      () => {
+        const v = (
+          globalThis as unknown as { __VIVARIUM_VERDICT__?: string }
+        ).__VIVARIUM_VERDICT__;
+        return v === 'reproduced' || v === 'unreproduced';
+      },
+      undefined,
+      { timeout: timeoutForRuntime(c.expectedRuntimeName) },
+    );
+
+    const verdict = await page.evaluate(
+      () =>
+        (globalThis as unknown as { __VIVARIUM_VERDICT__?: string })
+          .__VIVARIUM_VERDICT__,
+    );
+    expect.soft(verdict, 'japanese page verdict').toBe(c.expectedVerdict);
+
+    const fixPane = page.locator('#output-fix');
+    await expect.soft(fixPane, '#output-fix exists').toHaveCount(1);
+    await expect
+      .soft(fixPane, '#output-fix settled (not left pending)')
+      .not.toHaveAttribute('data-fix-status', 'pending', { timeout: 60_000 });
+    const fixText = ((await fixPane.textContent()) ?? '').trim();
+    expect.soft(fixText.length, '#output-fix is non-empty').toBeGreaterThan(0);
+
+    expect
+      .soft(notFound, 'recipe assets that failed to load')
+      .toStrictEqual([]);
+  });
+}


### PR DESCRIPTION
## Why

The broken Japanese fix-candidate pane that #405 repaired had been shipping for as long as wheel-based recipes existed. Nothing was watching.

Every guard around the JA pages is **structural**: `generate-repro-i18n.ts` and `reproI18n.test.ts` check that the `data-i18n` keys and `i18n.ja.json` agree, `validate-page-slots.ts` checks the slots are present. None of them opens the page. And `repro.spec.ts` builds every URL from `slug`, so it only ever visits the English one. A page whose translations are all present and whose assets all 404 passes every check we had.

## The test

`src/layer1_wasm/tests/repro-ja.spec.ts` opens every recipe carrying `page_url_ja` — 7 of 7 Layer 1 recipes today — and asserts four things:

1. `html[lang]` is `ja`, so it really is the Japanese artefact
2. the verdict settles to `expected_verdict` — proves `repro.js` and `../_shared/*` resolved through the `<base>`
3. `#output-fix` leaves `pending` and is non-empty
4. **nothing under `/repro/` answered 4xx**

The fourth is the point. It catches the cause instead of a downstream symptom, and it is the **only one of the four that fails on #405** — the broken wheel URL still leaves the pane at `error` with non-empty text, so assertions 1–3 all pass against the bug.

The URL comes from `page_url_ja`'s pathname, never by inserting `/ja/` into `page_url`, per the authoring rule: the field's absence is the signal that no Japanese page exists.

## Serving it faithfully was the whole problem

The JA page carries `<base href="/vivarium/repro/<project>/<issue>/">`, so on the existing `python -m http.server` rooted at `src/layer1_wasm` every relative asset 404s and the page never runs at all.

`docs/scripts/serve-repro.ts` wraps the routing `repro-dev-middleware.ts` already implements — `/vivarium/(ja/)?repro/…` → `src/layer{1,2,3}_*/<slug>/…`, including the `index.html` → `index.ja.html` swap — and adds the one rule that middleware deliberately lacks:

```ts
function servedByPages(pathname: string): boolean {
  if (!pathname.startsWith(JA_PREFIX)) return true;
  return pathname.endsWith('/') || pathname.endsWith('/index.html');
}
```

The deployed `/ja/` tree holds the page and nothing else, because `bundle-layer1-pages.sh` copies only `index.ja.html` into it. Everything else has to resolve through the `<base>`.

**That rule is load-bearing, and I only found out because I tried to break it.** Without it the middleware resolves `/vivarium/ja/repro/dateutil/1478/wheels/…` back to the same recipe directory and answers 200 — so the first version of this test was **green with the #405 bug reintroduced**. A test that cannot fail is worse than no test.

## Proving it fails on the bug it exists for

`document.baseURI` reverted to `window.location.href` in both places that build a wheel URL, then the suite re-run:

```text
x  dateutil-1478 japanese page produces reproduced (24.3s)
   Error: recipe assets that failed to load
   + "404 /vivarium/ja/repro/dateutil/1478/wheels/python_dateutil-0.1.dev1615+g1f30198-py2.py3-none-any.whl"

x  lark-1585 japanese page produces reproduced (45.1s)
   Error: recipe assets that failed to load
   + "404 /vivarium/ja/repro/lark/1585/wheels/lark-1.3.1-py3-none-any.whl"
```

`dateutil-1478` fails through the shared helper, `lark-1585` through its inline copy — both paths #405 had to fix. Restored, all seven pass.

## `verdict-capture.spec.ts` stays English-only

It is not a rendering test. It reads one global and writes a slug-keyed record to `VERDICT_CAPTURE_OUTPUT`; it is the round-trip pipeline's verdict oracle under `PLAYWRIGHT_FIX_URL`. Both locales run the same `repro.js` against the same runtime, so a Japanese pass would overwrite the same record with the same value — noise at best, a hazard in the round-trip flow.

## CI

`index.ja.html` is gitignored and `mise run repro:i18n` was in neither `ci:repro` nor `repro-regression.yml`, so **the artefact did not exist where the suite runs**. Both now run it after `repro:build`, which the Shiki inlining has to precede.

`timeout-minutes` goes 15 → 20, from measurement rather than caution:

| job | measured | |
|---|---|---|
| regression (chromium) | 2.8 min | |
| regression (webkit) | 3.7 min | |
| regression (firefox) | **6.2 min** | the binding one |

Seven more pyodide pages took 3.5 min locally on chromium, and `retries: 1` doubles a flake. That fits inside 15, but not with margin worth betting a red build on.

## Verification

`repro:typecheck`, `repro:build`, `repro:i18n`, `docs:check`, `markdown:check`, `actionlint` and `tombi lint` are clean. `tests/repro-ja.spec.ts` is 7/7 green on chromium in 3.5 min; the negative case above is the evidence that it can fail.

`.claude/rules/recipe-authoring.md` gains the two facts the next author needs: the JA page is executed now, not just key-checked, and the suite depends on `repro:i18n` having run.

## Follow-ups

- The remaining main-thread recipes (`cpython-137205` / `pandas-56679` / `numpy-28287`) — measure before deciding; numpy blocks only 1.8 s
- Rolling #401's plain-Python + real-stdout shape out to the recipes that still print `json.dumps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
