### PR TITLE
refactor(wasm): capture real stdout from ruby-21709, on Ruby 4.0

### DIFF
--- a/.claude/rules/recipe-authoring.md
+++ b/.claude/rules/recipe-authoring.md
@@ -287,11 +287,16 @@ of values it read back. The shape:
 - It `print`s a short human-readable summary: the inputs, the answer
   each one produced, and a marker on the ones that show the bug.
 - It leaves the machine-readable values in a named global — `result`
-  for a single mapping, `results` for a list of rows. The driver reads
+  for a single mapping, `results` for a list of rows, `$result` in Ruby
+  where a local would not survive to the next `eval`. The driver reads
   that global for the verdict and the Contract v1 envelope, and puts
   the captured stdout into `#output` unchanged.
-- Capture stdout with `setStdout({ batched })` under Pyodide, or
-  `ConsoleStdout.lineBuffered` under the WASI shim.
+- Capture stdout with `setStdout({ batched })` under Pyodide,
+  `consolePrinter({ stdout, stderr })` under Ruby.wasm, or
+  `ConsoleStdout.lineBuffered` under the WASI shim. Ruby.wasm's
+  `DefaultRubyVM` cannot do it — it hardcodes its fds and installs a
+  printer that writes to `console.log`, so `_shared/ruby_loader.ts`
+  builds the WASI itself and calls `RubyVM.instantiateModule`.
 - **Delete the global before every run.** One Pyodide namespace spans
   every run, including the ones a visitor triggers from the Edit box.
   Without `globals.delete`, a script that no longer assigns the global
@@ -318,8 +323,8 @@ go back to JSON:
   the envelope. stderr is the machine channel there, the way a named
   global is under Pyodide.
 
-`ruby-21709` still hands its pane a JSON string its driver built. Do not
-copy its output handling into a new recipe.
+Every other Layer 1 recipe follows the shape above. There is no
+remaining recipe to copy the old JSON-pane handling from.
 
 **Local validation**:
 

