### PR TITLE
refactor(wasm): print human-readable output in the three pyodide recipes

### DIFF
--- a/.claude/rules/recipe-authoring.md
+++ b/.claude/rules/recipe-authoring.md
@@ -273,6 +273,42 @@ one. Copy the block from
   correct `reproduced` to `unreproduced`, reporting a fix nobody
   observed. See `regex-779/repro.ts`.
 
+**Output shape — the script prints, the page shows what it printed**:
+
+The pane exists so a visitor can read what the script did. It must show
+the script's **real stdout**, never a JSON blob the driver assembled out
+of values it read back. The shape:
+
+- The script must read as ordinary code in its own language, and must
+  not end in a bare expression that exists only for the host to pick
+  up — that is what made the first generation of these pages
+  unreadable: the visitor could not see why running the script
+  produced JSON.
+- It `print`s a short human-readable summary: the inputs, the answer
+  each one produced, and a marker on the ones that show the bug.
+- It leaves the machine-readable values in a named global — `result`
+  for a single mapping, `results` for a list of rows. The driver reads
+  that global for the verdict and the Contract v1 envelope, and puts
+  the captured stdout into `#output` unchanged.
+- Capture stdout with `setStdout({ batched })` under Pyodide, or
+  `ConsoleStdout.lineBuffered` under the WASI shim.
+- **Delete the global before every run.** One Pyodide namespace spans
+  every run, including the ones a visitor triggers from the Edit box.
+  Without `globals.delete`, a script that no longer assigns the global
+  is judged on the previous run's values.
+- Treat a missing global as `unreproduced` with a message that says so,
+  not as a crash. An edited script is the expected way to reach it.
+- The native variant (`repro.py` / `repro.rb`) keeps the **same body**
+  as the browser script, adding only its header, docstring, `verdict=`
+  line on stderr and exit code. Run the repo formatter over the native
+  file and mirror what it does back into the driver's string literal —
+  otherwise the next autofix pass silently drifts the two apart.
+
+`dateutil-1478`, `cpython-137205`, `pandas-56679` and `numpy-28287`
+follow this. `lark-1585`, `regex-779` and `ruby-21709` predate it and
+still hand the pane a JSON string their driver built; they are being
+converted. Do not copy their output handling into a new recipe.
+
 **Local validation**:
 
 ```bash

--- a/src/layer1_wasm/cpython-137205/README.md
+++ b/src/layer1_wasm/cpython-137205/README.md
@@ -59,7 +59,7 @@ the Python API surface.
 | ------------ | ----------------------------------------------------------------- |
 | `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
 | `repro.ts`   | **Main-thread driver.** Spawns the Pyodide Web Worker, relays its progress into the page's progress bar, and owns the verdict, the Contract v1 envelope and the output pane. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
-| `repro.worker.ts` | **Worker source.** Loads Pyodide with the stdlib `sqlite3` it ships, runs the reproduction script, and posts the result back. |
+| `repro.worker.ts` | **Worker source.** Loads Pyodide with the stdlib `sqlite3` it ships, runs the reproduction script, and posts back what the script printed together with the `result` mapping it left behind. |
 | `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
 | `repro.py`   | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. The bug is in the CPython binding layer, so no third-party deps are needed (PEP 723 `dependencies = []`). See "Native verification" below. |
 

--- a/src/layer1_wasm/cpython-137205/repro.py
+++ b/src/layer1_wasm/cpython-137205/repro.py
@@ -20,14 +20,17 @@ same Python 3.13 binding through the `sqlite3` Pyodide package; this
 CLI exercises the same binding through whatever CPython 3.13 build
 mise installs.
 
-Prints `pass` if the bug REPRODUCES (the two connections disagree
-on PRAGMA foreign_keys), `fail` otherwise. Exit code: 0 on `pass`,
-1 on `fail`.
+Sets `PRAGMA foreign_keys = ON` on two connections that differ only
+in their `autocommit` setting, reads the pragma back on each, and
+prints the two answers side by side. Exits 0 on `reproduced` (the
+two connections disagree), 1 on `unreproduced` (they agree; likely
+fixed upstream).
 """
 
-import json
 import sqlite3
 import sys
+
+DROPPED = "   <-- setting dropped"
 
 off = sqlite3.connect(":memory:", autocommit=False)
 off.execute("PRAGMA foreign_keys = ON")
@@ -38,20 +41,32 @@ on.execute("PRAGMA foreign_keys = ON")
 
 off_value = int(off.execute("PRAGMA foreign_keys").fetchone()[0])
 on_value = int(on.execute("PRAGMA foreign_keys").fetchone()[0])
-fk_disagreement = off_value != on_value
+disagreement = off_value != on_value
 
 result = {
     "python_version": sys.version.split()[0],
     "sqlite_version": sqlite3.sqlite_version,
     "off_autocommit_fk": off_value,
     "on_autocommit_fk": on_value,
-    "fk_disagreement": fk_disagreement,
-    "reproduced": fk_disagreement,
+    "fk_disagreement": disagreement,
 }
 
-print(json.dumps(result, indent=2))
+off_note = DROPPED if off_value == 0 else ""
+on_note = DROPPED if on_value == 0 else ""
 
-if fk_disagreement:
+print("Set PRAGMA foreign_keys = ON on two connections, then read it back:")
+print()
+print("autocommit".ljust(14) + "foreign_keys".rjust(14))
+print("False".ljust(14) + str(off_value).rjust(14) + off_note)
+print("True".ljust(14) + str(on_value).rjust(14) + on_note)
+print()
+if disagreement:
+    print("The two connections disagree: autocommit=False dropped the PRAGMA.")
+else:
+    print("Both connections agree: the PRAGMA survived on both.")
+print("Python " + result["python_version"] + " / SQLite " + result["sqlite_version"])
+
+if disagreement:
     print(
         "verdict=reproduced — autocommit=False silently drops PRAGMA foreign_keys",
         file=sys.stderr,

--- a/src/layer1_wasm/cpython-137205/repro.ts
+++ b/src/layer1_wasm/cpython-137205/repro.ts
@@ -12,8 +12,10 @@ import {
 } from '../_shared/verdict.js';
 
 const REPRO_CODE = `
