### PR TITLE
fix(wasm): stop truncating a displayed script at an escaped backtick

### DIFF
--- a/docs/scripts/__tests__/reproSource.test.ts
+++ b/docs/scripts/__tests__/reproSource.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  extractReproSource,
+  extractTemplateLiteral,
+} from '../../../src/layer1_wasm/scripts/repro-source';
+
+function reproTs(body: string, declaration = 'const REPRO_CODE = `'): string {
+  return `${declaration}\n${body}\n\`.trim();\n`;
+}
+
+describe('extractTemplateLiteral', () => {
+  test('reads a plain template literal', () => {
+    const src = reproTs('print("one")\nprint("two")');
+    expect(extractTemplateLiteral(src, 'REPRO_CODE')).toBe(
+      'print("one")\nprint("two")',
+    );
+  });
+
+  test('does not stop at an escaped backtick', () => {
+    const src = reproTs('print("one")\nprint("a \\` tick")\nprint("three")');
+    expect(extractTemplateLiteral(src, 'REPRO_CODE')).toBe(
+      'print("one")\nprint("a ` tick")\nprint("three")',
+    );
+  });
+
+  test('keeps an escaped backslash in the body', () => {
+    const src = reproTs('print("a \\\\ slash")\nprint("still here")');
+    expect(extractTemplateLiteral(src, 'REPRO_CODE')).toBe(
+      'print("a \\ slash")\nprint("still here")',
+    );
+  });
+
+  test('stops at a backtick that directly follows an escaped backslash', () => {
+    const src = 'const REPRO_CODE = `a\\\\`.trim();\n';
+    expect(extractTemplateLiteral(src, 'REPRO_CODE')).toBe('a\\');
+  });
+
+  test('unescapes \\n in a plain literal', () => {
+    const src = reproTs('print("a\\nb")');
+    expect(extractTemplateLiteral(src, 'REPRO_CODE')).toBe('print("a\nb")');
+  });
+
+  test('leaves escapes alone in a String.raw literal', () => {
+    const src = reproTs(
+      "prefix = '\\p{In_Arabic}'",
+      'const REPRO_CODE = String.raw`',
+    );
+    expect(extractTemplateLiteral(src, 'REPRO_CODE')).toBe(
+      "prefix = '\\p{In_Arabic}'",
+    );
+  });
+
+  test('does not stop at an escaped backtick in a String.raw literal', () => {
+    const src = reproTs("prefix = '\\`'", 'const REPRO_CODE = String.raw`');
+    expect(extractTemplateLiteral(src, 'REPRO_CODE')).toBe("prefix = '\\`'");
+  });
+
+  test('returns null when the name is absent', () => {
+    expect(extractTemplateLiteral(reproTs('x'), 'MISSING')).toBeNull();
+  });
+});
+
+describe('extractReproSource', () => {
+  test('prefers REPRO_CODE over REPRO_SOURCE_HINT', () => {
+    const src = `${reproTs('the code')}\n${reproTs('the hint', 'const REPRO_SOURCE_HINT = `')}`;
+    expect(extractReproSource(src)).toBe('the code');
+  });
+
+  test('falls back to REPRO_SOURCE_HINT', () => {
+    const src = reproTs('the hint', 'const REPRO_SOURCE_HINT = `');
+    expect(extractReproSource(src)).toBe('the hint');
+  });
+});

--- a/src/layer1_wasm/scripts/repro-source.ts
+++ b/src/layer1_wasm/scripts/repro-source.ts
@@ -24,7 +24,7 @@ export function extractTemplateLiteral(
   name: string,
 ): string | null {
   const re = new RegExp(
-    `const\\s+${name}\\s*=\\s*(String\\.raw)?\\s*\`([\\s\\S]*?)\``,
+    `const\\s+${name}\\s*=\\s*(String\\.raw)?\\s*\`((?:\\\\[\\s\\S]|[^\\\\\`])*)\``,
     'm',
   );
   const m = src.match(re);


### PR DESCRIPTION
A page that showed the visitor less code than it actually ran, and said
nothing about it.

## The defect

`extractTemplateLiteral` matched the literal body with a non-greedy
`[\s\S]*?` up to the next backtick. That does not skip an escaped one,
so a repro script containing a backtick was cut off there — mid-line —
and the page rendered the remainder as if it were the whole script.

```text
print("line one")
print("a ` backtick")     ← script actually has 3 lines
print("line three")
```

```text
print("line one")
print("a                  ← what the page showed
```

`unescapeTemplate` already handles `` \` `` on the way out, so escaped
backticks were meant to work; only the regex disagreed. The failure is
silent — no warning, no exception, and `repro.highlighted.html` looks
like a perfectly good file.

This is the same class the last several PRs have been closing: the page
telling the reader something that is not true about what ran. I hit it
myself earlier in this series, when a backtick in a script comment
collapsed the displayed source to one line.

## The fix

The body now matches *an escaped character, or a character that is
neither a backslash nor a backtick*, so it ends at the first
**unescaped** backtick:

```
`((?:\\[\s\S]|[^\\`])*)`
```

That is also correct for `String.raw`: an escaped backtick still does
not terminate the literal there, even though the backslash is retained
in the value — which is what the `isRaw` branch already does.

## No recipe is affected today

Which is why nothing was visibly broken. All seven
`repro.highlighted.html` files are **byte-identical** before and after
the change — I snapshotted them, rebuilt, and diffed each one.

## Tests

New `docs/scripts/__tests__/reproSource.test.ts` — the first coverage
this module has had. Ten cases: plain literal, escaped backtick, an
escaped backslash in the body, a backtick directly after an escaped
backslash, `\n` unescaping, `String.raw` leaving escapes alone,
`String.raw` with an escaped backtick, a missing name, and `REPRO_CODE`
taking precedence over `REPRO_SOURCE_HINT`.

Every case that guards the fix was checked against an implementation it
should reject, not against a green run:

| implementation | fails |
|---|---|
| old `([\s\S]*?)` | both escaped-backtick cases (plain and `String.raw`) |
| `([\s\S]*?)(?<!\\)` — counting backslashes instead of consuming escape pairs | the backslash-pair-before-the-delimiter case |
| shipped | none, 10 pass |

The middle row is the even-vs-odd backslash trap this pattern is prone
to: with ``a\\`` the lookbehind sees a backslash before the closing
delimiter, decides it is escaped, and runs off the end of the literal.

## Verification

- `repro:typecheck`, `repro:build:ts`, `docs:check`
- docs unit suite: 130 pass (120 before, 10 new)
- all seven rendered scripts byte-identical to the pre-change snapshot

## Review follow-up

The finding was right: the test named *"does not stop at a backtick that
follows an escaped backslash"* had no backtick in its input, so it
claimed a case it did not exercise — and the PR description repeated
that claim.

It is now two tests that do what they say: one for an escaped backslash
in the body, and one with the backslash pair sitting **directly** before
the closing delimiter, which is the adversarial placement. The
`String.raw` + escaped-backtick combination the commit message reasoned
about is covered too. Both new guards were confirmed against an
implementation that fails them, per the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
