### PR TITLE
fix(docs): describe the real bug on the ruby-21709 hero card

### DIFF
--- a/docs/site/_components/VivariumHero.tsx
+++ b/docs/site/_components/VivariumHero.tsx
@@ -40,12 +40,12 @@ const STRINGS = {
       waiting: 'waiting for both transactions to commit…',
     },
     ruby: {
-      eyebrow: 'VIVARIUM · LAYER 1 · RUBY.WASM · UNICODE',
+      eyebrow: 'VIVARIUM · LAYER 1 · RUBY.WASM · ENCODING',
       title: 'Reproducing ruby/ruby#21709',
-      lede: 'String#unicode_normalize edge case for combining diacritics in NFD form.',
+      lede: 'Regexp interpolation rejects the mixed encodings that String interpolation silently upgrades.',
       verdictText: '✓ REPRODUCED — bug reproduced',
       tabVerified: 'verified',
-      okLine: 'round-trip lost (RuntimeError raised as expected)',
+      okLine: 'Regexp raised RegexpError; String built UTF-8',
       verdictTrace:
         'verdict: REPRODUCED — issue#21709 reproducible in ruby.wasm',
     },
@@ -84,12 +84,12 @@ const STRINGS = {
       waiting: '両トランザクションのコミットを待機中…',
     },
     ruby: {
-      eyebrow: 'VIVARIUM · LAYER 1 · RUBY.WASM · UNICODE',
+      eyebrow: 'VIVARIUM · LAYER 1 · RUBY.WASM · ENCODING',
       title: 'ruby/ruby#21709 を再現',
-      lede: 'NFD 形式の結合ダイアクリティカル記号における String#unicode_normalize のエッジケース。',
+      lede: 'String の式展開が黙って昇格させるエンコーディングの混在を、Regexp の式展開は拒否する。',
       verdictText: '✓ REPRODUCED — バグ再現',
       tabVerified: '検証済み',
-      okLine: 'round-trip lost (RuntimeError を期待通り raise)',
+      okLine: 'Regexp は RegexpError を raise、String は UTF-8 で構築',
       verdictTrace: 'verdict: REPRODUCED — issue#21709 が ruby.wasm で再現可能',
     },
   },
@@ -291,20 +291,22 @@ const RubyInner = ({ s }: { s: typeof STRINGS.en }) => (
       <div className="v-code">
         <span className="v-code__comment"># repro.rb</span>
         <span className="v-code__line">
-          s = <span className="v-code__str">"café"</span>
+          prefix ={' '}
+          <span className="v-code__str">'\p&#123;In_Arabic&#125;'</span>
         </span>
         <span className="v-code__line">
-          nfd = s.unicode_normalize(
-          <span className="v-code__str">:nfd</span>)
+          suffix = prefix.encode(
+          <span className="v-code__str">'US-ASCII'</span>)
         </span>
         <span className="v-code__line">
-          back = nfd.unicode_normalize(
-          <span className="v-code__str">:nfc</span>)
+          re = /<span className="v-code__str">#&#123;prefix&#125;</span>
+          <span className="v-code__str">#&#123;suffix&#125;</span>/
         </span>
         <span className="v-code__line">
-          <span className="v-code__kw">raise</span>{' '}
-          <span className="v-code__str">"round-trip lost"</span>{' '}
-          <span className="v-code__kw">unless</span> s == back
+          str ={' '}
+          <span className="v-code__str">
+            "#&#123;prefix&#125;#&#123;suffix&#125;"
+          </span>
         </span>
       </div>
 

--- a/docs/site/public/api/recipes.json
+++ b/docs/site/public/api/recipes.json
@@ -173,11 +173,12 @@
       "source_url": "https://github.com/aletheia-works/vivarium/tree/main/src/layer1_wasm/ruby-21709",
       "language": "ruby",
       "tags": [
-        "string",
-        "unicode",
-        "combining-diacritics"
+        "regexp",
+        "string-interpolation",
+        "encoding",
+        "onigmo"
       ],
-      "symptom": "unicode-normalize-nfd",
+      "symptom": "regexp-interpolation-encoding-mismatch",
       "severity": "bug",
       "expected_verdict": "reproduced",
       "expected_runtime": "ruby.wasm",

--- a/src/layer1_wasm/ruby-21709/recipe.json
+++ b/src/layer1_wasm/ruby-21709/recipe.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
   "language": "ruby",
-  "symptom": "unicode-normalize-nfd",
+  "symptom": "regexp-interpolation-encoding-mismatch",
   "severity": "bug",
-  "tags": ["string", "unicode", "combining-diacritics"],
+  "tags": ["regexp", "string-interpolation", "encoding", "onigmo"],
   "expected_verdict": "reproduced",
   "expected_runtime": "ruby.wasm"
 }


### PR DESCRIPTION
Found by the automated review on #411, which correctly flagged it as
pre-existing and out of that PR's scope.

## The landing page described a different bug

The pinned `ruby-21709` hero card — English and Japanese — said the
recipe reproduces a `String#unicode_normalize` NFD/NFC round-trip
failure on `"café"`. It does not, and never did. The recipe reproduces
Regexp interpolation rejecting mixed encodings that String
interpolation silently upgrades.

The eyebrow (`· UNICODE`), the lede, the code sample and the console
line were all wrong:

```ruby
# before — not this recipe
s = "café"
nfd = s.unicode_normalize(:nfd)
back = nfd.unicode_normalize(:nfc)
raise "round-trip lost" unless s == back
```

```ruby
# after — what repro.rb actually runs
prefix = '\p{In_Arabic}'
suffix = prefix.encode('US-ASCII')
re = /#{prefix}#{suffix}/
str = "#{prefix}#{suffix}"
```

Console line: `round-trip lost (RuntimeError raised as expected)` →
`Regexp raised RegexpError; String built UTF-8`.

## It was not only the hero

`recipe.json` carried the same stale narrative:

```json
"symptom": "unicode-normalize-nfd",
"tags": ["string", "unicode", "combining-diacritics"]
```

`symptom` is a gallery facet, and the file feeds
`docs/site/public/api/recipes.json` and, through `sync:bundled`, the MCP
server's bundled index. So the wrong label reached the public API and
the `search_recipes` tool too — a visitor filtering the gallery by
symptom would have found this recipe under Unicode normalisation.

Now:

```json
"symptom": "regexp-interpolation-encoding-mismatch",
"tags": ["regexp", "string-interpolation", "encoding", "onigmo"]
```

`recipe.schema.json` describes the symptom value space as
"intentionally open — pick the most descriptive existing tag if
possible, coin a new one if not". None of the existing symptoms fit, so
this coins one naming the `RegexpError` the reproduction actually
raises.

## Swept the rest

The other two pinned cards match their recipes: `cpython-137205`
(`fk-pragma-silently-dropped`) and `postgres-lost-update`
(`lost-update-read-committed`). Only ruby had drifted.

`packages/mcp-server/src/bundled/recipes.json` is gitignored and
regenerated by `sync:bundled`, so it is not in the diff.

## Verification

- `recipes:index` regenerated; `sync:bundled` run — both now carry
  `regexp-interpolation-encoding-mismatch`
- English and Japanese landing pages in the browser: eyebrow, lede, code
  sample and console line all read the new text, and
  `/vivarium/api/recipes.json` serves the new symptom and tags
- `docs:check`, `markdown:check`, docs unit suite (119 pass), MCP suite
  (131 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