-import sys
 import sqlite3
+import sys
+
+DROPPED = "   <-- setting dropped"
 
 off = sqlite3.connect(":memory:", autocommit=False)
 off.execute("PRAGMA foreign_keys = ON")
@@ -22,16 +24,32 @@ off.commit()
 on = sqlite3.connect(":memory:", autocommit=True)
 on.execute("PRAGMA foreign_keys = ON")
 
-off_value = off.execute("PRAGMA foreign_keys").fetchone()[0]
-on_value = on.execute("PRAGMA foreign_keys").fetchone()[0]
+off_value = int(off.execute("PRAGMA foreign_keys").fetchone()[0])
+on_value = int(on.execute("PRAGMA foreign_keys").fetchone()[0])
+disagreement = off_value != on_value
 
-{
+result = {
     "python_version": sys.version.split()[0],
     "sqlite_version": sqlite3.sqlite_version,
-    "off_autocommit_fk": int(off_value),
-    "on_autocommit_fk": int(on_value),
-    "fk_disagreement": off_value != on_value,
+    "off_autocommit_fk": off_value,
+    "on_autocommit_fk": on_value,
+    "fk_disagreement": disagreement,
 }
+
+off_note = DROPPED if off_value == 0 else ""
+on_note = DROPPED if on_value == 0 else ""
+
+print("Set PRAGMA foreign_keys = ON on two connections, then read it back:")
+print()
+print("autocommit".ljust(14) + "foreign_keys".rjust(14))
+print("False".ljust(14) + str(off_value).rjust(14) + off_note)
+print("True".ljust(14) + str(on_value).rjust(14) + on_note)
+print()
+if disagreement:
+    print("The two connections disagree: autocommit=False dropped the PRAGMA.")
+else:
+    print("Both connections agree: the PRAGMA survived on both.")
+print("Python " + result["python_version"] + " / SQLite " + result["sqlite_version"])
 `.trim();
 
 interface ReproOutput {
@@ -58,6 +76,7 @@ interface WorkerReady {
 interface WorkerRunResult {
   type: 'result';
   id: number;
+  stdout: string;
   result: ReproOutput | null;
   error: string | null;
 }
@@ -127,10 +146,16 @@ function emitProgress(pct: number, stage: ProgressStage): void {
   );
 }
 
-function evaluate(result: ReproOutput): {
+function evaluate(result: ReproOutput | null): {
   verdict: 'reproduced' | 'unreproduced';
   message: string;
 } {
+  if (!result) {
+    return {
+      verdict: 'unreproduced',
+      message: 'bug not reproduced — the script left no `result` mapping behind.',
+    };
+  }
   if (result.fk_disagreement) {
     return {
       verdict: 'reproduced',
@@ -214,38 +239,48 @@ interface CaptureResult {
   parsed: ReproOutput | null;
 }
 
+function toCapture(result: WorkerRunResult): CaptureResult {
+  if (result.error !== null) {
+    return {
+      run: {
+        exitCode: 1,
+        verdict: 'unreproduced',
+        message: `runtime error: ${result.error}`,
+        stdout: result.stdout,
+      },
+      parsed: null,
+    };
+  }
+  const ev = evaluate(result.result);
+  return {
+    run: {
+      exitCode: result.result ? 0 : 1,
+      verdict: ev.verdict,
+      message: ev.message,
+      stdout: result.stdout,
+    },
+    parsed: result.result,
+  };
+}
+
 async function captureIn(
   worker: Worker,
   source: string,
 ): Promise<CaptureResult> {
-  let message: string;
   try {
-    const result = await runInWorker(worker, source);
-    if (result.error === null && result.result !== null) {
-      const ev = evaluate(result.result);
-      return {
-        run: {
-          exitCode: 0,
-          verdict: ev.verdict,
-          message: ev.message,
-          stdout: JSON.stringify(result.result, null, 2),
-        },
-        parsed: result.result,
-      };
-    }
-    message = result.error ?? 'the worker returned no result.';
+    return toCapture(await runInWorker(worker, source));
   } catch (err: unknown) {
-    message = err instanceof Error ? err.message : String(err);
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      run: {
+        exitCode: 1,
+        verdict: 'unreproduced',
+        message: `runtime error: ${message}`,
+        stdout: message,
+      },
+      parsed: null,
+    };
   }
-  return {
-    run: {
-      exitCode: 1,
-      verdict: 'unreproduced',
-      message: `runtime error: ${message}`,
-      stdout: message,
-    },
-    parsed: null,
-  };
 }
 
 const startedAt = new Date();

--- a/src/layer1_wasm/cpython-137205/repro.worker.ts
+++ b/src/layer1_wasm/cpython-137205/repro.worker.ts
@@ -20,6 +20,12 @@ interface PyProxy {
 
 interface PyodideRuntime {
   runPythonAsync(code: string): Promise<unknown>;
+  setStdout(options: { batched: (text: string) => void }): void;
+  globals: {
+    get(name: string): unknown;
+    has(name: string): boolean;
+    delete(name: string): void;
+  };
 }
 
 interface PyodideModule {
@@ -49,6 +55,16 @@ function isPyProxy(value: unknown): value is PyProxy {
   );
 }
 
+function readResult(runtime: PyodideRuntime): unknown {
+  const handle = runtime.globals.get('result');
+  if (!isPyProxy(handle)) return null;
+  try {
+    return handle.toJs({ dict_converter: Object.fromEntries });
+  } finally {
+    handle.destroy?.();
+  }
+}
+
 async function bootstrap(): Promise<PyodideRuntime> {
   progress(5, 'init');
   progress(18, 'fetching-module');
@@ -73,41 +89,34 @@ async function runOnce(
   id: number,
   source: string,
 ): Promise<void> {
-  let handle: unknown;
-  try {
-    handle = await runtime.runPythonAsync(source);
-  } catch (err: unknown) {
-    workerScope.postMessage({
-      type: 'result',
-      id,
-      result: null,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return;
-  }
-
-  if (!isPyProxy(handle)) {
-    workerScope.postMessage({
-      type: 'result',
-      id,
-      result: null,
-      error: 'the script did not end in a mapping the page could read.',
-    });
-    return;
-  }
+  const lines: string[] = [];
+  runtime.setStdout({
+    batched: (text) => {
+      lines.push(text);
+    },
+  });
+  // One Pyodide namespace spans every run: an edited script that never
+  // assigns `result` would otherwise be judged on the previous run's values.
+  if (runtime.globals.has('result')) runtime.globals.delete('result');
 
   try {
-    const result = handle.toJs({ dict_converter: Object.fromEntries });
-    workerScope.postMessage({ type: 'result', id, result, error: null });
-  } catch (err: unknown) {
+    await runtime.runPythonAsync(source);
     workerScope.postMessage({
       type: 'result',
       id,
-      result: null,
-      error: err instanceof Error ? err.message : String(err),
+      stdout: lines.join('\n'),
+      result: readResult(runtime),
+      error: null,
     });
-  } finally {
-    handle.destroy?.();
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    workerScope.postMessage({
+      type: 'result',
+      id,
+      stdout: [...lines, message].join('\n'),
+      result: null,
+      error: message,
+    });
   }
 }
 

--- a/src/layer1_wasm/numpy-28287/repro.py
+++ b/src/layer1_wasm/numpy-28287/repro.py
@@ -18,12 +18,12 @@ whether the bug survives there is what decides if it is still open.
 The page runs the numpy Pyodide bundles (2.4.6), where it also
 reproduces.
 
-Prints `pass` if the bug REPRODUCES (`timedelta64` ordering is
-non-transitive across the generic unit), `fail` otherwise. Exit
-code: 0 on `pass`, 1 on `fail`.
+Compares three `timedelta64` values — two carrying a unit, one on the
+generic unit — and prints each pairwise `<` answer. Exits 0 on
+`reproduced` (ordering is non-transitive across the generic unit),
+1 on `unreproduced` (ordering is transitive; likely fixed upstream).
 """
 
-import json
 import sys
 
 import numpy as np
@@ -44,10 +44,25 @@ result = {
     "y_lt_z": y_lt_z,
     "x_lt_z": x_lt_z,
     "transitivity_violated": transitivity_violated,
-    "reproduced": transitivity_violated,
 }
 
-print(json.dumps(result, indent=2))
+broken = "   <-- transitivity broken" if transitivity_violated else ""
+
+print("Three timedelta64 values, two of them carrying a unit:")
+print()
+print("x = 1 ms")
+print("y = 2 (generic unit)")
+print("z = 5 ns")
+print()
+print("x < y  -> " + str(x_lt_y))
+print("y < z  -> " + str(y_lt_z))
+print("x < z  -> " + str(x_lt_z) + broken)
+print()
+if transitivity_violated:
+    print("Ordering is not transitive: x < y and y < z, yet x >= z.")
+else:
+    print("Ordering is transitive on these three values.")
+print("numpy " + result["numpy_version"] + " / Python " + result["python_version"])
 
 if transitivity_violated:
     print(

--- a/src/layer1_wasm/numpy-28287/repro.ts
+++ b/src/layer1_wasm/numpy-28287/repro.ts
@@ -9,6 +9,7 @@ import {
 
 const REPRO_CODE = `
 import sys
+
 import numpy as np
 
 x = np.timedelta64(1, "ms")
@@ -18,15 +19,34 @@ z = np.timedelta64(5, "ns")
 x_lt_y = bool(x < y)
 y_lt_z = bool(y < z)
 x_lt_z = bool(x < z)
+transitivity_violated = x_lt_y and y_lt_z and not x_lt_z
 
-{
+result = {
     "numpy_version": np.__version__,
     "python_version": sys.version.split()[0],
     "x_lt_y": x_lt_y,
     "y_lt_z": y_lt_z,
     "x_lt_z": x_lt_z,
-    "transitivity_violated": x_lt_y and y_lt_z and not x_lt_z,
+    "transitivity_violated": transitivity_violated,
 }
+
+broken = "   <-- transitivity broken" if transitivity_violated else ""
+
+print("Three timedelta64 values, two of them carrying a unit:")
+print()
+print("x = 1 ms")
+print("y = 2 (generic unit)")
+print("z = 5 ns")
+print()
+print("x < y  -> " + str(x_lt_y))
+print("y < z  -> " + str(y_lt_z))
+print("x < z  -> " + str(x_lt_z) + broken)
+print()
+if transitivity_violated:
+    print("Ordering is not transitive: x < y and y < z, yet x >= z.")
+else:
+    print("Ordering is transitive on these three values.")
+print("numpy " + result["numpy_version"] + " / Python " + result["python_version"])
 `.trim();
 
 interface ReproOutput {
@@ -38,11 +58,19 @@ interface ReproOutput {
   transitivity_violated: boolean;
 }
 
+interface PyProxy {
+  toJs(opts: { dict_converter: typeof Object.fromEntries }): unknown;
+  destroy?(): void;
+}
+
 interface PyodideRuntime {
-  runPythonAsync(code: string): Promise<{
-    toJs(opts: { dict_converter: typeof Object.fromEntries }): ReproOutput;
-    destroy?(): void;
-  }>;
+  runPythonAsync(code: string): Promise<unknown>;
+  setStdout(options: { batched: (text: string) => void }): void;
+  globals: {
+    get(name: string): unknown;
+    has(name: string): boolean;
+    delete(name: string): void;
+  };
 }
 
 const outputEl = document.getElementById('output');
@@ -65,10 +93,16 @@ if (!reproCodeEl.firstChild) {
     .catch(() => {});
 }
 
-function evaluate(result: ReproOutput): {
+function evaluate(result: ReproOutput | null): {
   verdict: 'reproduced' | 'unreproduced';
   message: string;
 } {
+  if (!result) {
+    return {
+      verdict: 'unreproduced',
+      message: 'bug not reproduced — the script left no `result` mapping behind.',
+    };
+  }
   if (result.transitivity_violated) {
     return {
       verdict: 'reproduced',
@@ -83,28 +117,66 @@ function evaluate(result: ReproOutput): {
   };
 }
 
+function isPyProxy(value: unknown): value is PyProxy {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as PyProxy).toJs === 'function'
+  );
+}
+
+function readResult(runtime: PyodideRuntime): ReproOutput | null {
+  const handle = runtime.globals.get('result');
+  if (!isPyProxy(handle)) return null;
+  try {
+    return handle.toJs({ dict_converter: Object.fromEntries }) as ReproOutput;
+  } finally {
+    handle.destroy?.();
+  }
+}
+
+interface CaptureResult {
+  run: PathACapturedRun;
+  parsed: ReproOutput | null;
+}
+
 async function captureRun(
   runtime: PyodideRuntime,
   source: string,
-): Promise<PathACapturedRun> {
+): Promise<CaptureResult> {
+  const lines: string[] = [];
+  runtime.setStdout({
+    batched: (text) => {
+      lines.push(text);
+    },
+  });
+  // One Pyodide namespace spans every run: an edited script that never
+  // assigns `result` would otherwise be judged on the previous run's values.
+  if (runtime.globals.has('result')) runtime.globals.delete('result');
+
   try {
-    const proxy = await runtime.runPythonAsync(source);
-    const result = proxy.toJs({ dict_converter: Object.fromEntries });
-    proxy.destroy?.();
-    const ev = evaluate(result);
+    await runtime.runPythonAsync(source);
+    const parsed = readResult(runtime);
+    const ev = evaluate(parsed);
     return {
-      exitCode: 0,
-      verdict: ev.verdict,
-      message: ev.message,
-      stdout: JSON.stringify(result, null, 2),
+      run: {
+        exitCode: parsed ? 0 : 1,
+        verdict: ev.verdict,
+        message: ev.message,
+        stdout: lines.join('\n'),
+      },
+      parsed,
     };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     return {
-      exitCode: 1,
-      verdict: 'unreproduced',
-      message: `runtime error: ${message}`,
-      stdout: message,
+      run: {
+        exitCode: 1,
+        verdict: 'unreproduced',
+        message: `runtime error: ${message}`,
+        stdout: [...lines, message].join('\n'),
+      },
+      parsed: null,
     };
   }
 }
@@ -121,20 +193,17 @@ try {
   const runtime = pyodide as PyodideRuntime;
   const baseline = await captureRun(runtime, REPRO_CODE);
 
-  let baselineResult: ReproOutput | null = null;
-  try {
-    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
-  } catch {
-    outputEl.textContent = baseline.stdout;
-    setVerdict(baseline.verdict, baseline.message);
-    throw new Error(baseline.message);
+  outputEl.textContent = baseline.run.stdout;
+  setVerdict(baseline.run.verdict, baseline.run.message);
+
+  const baselineResult = baseline.parsed;
+  if (!baselineResult) {
+    throw new Error(baseline.run.message);
   }
 
   metaEl.textContent =
     `numpy ${baselineResult.numpy_version} on Python ${baselineResult.python_version} ` +
     `via Pyodide v${version}.`;
-  outputEl.textContent = baseline.stdout;
-  setVerdict(baseline.verdict, baseline.message);
 
   const finishedAt = new Date();
   const envelope: VivariumResultV1 = {
@@ -169,7 +238,7 @@ try {
   enableRunner({
     slug: 'numpy-28287',
     baselineSource: REPRO_CODE,
-    runFix: (source) => captureRun(runtime, source),
+    runFix: async (source) => (await captureRun(runtime, source)).run,
   });
 } catch (err: unknown) {
   console.error(err);

--- a/src/layer1_wasm/pandas-56679/README.md
+++ b/src/layer1_wasm/pandas-56679/README.md
@@ -29,7 +29,7 @@ constructors should produce a consistent dtype for an empty input.
 | ------------ | ----------------------------------------------------------------- |
 | `index.html` | Static page; declares `<meta name="vivarium-contract" content="v1">`. |
 | `repro.ts`   | **Main-thread driver.** Spawns the Pyodide Web Worker, relays its progress into the page's progress bar, and owns the verdict, the Contract v1 envelope and the output pane. Compiled to `repro.js` by `bun run build` from `src/layer1_wasm/`. |
-| `repro.worker.ts` | **Worker source.** Loads Pyodide and the `pandas` package, runs the reproduction script, and posts the result back. |
+| `repro.worker.ts` | **Worker source.** Loads Pyodide and the `pandas` package, runs the reproduction script, and posts back what the script printed together with the `result` mapping it left behind. |
 | `repro.js`   | Generated; gitignored. Loaded by `index.html` at runtime.         |
 | `repro.py`   | **Native CLI variant.** Same reproduction logic, runnable directly under a real CPython interpreter via `uv run`. See "Native verification" below. |
 
@@ -106,14 +106,15 @@ mise install
 mise exec uv -- uv run src/layer1_wasm/pandas-56679/repro.py
 
 # Expected output (pandas 3.0.5):
-# {
-#   "pandas_version": "3.0.5",
-#   "python_version": "3.14.x",
-#   "series_dtype": "object",
-#   "df_dtype": "float64",
-#   "mismatch": true,
-#   "reproduced": true
-# }
+# Two empty containers built from the same empty input:
+#
+# pd.Series([]).dtype                 -> object
+# pd.DataFrame({"a": []})["a"].dtype  -> float64
+#
+# The two disagree: the same empty input yields different dtypes.
+# pandas 3.0.5 / Python 3.14.x
+#
+# ...and on stderr:
 # verdict=reproduced — Series and DataFrame disagree on empty-input dtype
 ```
 

--- a/src/layer1_wasm/pandas-56679/repro.py
+++ b/src/layer1_wasm/pandas-56679/repro.py
@@ -19,12 +19,12 @@ The page runs the pandas Pyodide bundles (3.0.2), where it also
 reproduces. `uv run` reads the metadata and creates an ephemeral venv
 on first invocation; subsequent runs hit uv's cache.
 
-Prints `pass` if the bug REPRODUCES (Series and DataFrame disagree on
-empty-input dtype), `fail` otherwise. Exit code: 0 on `pass`, 1 on
-`fail` so CI can shell-script around it without parsing stdout.
+Builds an empty Series and an empty single-column DataFrame from the
+same empty input and prints the dtype each one reports. Exits 0 on
+`reproduced` (the two disagree), 1 on `unreproduced` (they agree;
+likely fixed upstream).
 """
 
-import json
 import sys
 
 import pandas as pd
@@ -39,10 +39,18 @@ result = {
     "series_dtype": series_dtype,
     "df_dtype": df_dtype,
     "mismatch": mismatch,
-    "reproduced": mismatch,
 }
 
-print(json.dumps(result, indent=2))
+print("Two empty containers built from the same empty input:")
+print()
+print("pd.Series([]).dtype".ljust(36) + "-> " + series_dtype)
+print('pd.DataFrame({"a": []})["a"].dtype'.ljust(36) + "-> " + df_dtype)
+print()
+if mismatch:
+    print("The two disagree: the same empty input yields different dtypes.")
+else:
+    print("The two agree: both empty containers report the same dtype.")
+print("pandas " + result["pandas_version"] + " / Python " + result["python_version"])
 
 if mismatch:
     print(

--- a/src/layer1_wasm/pandas-56679/repro.ts
+++ b/src/layer1_wasm/pandas-56679/repro.ts
@@ -13,18 +13,31 @@ import {
 
 const REPRO_CODE = `
 import sys
+
 import pandas as pd
 
 series_dtype = str(pd.Series([]).dtype)
-df_dtype = str(pd.DataFrame({'a': []})['a'].dtype)
+df_dtype = str(pd.DataFrame({"a": []})["a"].dtype)
+mismatch = series_dtype != df_dtype
 
-{
+result = {
     "pandas_version": pd.__version__,
     "python_version": sys.version.split()[0],
     "series_dtype": series_dtype,
     "df_dtype": df_dtype,
-    "mismatch": series_dtype != df_dtype,
+    "mismatch": mismatch,
 }
+
+print("Two empty containers built from the same empty input:")
+print()
+print("pd.Series([]).dtype".ljust(36) + "-> " + series_dtype)
+print('pd.DataFrame({"a": []})["a"].dtype'.ljust(36) + "-> " + df_dtype)
+print()
+if mismatch:
+    print("The two disagree: the same empty input yields different dtypes.")
+else:
+    print("The two agree: both empty containers report the same dtype.")
+print("pandas " + result["pandas_version"] + " / Python " + result["python_version"])
 `.trim();
 
 interface ReproOutput {
@@ -51,6 +64,7 @@ interface WorkerReady {
 interface WorkerRunResult {
   type: 'result';
   id: number;
+  stdout: string;
   result: ReproOutput | null;
   error: string | null;
 }
@@ -120,10 +134,16 @@ function emitProgress(pct: number, stage: ProgressStage): void {
   );
 }
 
-function evaluate(result: ReproOutput): {
+function evaluate(result: ReproOutput | null): {
   verdict: 'reproduced' | 'unreproduced';
   message: string;
 } {
+  if (!result) {
+    return {
+      verdict: 'unreproduced',
+      message: 'bug not reproduced — the script left no `result` mapping behind.',
+    };
+  }
   if (result.mismatch) {
     return {
       verdict: 'reproduced',
@@ -205,38 +225,48 @@ interface CaptureResult {
   parsed: ReproOutput | null;
 }
 
+function toCapture(result: WorkerRunResult): CaptureResult {
+  if (result.error !== null) {
+    return {
+      run: {
+        exitCode: 1,
+        verdict: 'unreproduced',
+        message: `runtime error: ${result.error}`,
+        stdout: result.stdout,
+      },
+      parsed: null,
+    };
+  }
+  const ev = evaluate(result.result);
+  return {
+    run: {
+      exitCode: result.result ? 0 : 1,
+      verdict: ev.verdict,
+      message: ev.message,
+      stdout: result.stdout,
+    },
+    parsed: result.result,
+  };
+}
+
 async function captureIn(
   worker: Worker,
   source: string,
 ): Promise<CaptureResult> {
-  let message: string;
   try {
-    const result = await runInWorker(worker, source);
-    if (result.error === null && result.result !== null) {
-      const ev = evaluate(result.result);
-      return {
-        run: {
-          exitCode: 0,
-          verdict: ev.verdict,
-          message: ev.message,
-          stdout: JSON.stringify(result.result, null, 2),
-        },
-        parsed: result.result,
-      };
-    }
-    message = result.error ?? 'the worker returned no result.';
+    return toCapture(await runInWorker(worker, source));
   } catch (err: unknown) {
-    message = err instanceof Error ? err.message : String(err);
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      run: {
+        exitCode: 1,
+        verdict: 'unreproduced',
+        message: `runtime error: ${message}`,
+        stdout: message,
+      },
+      parsed: null,
+    };
   }
-  return {
-    run: {
-      exitCode: 1,
-      verdict: 'unreproduced',
-      message: `runtime error: ${message}`,
-      stdout: message,
-    },
-    parsed: null,
-  };
 }
 
 const startedAt = new Date();

--- a/src/layer1_wasm/pandas-56679/repro.worker.ts
+++ b/src/layer1_wasm/pandas-56679/repro.worker.ts
@@ -20,6 +20,12 @@ interface PyProxy {
 
 interface PyodideRuntime {
   runPythonAsync(code: string): Promise<unknown>;
+  setStdout(options: { batched: (text: string) => void }): void;
+  globals: {
+    get(name: string): unknown;
+    has(name: string): boolean;
+    delete(name: string): void;
+  };
 }
 
 interface PyodideModule {
@@ -49,6 +55,16 @@ function isPyProxy(value: unknown): value is PyProxy {
   );
 }
 
+function readResult(runtime: PyodideRuntime): unknown {
+  const handle = runtime.globals.get('result');
+  if (!isPyProxy(handle)) return null;
+  try {
+    return handle.toJs({ dict_converter: Object.fromEntries });
+  } finally {
+    handle.destroy?.();
+  }
+}
+
 async function bootstrap(): Promise<PyodideRuntime> {
   progress(5, 'init');
   progress(18, 'fetching-module');
@@ -73,41 +89,34 @@ async function runOnce(
   id: number,
   source: string,
 ): Promise<void> {
-  let handle: unknown;
-  try {
-    handle = await runtime.runPythonAsync(source);
-  } catch (err: unknown) {
-    workerScope.postMessage({
-      type: 'result',
-      id,
-      result: null,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return;
-  }
-
-  if (!isPyProxy(handle)) {
-    workerScope.postMessage({
-      type: 'result',
-      id,
-      result: null,
-      error: 'the script did not end in a mapping the page could read.',
-    });
-    return;
-  }
+  const lines: string[] = [];
+  runtime.setStdout({
+    batched: (text) => {
+      lines.push(text);
+    },
+  });
+  // One Pyodide namespace spans every run: an edited script that never
+  // assigns `result` would otherwise be judged on the previous run's values.
+  if (runtime.globals.has('result')) runtime.globals.delete('result');
 
   try {
-    const result = handle.toJs({ dict_converter: Object.fromEntries });
-    workerScope.postMessage({ type: 'result', id, result, error: null });
-  } catch (err: unknown) {
+    await runtime.runPythonAsync(source);
     workerScope.postMessage({
       type: 'result',
       id,
-      result: null,
-      error: err instanceof Error ? err.message : String(err),
+      stdout: lines.join('\n'),
+      result: readResult(runtime),
+      error: null,
     });
-  } finally {
-    handle.destroy?.();
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    workerScope.postMessage({
+      type: 'result',
+      id,
+      stdout: [...lines, message].join('\n'),
+      result: null,
+      error: message,
+    });
   }
 }
 


### PR DESCRIPTION
Rolls the dateutil-1478 output shape out to the three Pyodide recipes.

## The problem

`cpython-137205`, `pandas-56679` and `numpy-28287` each ended their
reproduction script in a **bare dict literal** that existed only for the
driver to read back, and the output pane showed a **JSON blob the driver
had assembled** — not anything the script printed. A visitor reading the
page could not see why running the script produced JSON.

## Before / after

`cpython-137205`, script tail and pane:

```python
# before — the script ends here, and this is why JSON appears
{
    "python_version": sys.version.split()[0],
    "off_autocommit_fk": int(off_value),
    "fk_disagreement": off_value != on_value,
}
```

```json
{
  "python_version": "3.14.2",
  "sqlite_version": "3.39.0",
  "off_autocommit_fk": 0,
  "on_autocommit_fk": 1,
  "fk_disagreement": true
}
```

```text
Set PRAGMA foreign_keys = ON on two connections, then read it back:

autocommit      foreign_keys
False                      0   <-- setting dropped
True                       1

The two connections disagree: autocommit=False dropped the PRAGMA.
Python 3.14.2 / SQLite 3.39.0
```

`pandas-56679` and `numpy-28287` get the same treatment:

```text
Two empty containers built from the same empty input:

pd.Series([]).dtype                 -> object
pd.DataFrame({"a": []})["a"].dtype  -> float64

The two disagree: the same empty input yields different dtypes.
pandas 3.0.2 / Python 3.14.2
```

```text
x < y  -> True
y < z  -> True
x < z  -> False   <-- transitivity broken

Ordering is not transitive: x < y and y < z, yet x >= z.
```

## How

Each script now reads as ordinary Python: it computes, leaves the
machine-readable values in a `result` global, then prints. The driver
captures real stdout with `setStdout({ batched })` and puts it in
`#output` unchanged; `result` feeds the verdict and the Contract v1
envelope. Every `repro.py` keeps the **same body** as its browser
script, so the native run stays a check on the browser one.

**The global is deleted before every run.** One Pyodide namespace spans
every run, including the ones a visitor triggers from the Edit box, so a
script that no longer assigns `result` would otherwise be judged on the
previous run's values. Verified by editing each page's script to one
that never assigns it — both the worker and main-thread paths report
`unreproduced`, not a stale `reproduced`.

## numpy-28287 stays on the main thread

Its 2.5 s of blocking is still below the threshold that moved the other
two into workers (18.3–25.8 s), and the follow-up PR consolidates every
worker into one shared module. A numpy-only worker written here would be
deleted there; the eight lines of main-thread capture would not. Measured
after the change: 3.9 s total blocking, 2.9 s worst task on a cold local
load — unchanged in character.

## Unchanged

Verdicts, `__VIVARIUM_RESULT__` `result` and `runtime.extras` key sets,
i18n key sets, and the static `data-fix-status="none"` panes.

## Review follow-up

Both findings from the automated review were real and are fixed:

- `pandas-56679/README.md` still showed the **old JSON blob** as the
  expected `uv run` output. Replaced with the actual current output, in
  the same stdout-then-stderr form `dateutil-1478/README.md` uses. (My
  pre-PR sweep grepped the READMEs for the word "JSON" and this block
  does not contain it — the key names were the tell.)
- The new rule text claimed *"Every Layer 1 recipe follows the same
  shape"*, which is false today. It is now written as the required shape
  and names `lark-1585`, `regex-779` and `ruby-21709` as not yet
  converted. Worth flagging: **`lark-1585` still emits JSON too** — my
  plan had assumed it was already converted, so it belongs in the
  follow-up alongside the other two.

## Verification

- `repro:typecheck` / `repro:build` / `repro:pages` / `repro:i18n`
- `python:check` (ruff) — no reformatting, which is what keeps each
  `repro.py` byte-identical to its `REPRO_CODE`
- `docs:check`, `markdown:check`
- All three pages plus the Japanese numpy page: verdict `reproduced`,
  envelope keys identical, `#output-fix` still `none`, Edit / Run / Reset
  working
- All three `repro.py` under `uv run`: same text as the pane, exit 0

Playwright is left to CI.

## Follow-ups

- **A2** — same shape for `lark-1585`, `regex-779` (Rust `println!`;
  `serde_json` becomes removable from both crates) and `ruby-21709`
  (`ruby_loader.ts` moves from `DefaultRubyVM` to
  `RubyVM.instantiateModule` + `consolePrinter` to capture real stdout)
- **B** — one shared `_shared/pyodide-worker.ts`; numpy moves into it and
  `loadVivariumPyodide` goes away

🤖 Generated with [Claude Code](https://claude.com/claude-code)