--- a/docs/scripts/__tests__/reproPreload.test.ts
+++ b/docs/scripts/__tests__/reproPreload.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { runtimeShells } from '../generate-repro-pages';
+import { REPO_ROOT } from '../site-paths';
+
+const SHARED_DIR = path.join(REPO_ROOT, 'src', 'layer1_wasm', '_shared');
+
+const LOADER_FOR_RUNTIME: Record<string, string> = {
+  pyodide: 'loader.ts',
+  'php-wasm': 'php_loader.ts',
+  'ruby.wasm': 'ruby_loader.ts',
+  'rust-wasi': 'rust_loader.ts',
+};
+
+function resolvedCdnUrls(loaderFile: string): string[] {
+  const source = readFileSync(path.join(SHARED_DIR, loaderFile), 'utf-8');
+
+  const values = new Map<string, string>();
+  for (const m of source.matchAll(
+    /export const (\w+)\s*=\s*["']([^"']+)["']/g,
+  )) {
+    values.set(m[1] as string, m[2] as string);
+  }
+  for (const m of source.matchAll(/const (\w+) = options\.\w+ \?\? (\w+);/g)) {
+    const target = values.get(m[2] as string);
+    if (target !== undefined) values.set(m[1] as string, target);
+  }
+
+  const urls: string[] = [];
+  for (const m of source.matchAll(/https:\/\/cdn\.jsdelivr\.net\/[^\s"'`]+/g)) {
+    const resolved = (m[0] as string).replaceAll(
+      /\$\{(\w+)\}/g,
+      (whole, name: string) => values.get(name) ?? whole,
+    );
+    if (!resolved.includes('${')) urls.push(resolved);
+  }
+  return urls;
+}
+
+function modulePreloadHrefs(preload: string): string[] {
+  return [
+    ...preload.matchAll(/rel="modulepreload"\s*\n\s*href="([^"]+)"/g),
+  ].map((m) => m[1] as string);
+}
+
+describe('runtime shells — preloaded modules come from the backing loader', () => {
+  for (const [runtime, shell] of Object.entries(runtimeShells())) {
+    const loaderFile = LOADER_FOR_RUNTIME[runtime];
+    const hrefs = modulePreloadHrefs(shell.preload);
+
+    test(`${runtime} maps to a known loader and preloads a module`, () => {
+      expect(loaderFile).toBeDefined();
+      expect(hrefs.length).toBeGreaterThan(0);
+    });
+
+    if (!loaderFile) continue;
+    const imported = resolvedCdnUrls(loaderFile);
+
+    for (const href of hrefs) {
+      test(`${runtime} preloads ${href}, which ${loaderFile} imports at that version`, () => {
+        expect(imported).toContain(href);
+      });
+    }
+  }
+});

--- a/docs/scripts/generate-repro-pages.ts
+++ b/docs/scripts/generate-repro-pages.ts
@@ -17,7 +17,7 @@ interface RecipeIndexEntry {
   title: string;
 }
 
-interface RuntimeShell {
+export interface RuntimeShell {
   preconnect: string;
   preload: string;
   kicker: string;
@@ -59,13 +59,18 @@ const RUNTIME_VERSIONS: Record<string, string> = {
     'rust_loader.ts',
     'DEFAULT_WASI_SHIM_VERSION',
   ),
+  RUBY_WASI_SHIM_VERSION: loaderConstant(
+    'ruby_loader.ts',
+    'DEFAULT_WASI_SHIM_VERSION',
+  ),
 };
 
-function runtimeShells(): Record<string, RuntimeShell> {
+export function runtimeShells(): Record<string, RuntimeShell> {
   const pyodide = RUNTIME_VERSIONS.PYODIDE_VERSION as string;
   const php = RUNTIME_VERSIONS.PHP_WASM_VERSION as string;
   const ruby = RUNTIME_VERSIONS.RUBY_WASM_VERSION as string;
   const wasi = RUNTIME_VERSIONS.WASI_SHIM_VERSION as string;
+  const rubyWasi = RUNTIME_VERSIONS.RUBY_WASI_SHIM_VERSION as string;
   const pyodideBase = `https://cdn.jsdelivr.net/pyodide/v${pyodide}/full`;
   return {
     pyodide: {
@@ -89,9 +94,14 @@ function runtimeShells(): Record<string, RuntimeShell> {
     },
     'ruby.wasm': {
       preconnect: CDN_PRECONNECT,
-      preload: modulePreload(
-        `https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@${ruby}/dist/browser/+esm`,
-      ),
+      preload: [
+        modulePreload(
+          `https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@${ruby}/+esm`,
+        ),
+        modulePreload(
+          `https://cdn.jsdelivr.net/npm/@bjorn3/browser_wasi_shim@${rubyWasi}/dist/index.js`,
+        ),
+      ].join('\n'),
       kicker: 'L1 · Ruby.wasm',
       verdictPending: 'Loading Ruby.wasm runtime…',
     },
@@ -336,12 +346,14 @@ function renderLayer2(): void {
   }
 }
 
-renderLayer1();
-renderLayer2();
+if (import.meta.main) {
+  renderLayer1();
+  renderLayer2();
 
-console.log(`[generate-repro-pages] wrote ${written} reproduction page(s).`);
-if (unhighlighted.length > 0) {
-  console.warn(
-    `[generate-repro-pages] plain source inlined for ${unhighlighted.join(', ')} — run \`mise run repro:build:ts\` to render the highlighted version.`,
-  );
+  console.log(`[generate-repro-pages] wrote ${written} reproduction page(s).`);
+  if (unhighlighted.length > 0) {
+    console.warn(
+      `[generate-repro-pages] plain source inlined for ${unhighlighted.join(', ')} — run \`mise run repro:build:ts\` to render the highlighted version.`,
+    );
+  }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -139,8 +139,8 @@ description = "Run every src/layer1_wasm/*/repro.py against host Python (auto-di
 run = "bash scripts/run-layer1-python.sh"
 
 [tasks."repro:native:ruby"]
-description = "Run Ruby repros against host Ruby (3.3.x pin)"
-tools = { ruby = "3.3.3" }
+description = "Run Ruby repros against host Ruby (4.0.x pin)"
+tools = { ruby = "4.0.6" }
 run = "ruby src/layer1_wasm/ruby-21709/repro.rb"
 
 [tasks."repro:native:rust"]

--- a/src/layer1_wasm/_shared/ruby_loader.ts
+++ b/src/layer1_wasm/_shared/ruby_loader.ts
@@ -1,5 +1,5 @@
-import { setVerdict } from "./verdict.js";
 import { pick } from "./i18n.js";
+import { setVerdict } from "./verdict.js";
 
 const S = pick(
   { pending: 'Loading Ruby.wasm runtime…' },
@@ -8,20 +8,67 @@ const S = pick(
 
 export const DEFAULT_RUBY_WASM_VERSION = "2.10.1";
 
-export const DEFAULT_RUBY_VERSION = "3.4";
+export const DEFAULT_RUBY_VERSION = "4.0";
+
+export const DEFAULT_WASI_SHIM_VERSION = "0.4.2";
 
 export interface LoadOptions {
   rubyWasmVersion?: string;
   rubyVersion?: string;
+  wasiShimVersion?: string;
   pendingText?: string;
 }
 
-export type RubyVMInstance = unknown;
+export interface RunResult {
+  stdout: string;
+  stderr: string;
+  value: string | null;
+  error: string | null;
+}
+
+export interface RubyRunner {
+  eval(source: string): RunResult;
+}
 
 export interface LoadResult {
-  vm: RubyVMInstance;
+  ruby: RubyRunner;
   rubyWasmVersion: string;
   rubyVersion: string;
+}
+
+interface RubyPrinter {
+  addToImports(imports: WebAssembly.Imports): void;
+  setMemory(memory: WebAssembly.Memory): void;
+}
+
+interface RubyModule {
+  RubyVM: {
+    instantiateModule(opts: {
+      module: WebAssembly.Module;
+      wasip1: unknown;
+      addToImports?: (imports: WebAssembly.Imports) => void;
+      setMemory?: (memory: WebAssembly.Memory) => void;
+    }): Promise<{ vm: { eval(code: string): { toString(): string } } }>;
+  };
+  consolePrinter(opts: {
+    stdout: (text: string) => void;
+    stderr: (text: string) => void;
+  }): RubyPrinter;
+}
+
+interface WasiShimModule {
+  WASI: new (
+    args: string[],
+    env: string[],
+    fds: unknown[],
+    options?: { debug: boolean },
+  ) => unknown;
+  File: new (data: Uint8Array | number[]) => unknown;
+  OpenFile: new (file: unknown) => unknown;
+  PreopenDirectory: new (
+    name: string,
+    contents: Map<string, unknown>,
+  ) => unknown;
 }
 
 export async function loadVivariumRuby(
@@ -29,22 +76,23 @@ export async function loadVivariumRuby(
 ): Promise<LoadResult> {
   const rubyWasmVersion = options.rubyWasmVersion ?? DEFAULT_RUBY_WASM_VERSION;
   const rubyVersion = options.rubyVersion ?? DEFAULT_RUBY_VERSION;
+  const wasiShimVersion = options.wasiShimVersion ?? DEFAULT_WASI_SHIM_VERSION;
   const pendingText = options.pendingText ?? S.pending;
   const total = 22.0; // ruby+stdlib.wasm is ~21 MB
 
   setVerdict("pending", pendingText, "loading");
   emitProgress(5, "Initialising…", `0.0 MB / ${total.toFixed(1)} MB`);
 
-  const loaderUrl = `https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@${rubyWasmVersion}/dist/browser/+esm`;
+  const rubyUrl = `https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@${rubyWasmVersion}/+esm`;
+  const shimUrl = `https://cdn.jsdelivr.net/npm/@bjorn3/browser_wasi_shim@${wasiShimVersion}/dist/index.js`;
   const wasmUrl = `https://cdn.jsdelivr.net/npm/@ruby/${rubyVersion}-wasm-wasi@${rubyWasmVersion}/dist/ruby+stdlib.wasm`;
 
   try {
     emitProgress(20, "Fetching Ruby.wasm loader…", `0.0 MB / ${total.toFixed(1)} MB`);
-    const mod = (await import(/* @vite-ignore */ loaderUrl)) as {
-      DefaultRubyVM: (
-        module: WebAssembly.Module,
-      ) => Promise<{ vm: RubyVMInstance }>;
-    };
+    const [ruby, shim] = (await Promise.all([
+      import(/* @vite-ignore */ rubyUrl),
+      import(/* @vite-ignore */ shimUrl),
+    ])) as [RubyModule, WasiShimModule];
 
     emitProgress(40, "Downloading ruby+stdlib.wasm…", `0.0 MB / ${total.toFixed(1)} MB`);
     const response = await fetch(wasmUrl);
@@ -60,10 +108,55 @@ export async function loadVivariumRuby(
     const wasmModule = await WebAssembly.compile(buffer);
 
     emitProgress(88, "Instantiating Ruby VM…", `${downloadedMB} MB / ${total.toFixed(1)} MB`);
-    const { vm } = await mod.DefaultRubyVM(wasmModule);
+
+    let stdout = "";
+    let stderr = "";
+    const printer = ruby.consolePrinter({
+      stdout: (text) => {
+        stdout += text;
+      },
+      stderr: (text) => {
+        stderr += text;
+      },
+    });
+
+    const wasi = new shim.WASI(
+      [],
+      [],
+      [
+        new shim.OpenFile(new shim.File([])),
+        new shim.OpenFile(new shim.File([])),
+        new shim.OpenFile(new shim.File([])),
+        new shim.PreopenDirectory("/", new Map()),
+      ],
+      { debug: false },
+    );
+
+    const { vm } = await ruby.RubyVM.instantiateModule({
+      module: wasmModule,
+      wasip1: wasi,
+      addToImports: (imports) => printer.addToImports(imports),
+      setMemory: (memory) => printer.setMemory(memory),
+    });
 
     emitProgress(94, "Runtime ready.", `${downloadedMB} MB / ${total.toFixed(1)} MB`);
-    return { vm, rubyWasmVersion, rubyVersion };
+    return {
+      ruby: {
+        eval(source: string): RunResult {
+          stdout = "";
+          stderr = "";
+          try {
+            const value = vm.eval(source).toString();
+            return { stdout, stderr, value, error: null };
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            return { stdout, stderr, value: null, error: message };
+          }
+        },
+      },
+      rubyWasmVersion,
+      rubyVersion,
+    };
   } catch (err: unknown) {
     const errAny = err as { stack?: string; message?: string } | null;
     const message =

--- a/src/layer1_wasm/ruby-21709/README.md
+++ b/src/layer1_wasm/ruby-21709/README.md
@@ -28,7 +28,8 @@ of different encodings. The disagreement is the bug surface.
   succeeds — so the page emits a mechanically-distinguishable
   `reproduced` / `unreproduced`.
 - Open upstream (Status: Open) at the time of writing; reported
-  against Ruby 3.4 and confirmed to affect 3.2 / 3.3 / 3.4. A draft
+  against Ruby 3.4 and confirmed to affect 3.2 / 3.3 / 3.4; still
+  reproduces on 4.0 (Ruby 4.0.0 in the browser, 4.0.6 natively). A draft
   patch is in flight but has not landed.
 - Suits the WASM cell shape exactly — Ruby.wasm bundles full Onigmo
   and Encoding support, so this reproduces without runtime gaps.
@@ -78,26 +79,30 @@ python -m http.server -d . 8767
 The companion `repro.rb` script reproduces the bug without any
 WASM layer, so a contributor can confirm the gallery page is
 catching a *real* upstream behaviour rather than a Ruby.wasm
-quirk. The `mise.toml` at the repo root pins Ruby to **3.3.3**
-to match the version `@ruby/3.3-wasm-wasi` bundles, so:
+quirk. The `repro:native:ruby` task in the repo-root `mise.toml`
+pins Ruby to **4.0.6**, the latest release, matching the major.minor
+of the `@ruby/4.0-wasm-wasi` bundle the page runs, so:
 
 ```bash
 # One-time per machine / mise.toml change.
 mise install
 
-# Reproduces the bug; exits 0 on `reproduced`.
-mise exec ruby -- ruby src/layer1_wasm/ruby-21709/repro.rb
+# Reproduces the bug; exits 0 on `reproduced`. Run it through the
+# task rather than `mise exec ruby` — the 4.0.6 pin lives on the
+# task, so `mise exec` resolves to whatever Ruby mise picks.
+mise run repro:native:ruby
 
-# Expected output (Ruby 3.3.3):
-# {
-#   "ruby_version": "3.3.3",
-#   "regexp_built": false,
-#   "regexp_raised": "RegexpError",
-#   "string_built": true,
-#   "string_encoding": "UTF-8",
-#   "string_raised": null,
-#   "reproduced": true
-# }
+# Expected output:
+# Interpolating the same two fragments, one UTF-8 and one US-ASCII:
+#
+#   Regexp   /#{prefix}#{suffix}/    raised RegexpError   <-- rejected
+#   String   "#{prefix}#{suffix}"    built, encoding UTF-8
+#
+# The two forms disagree: Regexp interpolation rejects the mixed
+# encodings that String interpolation silently upgrades.
+# Ruby 4.0.6
+#
+# ...and on stderr:
 # verdict=reproduced — bug reproduces on this interpreter
 ```
 

--- a/src/layer1_wasm/ruby-21709/i18n.ja.json
+++ b/src/layer1_wasm/ruby-21709/i18n.ja.json
@@ -20,7 +20,7 @@
     "page.title": "Vivarium · ruby/ruby#21709 の再現",
     "verdict.pending": "Ruby.wasm runtime を読み込み中…",
     "drawer.body.p1": "Ruby の Regexp の式展開はエンコーディングの異なる断片を拒否するのに、String の式展開は黙って UTF-8 に昇格させる。{0} と {1} を使うと、{2} は {3} を送出する一方で {4} は UTF-8 の文字列を組み立てる。",
-    "drawer.body.p2": "2 つの式展開は、エンコーディングの異なる断片をどう結合するかで一致すべき。このページのスクリプトは両方を試し、それぞれが例外を送出したかを記録して、verdict のロジックが reproduced か unreproduced かを決めるのに使う JSON サマリを返す。",
+    "drawer.body.p2": "2 つの式展開は、エンコーディングの異なる断片をどう結合するかで一致すべき。このページのスクリプトは両方を試してそれぞれの結果を印字し、verdict のロジックは同じ観測値をスクリプトが残した {0} ハッシュから読み戻す。",
     "drawer.body.p3": "議論の全体（動機、fix の進捗）は下の GitHub issue スレッドにある。",
     "runner.edit": "編集",
     "runner.run": "実行",

--- a/src/layer1_wasm/ruby-21709/page.en.html
+++ b/src/layer1_wasm/ruby-21709/page.en.html
@@ -11,9 +11,9 @@
     <p data-i18n="drawer.body.p2">
       The two interpolation forms should agree on how to combine
       fragments of different encodings. The script on this page
-      attempts both, captures whether each raised, and returns
-      a JSON summary the verdict logic uses to decide reproduced
-      vs unreproduced.
+      attempts both and prints what each one did; the verdict
+      logic reads the same observations back out of the
+      <code>$result</code> hash it leaves behind.
     </p>
     <p data-i18n="drawer.body.p3">
       The full discussion (motivation, fix progress) lives in the

--- a/src/layer1_wasm/ruby-21709/repro.rb
+++ b/src/layer1_wasm/ruby-21709/repro.rb
@@ -6,50 +6,65 @@
 #   mise install                     # one-time, picks up mise.toml
 #   mise exec ruby -- ruby src/layer1_wasm/ruby-21709/repro.rb
 #
-# Prints `pass` if the bug REPRODUCES (Regexp interpolation rejects
-# the mixed-encoding combine ∧ String interpolation accepts it),
-# `fail` otherwise. Exit code: 0 on `pass`, 1 on `fail` so CI can
-# shell-script around it without parsing stdout.
-
-require "json"
-
-result = { ruby_version: RUBY_VERSION }
+# Interpolates the same two fragments — one UTF-8, one US-ASCII — into
+# a Regexp and into a String, and prints what each one did. Exits 0 on
+# `reproduced` (Regexp interpolation rejects the combine ∧ String
+# interpolation accepts it), 1 on `unreproduced`, so CI can shell-script
+# around it without parsing stdout.
 
 prefix = '\p{In_Arabic}'
-suffix = '\p{In_Arabic}'.encode("US-ASCII")
+suffix = '\p{In_Arabic}'.encode('US-ASCII')
 
 begin
   re = /#{prefix}#{suffix}/
-  result[:regexp_built] = true
-  result[:regexp_raised] = nil
+  regexp_raised = nil
 rescue => e
-  result[:regexp_built] = false
-  result[:regexp_raised] = e.class.name
+  regexp_raised = e.class.name
 end
 
 begin
-  s = "#{prefix}#{suffix}"
-  result[:string_built] = true
-  result[:string_encoding] = s.encoding.name
-  result[:string_raised] = nil
+  str = "#{prefix}#{suffix}"
+  string_encoding = str.encoding.name
+  string_raised = nil
 rescue => e
-  result[:string_built] = false
-  result[:string_encoding] = nil
-  result[:string_raised] = e.class.name
+  string_encoding = nil
+  string_raised = e.class.name
 end
 
-reproduced = !result[:regexp_built] && result[:string_built]
-result[:reproduced] = reproduced
+$result = {
+  ruby_version: RUBY_VERSION,
+  regexp_built: regexp_raised.nil?,
+  regexp_raised: regexp_raised,
+  string_built: string_raised.nil?,
+  string_encoding: string_encoding,
+  string_raised: string_raised,
+}
 
-puts JSON.pretty_generate(result)
+regexp_note =
+  regexp_raised ? "raised #{regexp_raised}   <-- rejected" : 'built'
+string_note =
+  string_raised ? "raised #{string_raised}" : "built, encoding #{string_encoding}"
 
-if reproduced
-  warn "verdict=reproduced — bug reproduces on this interpreter"
+puts 'Interpolating the same two fragments, one UTF-8 and one US-ASCII:'
+puts
+puts '  Regexp   /#{prefix}#{suffix}/    ' + regexp_note
+puts '  String   "#{prefix}#{suffix}"    ' + string_note
+puts
+if regexp_raised && string_raised.nil?
+  puts 'The two forms disagree: Regexp interpolation rejects the mixed'
+  puts 'encodings that String interpolation silently upgrades.'
+else
+  puts 'The two forms agree on how to combine fragments of different encodings.'
+end
+puts "Ruby #{RUBY_VERSION}"
+
+if $result[:regexp_built] == false && $result[:string_built]
+  warn 'verdict=reproduced — bug reproduces on this interpreter'
   exit 0
-elsif result[:regexp_built] && result[:string_built]
-  warn "verdict=unreproduced — Regexp and String interpolation now agree (likely fixed upstream)"
+elsif $result[:regexp_built] && $result[:string_built]
+  warn 'verdict=unreproduced — Regexp and String interpolation now agree (likely fixed upstream)'
   exit 1
 else
-  warn "verdict=unreproduced — unexpected outcome (regexp_built=#{result[:regexp_built]}, string_built=#{result[:string_built]})"
+  warn "verdict=unreproduced — unexpected outcome (regexp_built=#{$result[:regexp_built]}, string_built=#{$result[:string_built]})"
   exit 1
 end

--- a/src/layer1_wasm/ruby-21709/repro.ts
+++ b/src/layer1_wasm/ruby-21709/repro.ts
@@ -1,5 +1,9 @@
 import type { PathACapturedRun } from '../_shared/path_a.js';
-import { loadVivariumRuby } from '../_shared/ruby_loader.js';
+import {
+  loadVivariumRuby,
+  type RubyRunner,
+  type RunResult,
+} from '../_shared/ruby_loader.js';
 import { enableRunner } from '../_shared/runner.js';
 import {
   setResult,
@@ -8,35 +12,55 @@ import {
 } from '../_shared/verdict.js';
 
 const REPRO_CODE = String.raw`
-require "json"
-
-result = { ruby_version: RUBY_VERSION }
-
 prefix = '\p{In_Arabic}'
 suffix = '\p{In_Arabic}'.encode('US-ASCII')
 
 begin
   re = /#{prefix}#{suffix}/
-  result[:regexp_built] = true
-  result[:regexp_raised] = nil
+  regexp_raised = nil
 rescue => e
-  result[:regexp_built] = false
-  result[:regexp_raised] = e.class.name
+  regexp_raised = e.class.name
 end
 
 begin
-  s = "#{prefix}#{suffix}"
-  result[:string_built] = true
-  result[:string_encoding] = s.encoding.name
-  result[:string_raised] = nil
+  str = "#{prefix}#{suffix}"
+  string_encoding = str.encoding.name
+  string_raised = nil
 rescue => e
-  result[:string_built] = false
-  result[:string_encoding] = nil
-  result[:string_raised] = e.class.name
+  string_encoding = nil
+  string_raised = e.class.name
 end
 
-JSON.dump(result)
+$result = {
+  ruby_version: RUBY_VERSION,
+  regexp_built: regexp_raised.nil?,
+  regexp_raised: regexp_raised,
+  string_built: string_raised.nil?,
+  string_encoding: string_encoding,
+  string_raised: string_raised,
+}
+
+regexp_note =
+  regexp_raised ? "raised #{regexp_raised}   <-- rejected" : 'built'
+string_note =
+  string_raised ? "raised #{string_raised}" : "built, encoding #{string_encoding}"
+
+puts 'Interpolating the same two fragments, one UTF-8 and one US-ASCII:'
+puts
+puts '  Regexp   /#{prefix}#{suffix}/    ' + regexp_note
+puts '  String   "#{prefix}#{suffix}"    ' + string_note
+puts
+if regexp_raised && string_raised.nil?
+  puts 'The two forms disagree: Regexp interpolation rejects the mixed'
+  puts 'encodings that String interpolation silently upgrades.'
+else
+  puts 'The two forms agree on how to combine fragments of different encodings.'
+end
+puts "Ruby #{RUBY_VERSION}"
 `.trim();
+
+const RESET_RESULT = '$result = nil';
+const READ_RESULT = 'require "json"; JSON.dump($result)';
 
 interface ReproOutput {
   ruby_version: string;
@@ -45,10 +69,6 @@ interface ReproOutput {
   string_built: boolean;
   string_encoding: string | null;
   string_raised: string | null;
-}
-
-interface RubyVM {
-  eval(code: string): { toString(): string };
 }
 
 const outputEl = document.getElementById('output');
@@ -71,12 +91,17 @@ if (!reproCodeEl.firstChild) {
     .catch(() => {});
 }
 
-function evaluate(result: ReproOutput): {
+function evaluate(result: ReproOutput | null): {
   verdict: 'reproduced' | 'unreproduced';
   message: string;
 } {
-  const reproduced = !result.regexp_built && result.string_built;
-  if (reproduced) {
+  if (!result) {
+    return {
+      verdict: 'unreproduced',
+      message: 'bug not reproduced — the script left no `$result` hash behind.',
+    };
+  }
+  if (!result.regexp_built && result.string_built) {
     return {
       verdict: 'reproduced',
       message:
@@ -96,57 +121,72 @@ function evaluate(result: ReproOutput): {
   };
 }
 
-async function captureRun(
-  rb: RubyVM,
-  source: string,
-): Promise<PathACapturedRun> {
+function readResult(ruby: RubyRunner): ReproOutput | null {
+  const probe = ruby.eval(READ_RESULT);
+  if (probe.error !== null || probe.value === null) return null;
   try {
-    const jsonText = rb.eval(source).toString();
-    const result = JSON.parse(jsonText) as ReproOutput;
-    const ev = evaluate(result);
+    return JSON.parse(probe.value) as ReproOutput | null;
+  } catch {
+    return null;
+  }
+}
+
+interface CaptureResult {
+  run: PathACapturedRun;
+  parsed: ReproOutput | null;
+}
+
+function toCapture(run: RunResult, parsed: ReproOutput | null): CaptureResult {
+  if (run.error !== null) {
     return {
-      exitCode: 0,
-      verdict: ev.verdict,
-      message: ev.message,
-      stdout: JSON.stringify(result, null, 2),
-    };
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    return {
-      exitCode: 1,
-      verdict: 'unreproduced',
-      message: `runtime error: ${message}`,
-      stdout: message,
+      run: {
+        exitCode: 1,
+        verdict: 'unreproduced',
+        message: `runtime error: ${run.error}`,
+        stdout: [run.stdout, run.error].filter(Boolean).join('\n'),
+      },
+      parsed: null,
     };
   }
+  const ev = evaluate(parsed);
+  return {
+    run: {
+      exitCode: parsed ? 0 : 1,
+      verdict: ev.verdict,
+      message: ev.message,
+      stdout: run.stdout.trimEnd(),
+    },
+    parsed,
+  };
+}
+
+function captureRun(ruby: RubyRunner, source: string): CaptureResult {
+  ruby.eval(RESET_RESULT);
+  const run = ruby.eval(source);
+  return toCapture(run, run.error === null ? readResult(ruby) : null);
 }
 
 const startedAt = new Date();
 
 try {
-  const { vm, rubyWasmVersion, rubyVersion } = await loadVivariumRuby({
+  const { ruby, rubyWasmVersion, rubyVersion } = await loadVivariumRuby({
     pendingText: 'Loading Ruby.wasm runtime and stdlib…',
   });
 
   setVerdict('pending', 'Running reproduction script…');
-  const rb = vm as RubyVM;
-  const baseline = await captureRun(rb, REPRO_CODE);
+  const baseline = captureRun(ruby, REPRO_CODE);
 
-  let baselineResult: ReproOutput | null = null;
-  try {
-    baselineResult = JSON.parse(baseline.stdout) as ReproOutput;
-  } catch {
-    outputEl.textContent = baseline.stdout;
-    setVerdict(baseline.verdict, baseline.message);
-    throw new Error(baseline.message);
+  outputEl.textContent = baseline.run.stdout;
+  setVerdict(baseline.run.verdict, baseline.run.message);
+
+  const baselineResult = baseline.parsed;
+  if (!baselineResult) {
+    throw new Error(baseline.run.message);
   }
 
   metaEl.textContent = `Ruby ${baselineResult.ruby_version} via @ruby/${rubyVersion}-wasm-wasi v${rubyWasmVersion}.`;
-  outputEl.textContent = baseline.stdout;
-  setVerdict(baseline.verdict, baseline.message);
 
   const finishedAt = new Date();
-  const reproduced = baseline.verdict === 'reproduced';
   const envelope: VivariumResultV1 = {
     contract: 'v1',
     bug: {
@@ -168,7 +208,7 @@ try {
       string_built: baselineResult.string_built,
       string_encoding: baselineResult.string_encoding,
       string_raised: baselineResult.string_raised,
-      reproduced,
+      reproduced: baseline.run.verdict === 'reproduced',
     },
     timing: {
       started_at: startedAt.toISOString(),
@@ -181,7 +221,7 @@ try {
   enableRunner({
     slug: 'ruby-21709',
     baselineSource: REPRO_CODE,
-    runFix: (source) => captureRun(rb, source),
+    runFix: (source) => Promise.resolve(captureRun(ruby, source).run),
   });
 } catch (err: unknown) {
   console.error(err);


### PR DESCRIPTION
Completes the rollout started in #409 and continued in #410.
`ruby-21709` was the last recipe whose driver handed the output pane a
JSON string it had built.

## Before / after

The script ended in `JSON.dump(result)` and the page re-serialised the
parsed hash, so nothing on the pane was anything the script printed:

```json
{
  "ruby_version": "3.4.1",
  "regexp_built": false,
  "regexp_raised": "RegexpError",
  "string_built": true,
  "string_encoding": "UTF-8",
  "string_raised": null
}
```

```text
Interpolating the same two fragments, one UTF-8 and one US-ASCII:

  Regexp   /#{prefix}#{suffix}/    raised RegexpError   <-- rejected
  String   "#{prefix}#{suffix}"    built, encoding UTF-8

The two forms disagree: Regexp interpolation rejects the mixed
encodings that String interpolation silently upgrades.
Ruby 4.0.0
```

## Why the loader had to change

`DefaultRubyVM` **cannot** be made to capture stdout. It hardcodes its
fds and installs `consolePrinter()` with the default `console.log` /
`console.warn` sinks, and that printer patches `fd_write` for fds 1 and
2 *before* anything reaches the shim — so `ConsoleStdout.lineBuffered`
fds would never see a byte. Its option bag is only
`{ consolePrint?, env? }`.

`_shared/ruby_loader.ts` therefore stops calling it and does what
`DefaultRubyVM` does internally (I read the shipped
`dist/esm/browser.js` on the CDN rather than guessing):

- build the WASI from `@bjorn3/browser_wasi_shim` — the same shim at the
  same version `@ruby/wasm-wasi@2.10.1` already declares, so this adds
  no new runtime, only a second CDN module fetched in parallel with the
  first
- install `consolePrinter({ stdout, stderr })` with callbacks into a
  buffer the loader owns
- call `RubyVM.instantiateModule({ module, wasip1, addToImports, setMemory })`

It also imports from the package root rather than `/dist/browser/+esm`,
because that browser bundle exports only `DefaultRubyVM` — `RubyVM` and
`consolePrinter` are not reachable from it.

The loader now returns a runner instead of the raw VM. `eval` returns
`{ stdout, stderr, value, error }` and resets the buffers per call,
which is what the re-run path needs: the Ruby VM is instantiated once
and evaluated many times, unlike the Rust loader where every `run()`
builds a fresh instance.

## `$result`, not `result`

A local assigned inside one `vm.eval` does not survive to the next one,
so the named global is `$result`. The driver resets it before each run
and reads it back with a separate `JSON.dump($result)` eval.

Verified in the browser, both re-run paths:

| edited script | pane | verdict |
|---|---|---|
| `puts 'edited: this script leaves no $result'` | that line | `unreproduced` |
| `raise 'boom'` | `eval:1:in '<main>': boom (RuntimeError)` | `unreproduced` |
| Reset → Run | the full table | `reproduced` |

No stale `reproduced` from the previous run in either case.

## Ruby 4.0

`@ruby/4.0-wasm-wasi@2.10.1` is published (`4.1` and `3.5` are not), so
the page moves to it and the `repro:native:ruby` pin goes 3.3.3 → 4.0.6.

**The bug still reproduces on both** — Ruby 4.0.0 in the browser, 4.0.6
natively, verdict `reproduced` in each case. That is what the recipe
needs to keep claiming the issue is live, and it satisfies filter 1 of
the upstream-issue selection rule (still reproducible on the current
release).

It also closes a drift this PR's review surfaced: native was pinned to
3.3.3 while the page ran `@ruby/3.4-wasm-wasi`, so the two were no
longer checking the same interpreter line. They are again.

## Preload regression, and the test that guards it

Changing which CDN modules the loader imports left
`generate-repro-pages.ts` preloading
`@ruby/wasm-wasi@2.10.1/dist/browser/+esm` — a URL nothing fetches any
more — and preloading neither of the two it does. Confirmed in the
browser: before the fix the preloaded URL appears nowhere in
`performance.getEntriesByType('resource')`; after it, both preloads
match fetched entries exactly.

The shell now emits both, and reads the shim version from
`ruby_loader.ts`'s own `DEFAULT_WASI_SHIM_VERSION` rather than
`rust_loader.ts`'s identically-named one. They agree today but are
independent pins.

Nothing in CI covered `runtimeShells()`, so this adds
`docs/scripts/__tests__/reproPreload.test.ts`. It resolves each
loader's CDN URLs through **that loader's own** constants
(`export const NAME = "..."` plus the `const local = options.x ?? NAME`
hop) into concrete URLs, then asserts per runtime that every
`modulepreload` href is one of them. No version normalisation, so a
swapped constant cannot slip through.

Checked against two deliberate regressions rather than trusting a green run:

| injected fault | result |
|---|---|
| ruby preload back to `/dist/browser/+esm` | fails |
| ruby shell reads `rust_loader.ts`'s shim constant, bumped to `0.5.0` | fails |
| neither | 9 pass |

The generator's top-level render moved behind `import.meta.main` so
importing it from the test writes no files; `bun run
scripts/generate-repro-pages.ts` still renders as before.

## Unchanged

Verdicts, `__VIVARIUM_RESULT__` `result` and `runtime.extras` key sets,
the i18n **key** set, and the static `data-fix-status="none"` pane.

The drawer paragraph that described the JSON summary now describes what
the script prints. It gained one `<code>` element, so the Japanese value
gained the matching `{0}` placeholder — a value change on both sides,
not a key change.

The README documented `mise exec ruby`, which does not honour the pin —
that lives on the `repro:native:ruby` task — so it now documents the
task, with that task's output.

## Verification

- `repro:typecheck`, `repro:build:ts`, `repro:pages`, `repro:i18n`
- `docs:check`, `markdown:check`, `toml:check`, docs unit suite (119 pass)
- English and Japanese pages: verdict `reproduced` on Ruby 4.0.0,
  envelope keys identical to before, `#output-fix` still `none`, `{0}`
  rendering as `$result` in the JA drawer, both preloads used
- Native: `mise run repro:native:ruby` on Ruby 4.0.6 — same text as the
  pane, exit 0
- Swept every `repro.ts` / `repro.py` / `repro.rb` under
  `src/layer1_wasm/`: no driver builds a JSON pane and no native script
  dumps JSON any more. The one remaining `JSON.stringify` is in
  `_shared/_test/`, a contract-harness fixture with no `recipe.json` —
  the envelope is what it exists to show.

Playwright is left to CI.

## Follow-ups

- **Landing-page hero describes the wrong bug** (pre-existing, found by
  review). `docs/site/_components/VivariumHero.tsx`'s pinned
  `ruby-21709` card — EN and JA — describes a
  `String#unicode_normalize` NFD/NFC round-trip failure on `"café"`,
  not the Regexp-vs-String interpolation bug this recipe reproduces.
  `recipe.json`'s `symptom: "unicode-normalize-nfd"` and tags
  `["string", "unicode", "combining-diacritics"]` match that stale
  narrative, and propagate into `recipes.json` and the MCP server's
  bundled data. Visitor-facing and wrong, but untouched by this PR.
- **B** — one shared `_shared/pyodide-worker.ts`; `numpy-28287` moves
  into it and `loadVivariumPyodide` goes away. That is the last item
  from the plan this series started from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
