### PR TITLE
perf(wasm): run cpython-137205 and pandas-56679 in web workers

### DIFF
--- a/.claude/rules/recipe-authoring.md
+++ b/.claude/rules/recipe-authoring.md
@@ -306,6 +306,11 @@ PRs 180 / 189 / 192.
   `runner.ts` — all three reach `_assets/chrome.js`, which touches
   `document` at module-evaluation time — so it loads Pyodide itself and
   posts results back. See `dateutil-1478/repro.worker.ts`.
+  `cpython-137205` and `pandas-56679` followed: 18.3–20.1 s and 25.8 s
+  of blocking became 259 ms and none. The cost is the runtime, not the
+  packages — cpython loads none and still blocked for 18 s. Measure
+  before assuming a recipe is light: `numpy-28287` blocks 2.5 s and is
+  deliberately left on the main thread.
 - **One worker per page, not one per variant.** A second worker is a
   second Pyodide — another download, another WASM compile, another
   micropip. `dateutil-1478` shipped that for one release and the

--- a/src/layer1_wasm/cpython-137205/README.md
+++ b/src/layer1_wasm/cpython-137205/README.md
@@ -58,9 +58,23 @@ the Python API surface.
 | File         | Role                                                              |
 | ------------ | ----------------------------------------------------------------- |
 | `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
-| `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `repro.ts`   | **Main-thread driver.** Spawns the Pyodide Web Worker, relays its progress into the page's progress bar, and owns the verdict, the Contract v1 envelope and the output pane. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `repro.worker.ts` | **Worker source.** Loads Pyodide with the stdlib `sqlite3` it ships, runs the reproduction script, and posts the result back. |
 | `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
 | `repro.py`   | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. The bug is in the CPython binding layer, so no third-party deps are needed (PEP 723 `dependencies = []`). See "Native verification" below. |
+
+## Why the runtime lives in a Web Worker
+
+Booting Pyodide is pure CPU work. Run on the main thread it lands as a
+single task tens of seconds long, and Chrome offers to kill the tab
+before it finishes — measured at 18.3–20.1 s of total main-thread blocking with a
+17.9–18.9 s worst task on the deployed page. Moving it into a worker takes the
+same page to 259 ms.
+
+The worker imports nothing from `../_shared/`: `_shared/verdict.ts` pulls
+in `_assets/chrome.js`, which touches `document` at module-evaluation
+time and would throw inside a worker. Everything DOM-bound — the verdict
+pill, the envelope, the pane, the progress bar — stays in `repro.ts`.
 
 ## Verdict contract — `vivarium-contract: v1`
 

--- a/src/layer1_wasm/cpython-137205/repro.ts
+++ b/src/layer1_wasm/cpython-137205/repro.ts
@@ -1,4 +1,8 @@
-import { loadVivariumPyodide } from '../_shared/loader.js';
+import { pick } from '../_shared/i18n.js';
+import {
+  DEFAULT_PYODIDE_VERSION,
+  totalEstimatedMB,
+} from '../_shared/loader.js';
 import type { PathACapturedRun } from '../_shared/path_a.js';
 import { enableRunner } from '../_shared/runner.js';
 import {
@@ -38,12 +42,56 @@ interface ReproOutput {
   fk_disagreement: boolean;
 }
 
-interface PyodideRuntime {
-  runPythonAsync(code: string): Promise<{
-    toJs(opts: { dict_converter: typeof Object.fromEntries }): ReproOutput;
-    destroy?(): void;
-  }>;
+type ProgressStage = 'init' | 'fetching-module' | 'loading-runtime' | 'ready';
+
+interface WorkerProgress {
+  type: 'progress';
+  pct: number;
+  stage: ProgressStage;
 }
+
+interface WorkerReady {
+  type: 'ready';
+  pyodideVersion: string;
+}
+
+interface WorkerRunResult {
+  type: 'result';
+  id: number;
+  result: ReproOutput | null;
+  error: string | null;
+}
+
+interface WorkerError {
+  type: 'error';
+  id?: number;
+  message: string;
+}
+
+type WorkerMessage =
+  | WorkerProgress
+  | WorkerReady
+  | WorkerRunResult
+  | WorkerError;
+
+const WORKER_PACKAGES: string[] = [];
+const ESTIMATED_MB = totalEstimatedMB(WORKER_PACKAGES.length);
+
+const STRINGS: Record<ProgressStage, string> = {
+  init: 'Starting Pyodide worker…',
+  'fetching-module': 'Fetching Pyodide module…',
+  'loading-runtime': 'Loading runtime + stdlib…',
+  ready: 'Runtime ready.',
+};
+
+const STRINGS_JA: Partial<Record<ProgressStage, string>> = {
+  init: 'Pyodide worker を起動中…',
+  'fetching-module': 'Pyodide モジュールを取得中…',
+  'loading-runtime': 'runtime と stdlib を読み込み中…',
+  ready: 'runtime の準備完了。',
+};
+
+const S = pick(STRINGS, STRINGS_JA);
 
 const outputEl = document.getElementById('output');
 const metaEl = document.getElementById('meta');
@@ -65,6 +113,20 @@ if (!reproCodeEl.firstChild) {
     .catch(() => {});
 }
 
+function emitProgress(pct: number, stage: ProgressStage): void {
+  const loaded = stage === 'ready' ? ESTIMATED_MB : 0;
+  document.dispatchEvent(
+    new CustomEvent('vh-progress', {
+      detail: {
+        pct,
+        label: S[stage],
+        bytes: `${loaded.toFixed(1)} MB / ${ESTIMATED_MB.toFixed(1)} MB`,
+        stage: stage === 'ready' ? 'packages' : 'runtime',
+      },
+    }),
+  );
+}
+
 function evaluate(result: ReproOutput): {
   verdict: 'reproduced' | 'unreproduced';
   message: string;
@@ -83,57 +145,132 @@ function evaluate(result: ReproOutput): {
   };
 }
 
-async function captureRun(
-  runtime: PyodideRuntime,
-  source: string,
-): Promise<PathACapturedRun> {
-  try {
-    const proxy = await runtime.runPythonAsync(source);
-    const result = proxy.toJs({ dict_converter: Object.fromEntries });
-    proxy.destroy?.();
-    const ev = evaluate(result);
-    return {
-      exitCode: 0,
-      verdict: ev.verdict,
-      message: ev.message,
-      stdout: JSON.stringify(result, null, 2),
+function spawnWorker(): Worker {
+  const workerUrl = new URL('./repro.worker.js', import.meta.url);
+  workerUrl.searchParams.set('pyodide', DEFAULT_PYODIDE_VERSION);
+  workerUrl.searchParams.set('packages', WORKER_PACKAGES.join(','));
+  return new Worker(workerUrl, { type: 'module' });
+}
+
+function awaitReady(worker: Worker): Promise<WorkerReady> {
+  return new Promise<WorkerReady>((resolve, reject) => {
+    const cleanup = (): void => {
+      worker.removeEventListener('message', onMessage);
+      worker.removeEventListener('error', onError);
     };
+    const onError = (ev: ErrorEvent): void => {
+      cleanup();
+      reject(new Error(ev.message));
+    };
+    const onMessage = (ev: MessageEvent<WorkerMessage>): void => {
+      const msg = ev.data;
+      if (msg.type === 'progress') {
+        setVerdict('pending', S[msg.stage], 'loading');
+        emitProgress(msg.pct, msg.stage);
+        return;
+      }
+      if (msg.type === 'ready') {
+        cleanup();
+        resolve(msg);
+      } else if (msg.type === 'error') {
+        cleanup();
+        reject(new Error(msg.message));
+      }
+    };
+    worker.addEventListener('message', onMessage);
+    worker.addEventListener('error', onError);
+  });
+}
+
+let runId = 0;
+
+function runInWorker(worker: Worker, source: string): Promise<WorkerRunResult> {
+  const id = ++runId;
+  return new Promise<WorkerRunResult>((resolve, reject) => {
+    const cleanup = (): void => {
+      worker.removeEventListener('message', onMessage);
+      worker.removeEventListener('error', onError);
+    };
+    const onError = (ev: ErrorEvent): void => {
+      cleanup();
+      reject(new Error(ev.message));
+    };
+    const onMessage = (ev: MessageEvent<WorkerMessage>): void => {
+      const msg = ev.data;
+      if (msg.type !== 'result' && msg.type !== 'error') return;
+      if (msg.id !== id) return;
+      cleanup();
+      if (msg.type === 'result') resolve(msg);
+      else reject(new Error(msg.message));
+    };
+    worker.addEventListener('message', onMessage);
+    worker.addEventListener('error', onError);
+    worker.postMessage({ type: 'run', id, source });
+  });
+}
+
+interface CaptureResult {
+  run: PathACapturedRun;
+  parsed: ReproOutput | null;
+}
+
+async function captureIn(
+  worker: Worker,
+  source: string,
+): Promise<CaptureResult> {
+  let message: string;
+  try {
+    const result = await runInWorker(worker, source);
+    if (result.error === null && result.result !== null) {
+      const ev = evaluate(result.result);
+      return {
+        run: {
+          exitCode: 0,
+          verdict: ev.verdict,
+          message: ev.message,
+          stdout: JSON.stringify(result.result, null, 2),
+        },
+        parsed: result.result,
+      };
+    }
+    message = result.error ?? 'the worker returned no result.';
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    return {
+    message = err instanceof Error ? err.message : String(err);
+  }
+  return {
+    run: {
       exitCode: 1,
       verdict: 'unreproduced',
       message: `runtime error: ${message}`,
       stdout: message,
-    };
-  }
+    },
+    parsed: null,
+  };
 }
 
 const startedAt = new Date();
 
 try {
-  const { pyodide, version } = await loadVivariumPyodide({
-    pendingText: 'Loading Pyodide runtime…',
-  });
+  setVerdict('pending', S.init, 'loading');
+  emitProgress(5, 'init');
 
-  setVerdict('pending', 'Running reproduction script…');
-  const runtime = pyodide as PyodideRuntime;
-  const baseline = await captureRun(runtime, REPRO_CODE);
+  const worker = spawnWorker();
+  const ready = await awaitReady(worker);
 
-  let baselineResult: ReproOutput | null = null;
-  try {
-    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
-  } catch {
-    outputEl.textContent = baseline.stdout;
-    setVerdict(baseline.verdict, baseline.message);
-    throw new Error(baseline.message);
+  setVerdict('pending', 'Running reproduction script…', 'running');
+  const baseline = await captureIn(worker, REPRO_CODE);
+  outputEl.textContent = baseline.run.stdout;
+  setVerdict(baseline.run.verdict, baseline.run.message);
+
+  const baselineResult = baseline.parsed;
+  if (!baselineResult) {
+    throw new Error(baseline.run.message);
   }
 
   metaEl.textContent =
     `Python ${baselineResult.python_version} with stdlib sqlite3 ` +
-    `(SQLite ${baselineResult.sqlite_version}) via Pyodide v${version}.`;
-  outputEl.textContent = baseline.stdout;
-  setVerdict(baseline.verdict, baseline.message);
+    `(SQLite ${baselineResult.sqlite_version}) via Pyodide v${ready.pyodideVersion} ` +
+    `(Web Worker).`;
 
   const finishedAt = new Date();
   const envelope: VivariumResultV1 = {
@@ -145,7 +282,7 @@ try {
     },
     runtime: {
       name: 'pyodide',
-      version,
+      version: ready.pyodideVersion,
       extras: {
         python: baselineResult.python_version,
         sqlite: baselineResult.sqlite_version,
@@ -167,7 +304,7 @@ try {
   enableRunner({
     slug: 'cpython-137205',
     baselineSource: REPRO_CODE,
-    runFix: (source) => captureRun(runtime, source),
+    runFix: async (source) => (await captureIn(worker, source)).run,
   });
 } catch (err: unknown) {
   console.error(err);

--- a/src/layer1_wasm/cpython-137205/repro.worker.ts
+++ b/src/layer1_wasm/cpython-137205/repro.worker.ts
@@ -1,0 +1,143 @@
+const workerScope = self as unknown as {
+  postMessage: (msg: unknown) => void;
+  addEventListener: (
+    type: 'message',
+    listener: (ev: MessageEvent<MainMessage>) => void,
+  ) => void;
+  location: { href: string };
+};
+
+interface MainMessage {
+  type: 'run';
+  id: number;
+  source: string;
+}
+
+interface PyProxy {
+  toJs(opts: { dict_converter: typeof Object.fromEntries }): unknown;
+  destroy?(): void;
+}
+
+interface PyodideRuntime {
+  runPythonAsync(code: string): Promise<unknown>;
+}
+
+interface PyodideModule {
+  loadPyodide(opts: {
+    indexURL: string;
+    packages?: string[];
+  }): Promise<PyodideRuntime>;
+}
+
+const params = new URL(workerScope.location.href).searchParams;
+const PYODIDE_VERSION = params.get('pyodide') ?? '';
+const PACKAGES = (params.get('packages') ?? '').split(',').filter(Boolean);
+
+function progress(pct: number, stage: string): void {
+  workerScope.postMessage({ type: 'progress', pct, stage });
+}
+
+function fail(message: string, id?: number): void {
+  workerScope.postMessage({ type: 'error', message, ...(id ? { id } : {}) });
+}
+
+function isPyProxy(value: unknown): value is PyProxy {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as PyProxy).toJs === 'function'
+  );
+}
+
+async function bootstrap(): Promise<PyodideRuntime> {
+  progress(5, 'init');
+  progress(18, 'fetching-module');
+  const mod = (await import(
+    /* @vite-ignore */ `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/pyodide.mjs`
+  )) as PyodideModule;
+
+  progress(35, 'loading-runtime');
+  const runtime = await mod.loadPyodide({
+    indexURL: `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/`,
+    packages: PACKAGES,
+  });
+
+  progress(92, 'ready');
+  return runtime;
+}
+
+let runtimeRef: PyodideRuntime | null = null;
+
+async function runOnce(
+  runtime: PyodideRuntime,
+  id: number,
+  source: string,
+): Promise<void> {
+  let handle: unknown;
+  try {
+    handle = await runtime.runPythonAsync(source);
+  } catch (err: unknown) {
+    workerScope.postMessage({
+      type: 'result',
+      id,
+      result: null,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  if (!isPyProxy(handle)) {
+    workerScope.postMessage({
+      type: 'result',
+      id,
+      result: null,
+      error: 'the script did not end in a mapping the page could read.',
+    });
+    return;
+  }
+
+  try {
+    const result = handle.toJs({ dict_converter: Object.fromEntries });
+    workerScope.postMessage({ type: 'result', id, result, error: null });
+  } catch (err: unknown) {
+    workerScope.postMessage({
+      type: 'result',
+      id,
+      result: null,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  } finally {
+    handle.destroy?.();
+  }
+}
+
+workerScope.addEventListener('message', (ev: MessageEvent<MainMessage>) => {
+  const msg = ev.data;
+  if (msg?.type !== 'run') return;
+  if (runtimeRef === null) {
+    fail('worker received a run request before the runtime was ready.', msg.id);
+    return;
+  }
+  void runOnce(runtimeRef, msg.id, msg.source);
+});
+
+if (!PYODIDE_VERSION) {
+  fail(
+    'worker URL is missing the `pyodide` query parameter; the main thread owns it.',
+  );
+} else {
+  bootstrap()
+    .then((runtime) => {
+      runtimeRef = runtime;
+      workerScope.postMessage({
+        type: 'ready',
+        pyodideVersion: PYODIDE_VERSION,
+      });
+    })
+    .catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      fail(`bootstrap failed: ${message}`);
+    });
+}
+
+export {};

--- a/src/layer1_wasm/pandas-56679/README.md
+++ b/src/layer1_wasm/pandas-56679/README.md
@@ -28,12 +28,26 @@ constructors should produce a consistent dtype for an empty input.
 | File         | Role                                                              |
 | ------------ | ----------------------------------------------------------------- |
 | `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
