### PR TITLE
refactor(wasm): drop the unused markReproductionDone

### DIFF
--- a/src/layer1_wasm/_shared/README.md
+++ b/src/layer1_wasm/_shared/README.md
@@ -28,7 +28,7 @@ and runner — `bun install`, `bun run build`, `bun run typecheck`.
 | `verdict.ts` | `verdict.js` | `setVerdict()` / `setResult()` + `VivariumResultV1` interface. |
 | `pyodide-worker-client.ts` | `pyodide-worker-client.js` | `startPyodideWorker()` — spawns the shared worker, drives the progress bar and the pending verdict, and returns `run` / `evaluate` / `install`. Every Pyodide recipe enters the runtime through this; none ships a worker of its own. |
 | `pyodide-worker.ts` | `pyodide-worker.js` | The shared Pyodide worker. Loads the runtime, optionally installs a spec, captures each run's stdout and reads back a named global. Imports nothing else from this directory — `verdict.ts` reaches `_assets/chrome.js`, which touches `document`. |
-| `loader.ts` | `loader.js` | `DEFAULT_PYODIDE_VERSION` (the version the worker and the generated pages both pin to), `totalEstimatedMB()` and `markReproductionDone()`. |
+| `loader.ts` | `loader.js` | `DEFAULT_PYODIDE_VERSION` (the version the worker and the generated pages both pin to) and `totalEstimatedMB()`. |
 | `i18n.ts` | `i18n.js` | `pick()` — chooses the English or Japanese variant of a strings object from the page's `lang`. |
 | `php_loader.ts` | `php_loader.js` | `loadVivariumPhp()` — php-wasm bootstrap. |
 | `ruby_loader.ts` | `ruby_loader.js` | `loadVivariumRuby()` — builds the WASI shim, installs a `consolePrinter` that captures stdout, and instantiates the Ruby VM. |

--- a/src/layer1_wasm/_shared/loader.ts
+++ b/src/layer1_wasm/_shared/loader.ts
@@ -1,19 +1,3 @@
-import { pick } from "./i18n.js";
-
-interface LoaderStrings {
-  complete: string;
-}
-
-const STRINGS: LoaderStrings = {
-  complete: "Reproduction complete.",
-};
-
-const STRINGS_JA: Partial<LoaderStrings> = {
-  complete: "再現完了。",
-};
-
-const S = pick(STRINGS, STRINGS_JA);
-
 export const DEFAULT_PYODIDE_VERSION = "314.0.6";
 
 const SIZE_RUNTIME_MB = 12.0; // wasm + stdlib + lockfile combined
@@ -21,13 +5,4 @@ const SIZE_PER_PACKAGE_MB = 0.6; // typical for sqlite3, pandas-light, etc.
 
 export function totalEstimatedMB(packageCount: number): number {
   return SIZE_RUNTIME_MB + packageCount * SIZE_PER_PACKAGE_MB;
-}
-
-export function markReproductionDone(): void {
-  if (typeof document === "undefined") return;
-  document.dispatchEvent(
-    new CustomEvent("vh-progress", {
-      detail: { pct: 100, label: S.complete, bytes: "", stage: "done" },
-    }),
-  );
 }


### PR DESCRIPTION
Flagged by the review on #413 as pre-existing, and the last item on the
list from this series.

## It was a duplicate, not a missing call

`markReproductionDone` dispatched a `vh-progress` event with
`stage: "done"`, which `chrome.js` answers by filling the bar to 100%,
adding `is-revealed` to the output and removing the progress element
after 600 ms. Nothing called it.

The obvious reading — "the progress bar never gets hidden, wire it up" —
is wrong. `_shared/verdict.ts` already dispatches that same event
whenever the verdict leaves `pending`:

```ts
if (state !== 'pending') {
  document.dispatchEvent(
    new CustomEvent('vh-progress', {
      detail: { stage: 'done', pct: 100, label: 'Reproduction complete.' },
    }),
  );
}
```

That is the better home for it. Every recipe has to call `setVerdict` to
satisfy Contract v1, so the overlay cannot be left up by forgetting a
second call — which is precisely what a separate `markReproductionDone`
invites.

It was also inert twice over: `chrome.js`'s `done` branch renders its
own localised `T.complete` and **ignores the event's label**, so the
English and Japanese strings `loader.ts` carried for it could never have
reached a page even if something had called it.

## What is left

`loader.ts` is now the version pin and the size estimate — no `i18n`
import, no strings table:

```ts
export const DEFAULT_PYODIDE_VERSION = "314.0.6";

const SIZE_RUNTIME_MB = 12.0;
const SIZE_PER_PACKAGE_MB = 0.6;

export function totalEstimatedMB(packageCount: number): number {
  return SIZE_RUNTIME_MB + packageCount * SIZE_PER_PACKAGE_MB;
}
```

`_shared/README.md`'s row for it is updated to match.

## Verification

The point to prove is that I deleted the dead path, not the live one.
In the browser, after the verdict settles:

| page | `stage:"done"` events | progress removed | output revealed |
|---|---|---|---|
| `cpython-137205` (Pyodide worker) | 1 | yes | yes |
| `ruby-21709` — Japanese page (Ruby.wasm loader) | — | yes | yes |
| `regex-779` (Rust WASI loader) | — | yes | yes |

Three different runtimes, so the behaviour is coming from `setVerdict`
rather than from anything a particular loader does.

`repro:typecheck`, `repro:build:ts` (the symbol is gone from the emitted
`loader.js`), `docs:check`, `markdown:check`, docs unit suite 130 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