-| `repro.ts`   | TypeScript source. Imports `loadVivariumPyodide` and the verdict helpers from `../_shared/`. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `repro.ts`   | **Main-thread driver.** Spawns the Pyodide Web Worker, relays its progress into the page's progress bar, and owns the verdict, the Contract v1 envelope and the output pane. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
+| `repro.worker.ts` | **Worker source.** Loads Pyodide and the `pandas` package, runs the reproduction script, and posts the result back. |
 | `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
 | `repro.py`   | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. See "Native verification" below. |
 
 Shared visual presentation lives in [`../_shared/style.css`](../_shared/style.css);
 this directory no longer carries its own copy.
+
+## Why the runtime lives in a Web Worker
+
+Booting Pyodide is pure CPU work. Run on the main thread it lands as a
+single task tens of seconds long, and Chrome offers to kill the tab
+before it finishes — measured at 25.8 s of total main-thread blocking with a
+25.1 s worst task on the deployed page. Moving it into a worker takes the
+same page to no long task at all.
+
+The worker imports nothing from `../_shared/`: `_shared/verdict.ts` pulls
+in `_assets/chrome.js`, which touches `document` at module-evaluation
+time and would throw inside a worker. Everything DOM-bound — the verdict
+pill, the envelope, the pane, the progress bar — stays in `repro.ts`.
 
 ## Verdict contract — `vivarium-contract: v1`
 

--- a/src/layer1_wasm/pandas-56679/repro.ts
+++ b/src/layer1_wasm/pandas-56679/repro.ts
@@ -1,6 +1,7 @@
+import { pick } from '../_shared/i18n.js';
 import {
   DEFAULT_PYODIDE_VERSION,
-  loadVivariumPyodide,
+  totalEstimatedMB,
 } from '../_shared/loader.js';
 import type { PathACapturedRun } from '../_shared/path_a.js';
 import { enableRunner } from '../_shared/runner.js';
@@ -34,12 +35,56 @@ interface ReproOutput {
   mismatch: boolean;
 }
 
-interface PyodideRuntime {
-  runPythonAsync(code: string): Promise<{
-    toJs(opts: { dict_converter: typeof Object.fromEntries }): ReproOutput;
-    destroy?(): void;
-  }>;
+type ProgressStage = 'init' | 'fetching-module' | 'loading-runtime' | 'ready';
+
+interface WorkerProgress {
+  type: 'progress';
+  pct: number;
+  stage: ProgressStage;
 }
+
+interface WorkerReady {
+  type: 'ready';
+  pyodideVersion: string;
+}
+
+interface WorkerRunResult {
+  type: 'result';
+  id: number;
+  result: ReproOutput | null;
+  error: string | null;
+}
+
+interface WorkerError {
+  type: 'error';
+  id?: number;
+  message: string;
+}
+
+type WorkerMessage =
+  | WorkerProgress
+  | WorkerReady
+  | WorkerRunResult
+  | WorkerError;
+
+const WORKER_PACKAGES = ['pandas'];
+const ESTIMATED_MB = totalEstimatedMB(WORKER_PACKAGES.length);
+
+const STRINGS: Record<ProgressStage, string> = {
+  init: 'Starting Pyodide worker…',
+  'fetching-module': 'Fetching Pyodide module…',
+  'loading-runtime': 'Loading runtime + pandas…',
+  ready: 'Runtime ready.',
+};
+
+const STRINGS_JA: Partial<Record<ProgressStage, string>> = {
+  init: 'Pyodide worker を起動中…',
+  'fetching-module': 'Pyodide モジュールを取得中…',
+  'loading-runtime': 'runtime と pandas を読み込み中…',
+  ready: 'runtime の準備完了。',
+};
+
+const S = pick(STRINGS, STRINGS_JA);
 
 const outputEl = document.getElementById('output');
 const metaEl = document.getElementById('meta');
@@ -61,6 +106,20 @@ if (!reproCodeEl.firstChild) {
     .catch(() => {});
 }
 
+function emitProgress(pct: number, stage: ProgressStage): void {
+  const loaded = stage === 'ready' ? ESTIMATED_MB : 0;
+  document.dispatchEvent(
+    new CustomEvent('vh-progress', {
+      detail: {
+        pct,
+        label: S[stage],
+        bytes: `${loaded.toFixed(1)} MB / ${ESTIMATED_MB.toFixed(1)} MB`,
+        stage: stage === 'ready' ? 'packages' : 'runtime',
+      },
+    }),
+  );
+}
+
 function evaluate(result: ReproOutput): {
   verdict: 'reproduced' | 'unreproduced';
   message: string;
@@ -77,58 +136,131 @@ function evaluate(result: ReproOutput): {
   };
 }
 
-async function captureRun(
-  runtime: PyodideRuntime,
-  source: string,
-): Promise<PathACapturedRun> {
-  try {
-    const proxy = await runtime.runPythonAsync(source);
-    const result = proxy.toJs({ dict_converter: Object.fromEntries });
-    proxy.destroy?.();
-    const ev = evaluate(result);
-    return {
-      exitCode: 0,
-      verdict: ev.verdict,
-      message: ev.message,
-      stdout: JSON.stringify(result, null, 2),
+function spawnWorker(): Worker {
+  const workerUrl = new URL('./repro.worker.js', import.meta.url);
+  workerUrl.searchParams.set('pyodide', DEFAULT_PYODIDE_VERSION);
+  workerUrl.searchParams.set('packages', WORKER_PACKAGES.join(','));
+  return new Worker(workerUrl, { type: 'module' });
+}
+
+function awaitReady(worker: Worker): Promise<WorkerReady> {
+  return new Promise<WorkerReady>((resolve, reject) => {
+    const cleanup = (): void => {
+      worker.removeEventListener('message', onMessage);
+      worker.removeEventListener('error', onError);
     };
+    const onError = (ev: ErrorEvent): void => {
+      cleanup();
+      reject(new Error(ev.message));
+    };
+    const onMessage = (ev: MessageEvent<WorkerMessage>): void => {
+      const msg = ev.data;
+      if (msg.type === 'progress') {
+        setVerdict('pending', S[msg.stage], 'loading');
+        emitProgress(msg.pct, msg.stage);
+        return;
+      }
+      if (msg.type === 'ready') {
+        cleanup();
+        resolve(msg);
+      } else if (msg.type === 'error') {
+        cleanup();
+        reject(new Error(msg.message));
+      }
+    };
+    worker.addEventListener('message', onMessage);
+    worker.addEventListener('error', onError);
+  });
+}
+
+let runId = 0;
+
+function runInWorker(worker: Worker, source: string): Promise<WorkerRunResult> {
+  const id = ++runId;
+  return new Promise<WorkerRunResult>((resolve, reject) => {
+    const cleanup = (): void => {
+      worker.removeEventListener('message', onMessage);
+      worker.removeEventListener('error', onError);
+    };
+    const onError = (ev: ErrorEvent): void => {
+      cleanup();
+      reject(new Error(ev.message));
+    };
+    const onMessage = (ev: MessageEvent<WorkerMessage>): void => {
+      const msg = ev.data;
+      if (msg.type !== 'result' && msg.type !== 'error') return;
+      if (msg.id !== id) return;
+      cleanup();
+      if (msg.type === 'result') resolve(msg);
+      else reject(new Error(msg.message));
+    };
+    worker.addEventListener('message', onMessage);
+    worker.addEventListener('error', onError);
+    worker.postMessage({ type: 'run', id, source });
+  });
+}
+
+interface CaptureResult {
+  run: PathACapturedRun;
+  parsed: ReproOutput | null;
+}
+
+async function captureIn(
+  worker: Worker,
+  source: string,
+): Promise<CaptureResult> {
+  let message: string;
+  try {
+    const result = await runInWorker(worker, source);
+    if (result.error === null && result.result !== null) {
+      const ev = evaluate(result.result);
+      return {
+        run: {
+          exitCode: 0,
+          verdict: ev.verdict,
+          message: ev.message,
+          stdout: JSON.stringify(result.result, null, 2),
+        },
+        parsed: result.result,
+      };
+    }
+    message = result.error ?? 'the worker returned no result.';
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    return {
+    message = err instanceof Error ? err.message : String(err);
+  }
+  return {
+    run: {
       exitCode: 1,
       verdict: 'unreproduced',
       message: `runtime error: ${message}`,
       stdout: message,
-    };
-  }
+    },
+    parsed: null,
+  };
 }
 
 const startedAt = new Date();
 
 try {
-  const { pyodide, version } = await loadVivariumPyodide({
-    packages: ['pandas'],
-    pendingText: 'Loading Pyodide runtime and pandas…',
-  });
+  setVerdict('pending', S.init, 'loading');
+  emitProgress(5, 'init');
 
-  setVerdict('pending', 'Running reproduction script…');
-  const runtime = pyodide as PyodideRuntime;
-  const baseline = await captureRun(runtime, REPRO_CODE);
+  const worker = spawnWorker();
+  const ready = await awaitReady(worker);
 
-  let baselineResult: ReproOutput | null = null;
-  try {
-    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
-  } catch {
-    outputEl.textContent = baseline.stdout;
-    setVerdict(baseline.verdict, baseline.message);
-    throw new Error(baseline.message);
+  setVerdict('pending', 'Running reproduction script…', 'running');
+  const baseline = await captureIn(worker, REPRO_CODE);
+  outputEl.textContent = baseline.run.stdout;
+  setVerdict(baseline.run.verdict, baseline.run.message);
+
+  const baselineResult = baseline.parsed;
+  if (!baselineResult) {
+    throw new Error(baseline.run.message);
   }
 
   metaEl.textContent =
     `pandas ${baselineResult.pandas_version} on Python ${baselineResult.python_version} ` +
-    `via Pyodide v${version}.`;
-  outputEl.textContent = baseline.stdout;
-  setVerdict(baseline.verdict, baseline.message);
+    `via Pyodide v${ready.pyodideVersion} (Web Worker).`;
 
   const finishedAt = new Date();
   const envelope: VivariumResultV1 = {
@@ -140,7 +272,7 @@ try {
     },
     runtime: {
       name: 'pyodide',
-      version,
+      version: ready.pyodideVersion,
       extras: {
         python: baselineResult.python_version,
         pandas: baselineResult.pandas_version,
@@ -162,7 +294,7 @@ try {
   enableRunner({
     slug: 'pandas-56679',
     baselineSource: REPRO_CODE,
-    runFix: (source) => captureRun(runtime, source),
+    runFix: async (source) => (await captureIn(worker, source)).run,
   });
 } catch (err: unknown) {
   console.error(err);
@@ -176,5 +308,3 @@ try {
     );
   }
 }
-
-void DEFAULT_PYODIDE_VERSION;

--- a/src/layer1_wasm/pandas-56679/repro.worker.ts
+++ b/src/layer1_wasm/pandas-56679/repro.worker.ts
@@ -1,0 +1,143 @@
+const workerScope = self as unknown as {
+  postMessage: (msg: unknown) => void;
+  addEventListener: (
+    type: 'message',
+    listener: (ev: MessageEvent<MainMessage>) => void,
+  ) => void;
+  location: { href: string };
+};
+
+interface MainMessage {
+  type: 'run';
+  id: number;
+  source: string;
+}
+
+interface PyProxy {
+  toJs(opts: { dict_converter: typeof Object.fromEntries }): unknown;
+  destroy?(): void;
+}
+
+interface PyodideRuntime {
+  runPythonAsync(code: string): Promise<unknown>;
+}
+
+interface PyodideModule {
+  loadPyodide(opts: {
+    indexURL: string;
+    packages?: string[];
+  }): Promise<PyodideRuntime>;
+}
+
+const params = new URL(workerScope.location.href).searchParams;
+const PYODIDE_VERSION = params.get('pyodide') ?? '';
+const PACKAGES = (params.get('packages') ?? '').split(',').filter(Boolean);
+
+function progress(pct: number, stage: string): void {
+  workerScope.postMessage({ type: 'progress', pct, stage });
+}
+
+function fail(message: string, id?: number): void {
+  workerScope.postMessage({ type: 'error', message, ...(id ? { id } : {}) });
+}
+
+function isPyProxy(value: unknown): value is PyProxy {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as PyProxy).toJs === 'function'
+  );
+}
+
+async function bootstrap(): Promise<PyodideRuntime> {
+  progress(5, 'init');
+  progress(18, 'fetching-module');
+  const mod = (await import(
+    /* @vite-ignore */ `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/pyodide.mjs`
+  )) as PyodideModule;
+
+  progress(35, 'loading-runtime');
+  const runtime = await mod.loadPyodide({
+    indexURL: `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/`,
+    packages: PACKAGES,
+  });
+
+  progress(92, 'ready');
+  return runtime;
+}
+
+let runtimeRef: PyodideRuntime | null = null;
+
+async function runOnce(
+  runtime: PyodideRuntime,
+  id: number,
+  source: string,
+): Promise<void> {
+  let handle: unknown;
+  try {
+    handle = await runtime.runPythonAsync(source);
+  } catch (err: unknown) {
+    workerScope.postMessage({
+      type: 'result',
+      id,
+      result: null,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  if (!isPyProxy(handle)) {
+    workerScope.postMessage({
+      type: 'result',
+      id,
+      result: null,
+      error: 'the script did not end in a mapping the page could read.',
+    });
+    return;
+  }
+
+  try {
+    const result = handle.toJs({ dict_converter: Object.fromEntries });
+    workerScope.postMessage({ type: 'result', id, result, error: null });
+  } catch (err: unknown) {
+    workerScope.postMessage({
+      type: 'result',
+      id,
+      result: null,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  } finally {
+    handle.destroy?.();
+  }
+}
+
+workerScope.addEventListener('message', (ev: MessageEvent<MainMessage>) => {
+  const msg = ev.data;
+  if (msg?.type !== 'run') return;
+  if (runtimeRef === null) {
+    fail('worker received a run request before the runtime was ready.', msg.id);
+    return;
+  }
+  void runOnce(runtimeRef, msg.id, msg.source);
+});
+
+if (!PYODIDE_VERSION) {
+  fail(
+    'worker URL is missing the `pyodide` query parameter; the main thread owns it.',
+  );
+} else {
+  bootstrap()
+    .then((runtime) => {
+      runtimeRef = runtime;
+      workerScope.postMessage({
+        type: 'ready',
+        pyodideVersion: PYODIDE_VERSION,
+      });
+    })
+    .catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      fail(`bootstrap failed: ${message}`);
+    });
+}
+
+export {};


### PR DESCRIPTION
## Why

Both pages block the main thread for **longer than `dateutil-1478` ever did** before #403 moved it into a worker. Measured on the deployed pages with `PerformanceObserver`:

| page | total blocked | worst task |
|---|---|---|
| **pandas-56679** | 25.8 s | **25.1 s** |
| **cpython-137205** | 18.3–20.1 s | **17.9–18.9 s** |
| dateutil-1478 (pre-#403) | 19.9 s | 15.0 s |
| numpy-28287 | 2.5 s | 1.9 s |

Chrome offers to kill a tab well inside those.

## After

| page | total blocked | worst task |
|---|---|---|
| pandas-56679 | **no long task at all** | — |
| cpython-137205 | **259 ms** | 207 ms |

## The cost is the runtime, not the packages

`cpython-137205` loads **no package at all** — it uses the stdlib `sqlite3` — and still blocked for 18 s. That was the counterintuitive finding, and it is why `numpy-28287` was measured rather than assumed.

cpython was measured twice, first and last in the session (20.1 s then 18.3 s), to rule out the browser's compiled-WASM cache warming between runs. It did not.

**`numpy-28287` stays on the main thread.** 2.5 s is nowhere near the threshold, and rewriting it would be a change with no observed problem behind it.

## Simpler than dateutil's worker

Neither recipe ships a fix candidate, so both workers drop the whole wheel half of dateutil's protocol: no `install` / `installed` message, no `micropip` swap, no restore.

The fix pane is static markup carrying `data-fix-status="none"` and `output.noFixCandidate`, and neither `repro.ts` touches it at runtime. `setFixPane` is deliberately **not** copied — writing a `pending` that never resolves would fail `repro.spec.ts` and `repro-ja.spec.ts`, both of which assert the pane leaves `pending`.

## One decision worth flagging: the read-back

A `PyProxy` cannot cross `postMessage`. These scripts end in a trailing dict that the main thread used to `toJs`, so moving them into a worker forces a choice about how the result comes back.

**They keep their current JSON output**: the worker calls `toJs({ dict_converter: Object.fromEntries })` and posts the plain object; the pane renders the same `JSON.stringify(result, null, 2)` it always did. Not one character of visible output changes.

That read-back is **temporary**. The pending conversion to plain Python printing real stdout (#401's shape) will replace it with the named-global shape `dateutil-1478` already uses. Keeping it here costs about ten lines that a later PR deletes, and buys a change that is purely about blocking time — so if something breaks, which half caused it is not a question.

## Why the four workers are not factored into a shared helper

`dateutil` reads a named global, these two read a trailing expression, `lark-1585` wraps the script in a try/except timing harness. Three read-backs, and the trailing-expression one is the one about to disappear. Designing the abstraction around a shape that is leaving would be the wrong order; the extraction belongs after the output-format rollout settles all of them on one read-back.

## Free with the worker

`generate-repro-pages.ts` keys the `<link rel="preload">` tags off the *absence* of a `repro.worker.ts`, so adding the file drops them with no generator change:

```text
cpython-137205     worker  preload=0  preconnect=1
dateutil-1478      worker  preload=0  preconnect=1
lark-1585          worker  preload=0  preconnect=1
numpy-28287        main    preload=3  preconnect=1
pandas-56679       worker  preload=0  preconnect=1
```

## Verification

`repro:typecheck`, `repro:build`, `repro:pages`, `repro:i18n`, `docs:check` and `markdown:check` are clean.

In a browser, per page: the verdict, the `#output` JSON, `__VIVARIUM_RESULT__`'s `result` keys and `runtime.extras` all match what the deployed pages produce today; `#output-fix` stays at `data-fix-status="none"`; and Run / Edit / Reset all round-trip through the worker (an edited script reporting matching dtypes flips to `unreproduced`, Reset restores `reproduced`).

Playwright on chromium, all six affected cases:

```text
ok  cpython-137205 japanese page produces reproduced
ok  pandas-56679 japanese page produces reproduced
ok  cpython-137205 reproduction produces reproduced
ok  pandas-56679 reproduction produces reproduced
ok  verdict-capture: cpython-137205
ok  verdict-capture: pandas-56679
```

The full suite is left to CI.

## Rules updated

The Layer 1 worker pitfall in `.claude/rules/recipe-authoring.md` gains these numbers and the point they make: the cost is the runtime, not the packages, so measure before assuming a recipe is light — with `numpy-28287` named as the one deliberately left alone.

## Follow-ups

- Convert `cpython-137205` / `pandas-56679` / `numpy-28287` / `ruby-21709` / `regex-779` to #401's plain-Python + real-stdout shape; the trailing-expression read-back disappears there
- Extract the shared worker bootstrap once those read-backs agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)
