### PR TITLE
docs(guide): teach the reproduction shape the recipes actually use

### DIFF
--- a/docs/site/en/guide/write-your-first-reproduction.mdx
+++ b/docs/site/en/guide/write-your-first-reproduction.mdx
@@ -93,19 +93,43 @@ import { ExampleSlug } from '../../_components/LiveExamples';
     eyebrow="// 4 · EDIT REPRO.TS"
     heading="Swap the reproduction logic; keep the helpers."
   >
-    <p>The copied <code>repro.ts</code> imports from{' '} <code>../_shared/loader.js</code> and{' '} <code>../_shared/verdict.js</code>. Leave that frame alone and swap only the <strong>reproduction body</strong>. For a Python recipe:</p>
+    <p>The copied <code>repro.ts</code> imports the verdict helpers from{' '} <code>../_shared/verdict.js</code> and, for a Python recipe,{' '} <code>startPyodideWorker</code> from{' '} <code>../_shared/pyodide-worker-client.js</code> (Ruby, PHP and Rust use{' '} <code>ruby_loader.js</code>, <code>php_loader.js</code> and{' '} <code>rust_loader.js</code> instead). Leave that frame alone and swap only the <strong>reproduction body</strong>.</p>
+    <p>Two rules make the page readable, and both matter:</p>
+    <ul>
+      <li><strong>Write ordinary code and <code>print</code> what happened.</strong> The output pane shows the script's real stdout, so a visitor can see why the answer is what it is. Do not end the script in a bare expression for the page to pick up — nothing reads it.</li>
+      <li><strong>Leave the machine-readable values in a global named <code>result</code></strong> (or <code>results</code> for a list of rows). That is what the verdict and the Contract v1 envelope are built from.</li>
+    </ul>
     <pre><code>{`const REPRO_CODE = \`
 import pandas as pd
 # ↑ minimum code that exercises the upstream bug
+
+left = ...   # value 1
+right = ...  # value 2
+mismatch = left != right
+
 result = {
-  "left": ...,   # value 1
-  "right": ...,  # value 2
-  "mismatch": <left> != <right>,
+    "left": left,
+    "right": right,
+    "mismatch": mismatch,
 }
-result
+
+print("left ".ljust(10) + str(left))
+print("right".ljust(10) + str(right))
+print()
+if mismatch:
+    print("The two disagree.")
+else:
+    print("The two agree.")
 \`.trim();
 `}</code></pre>
+    <p>The driver deletes <code>result</code> before every run, so a visitor who edits the script in the browser and removes the assignment gets{' '} <code>unreproduced</code> rather than the previous run's answer.</p>
     <p>The helpers handle the verdict wiring: if the comparison is{' '} <code>true</code> (bug reproduced), call{' '} <code>setVerdict("reproduced", "...")</code>; otherwise{' '} <code>setVerdict("unreproduced", "...")</code>.{' '} <code>setResult({`{ contract: "v1", bug, runtime, result, timing }`})</code>{' '} writes the <code>__VIVARIUM_RESULT__</code> envelope.</p>
+    <Callout>
+      Pyodide runs in a Web Worker shared by every Python recipe, so
+      booting it never freezes the page — and there is no worker file to
+      write. <code>startPyodideWorker</code> spawns it and returns{' '}
+      <code>run</code> / <code>evaluate</code> / <code>install</code>.
+    </Callout>
   </Section>
 
   <Section
@@ -138,9 +162,18 @@ python -m http.server -d src/layer1_wasm/<your-slug> 8765
 # requires-python = ">=3.14"
 # dependencies = ["pandas==2.3.3"]
 # ///
-import pandas as pd
-# … same reproduction logic …
+"""… what the bug is, and how to run this file …"""
+
+# ← the body here is the same text as REPRO_CODE, character for character
+
+if mismatch:
+    print("verdict=reproduced — …", file=sys.stderr)
+    sys.exit(0)
+else:
+    print("verdict=unreproduced — …", file=sys.stderr)
+    sys.exit(1)
 `}</code></pre>
+    <p>Keep the body <strong>identical</strong> to <code>REPRO_CODE</code>. Only the PEP 723 header, the docstring, and the{' '} <code>verdict=</code> line plus exit code are extra — that is what makes the native run a check on the browser one rather than a second script that merely looks similar. Run the repo's formatter over the native file and mirror whatever it does back into the string literal, or the next autofix pass will drift them apart.</p>
     <p><code>mise exec uv -- uv run repro.py</code> spins up an ephemeral venv and runs it. Ruby, PHP, and Rust use the same pattern — existing recipes' <code>repro.rb</code> /{' '} <code>repro.php</code> / <code>Cargo.toml</code> are good starting points.</p>
   </Section>
 

--- a/docs/site/ja/guide/write-your-first-reproduction.mdx
+++ b/docs/site/ja/guide/write-your-first-reproduction.mdx
@@ -93,19 +93,43 @@ import { ExampleSlug } from '../../_components/LiveExamples';
     eyebrow="// 4 · repro.ts を書き換える"
     heading="再現ロジックだけ差し替える。helper はそのまま。"
   >
-    <p>コピー元の <code>repro.ts</code> は <code>../_shared/loader.js</code> と{' '} <code>../_shared/verdict.js</code> を import している部分が共通骨格です。 ここはそのまま残して、<strong>再現コード本体だけ</strong>差し替えます。 Python レシピなら以下のような形:</p>
+    <p>コピー元の <code>repro.ts</code> は <code>../_shared/verdict.js</code> の verdict helper と、Python レシピなら{' '} <code>../_shared/pyodide-worker-client.js</code> の{' '} <code>startPyodideWorker</code> を import している部分が共通骨格です （Ruby / PHP / Rust はそれぞれ <code>ruby_loader.js</code> /{' '} <code>php_loader.js</code> / <code>rust_loader.js</code>）。 ここはそのまま残して、<strong>再現コード本体だけ</strong>差し替えます。</p>
+    <p>ページを読めるものにするための規則が 2 つあり、どちらも重要です:</p>
+    <ul>
+      <li><strong>普通のコードとして書き、起きたことを <code>print</code> する。</strong> 出力ペインにはスクリプトの実 stdout がそのまま出るので、訪問者はなぜその答えになるのかを読めます。ページに拾わせるための裸の式でスクリプトを終わらせないこと — 誰も読みません。</li>
+      <li><strong>機械可読な値は <code>result</code> という名前のグローバルに残す</strong>（行の並びなら <code>results</code>）。verdict と Contract v1 envelope はここから組み立てられます。</li>
+    </ul>
     <pre><code>{`const REPRO_CODE = \`
 import pandas as pd
 # ↑ 上流バグを表す最小コード
+
+left = ...   # 比較する値 1
+right = ...  # 比較する値 2
+mismatch = left != right
+
 result = {
-  "left": ...,   # 比較する値 1
-  "right": ...,  # 比較する値 2
-  "mismatch": <left> != <right>,
+    "left": left,
+    "right": right,
+    "mismatch": mismatch,
 }
-result
+
+print("left ".ljust(10) + str(left))
+print("right".ljust(10) + str(right))
+print()
+if mismatch:
+    print("The two disagree.")
+else:
+    print("The two agree.")
 \`.trim();
 `}</code></pre>
+    <p>driver は毎回の実行前に <code>result</code> を削除します。訪問者がブラウザ上でスクリプトを編集して代入を消した場合、前回の答えではなく{' '} <code>unreproduced</code> になります。</p>
     <p>verdict 設定は helper が面倒を見ます: 比較が <code>true</code>（バグが再現した）なら <code>setVerdict("reproduced", "...")</code>、そうでなければ <code>setVerdict("unreproduced", "...")</code>。 <code>setResult({`{ contract: "v1", bug, runtime, result, timing }`})</code>{' '} で <code>__VIVARIUM_RESULT__</code> envelope も書き出されます。</p>
+    <Callout>
+      Pyodide は全 Python レシピが共有する Web Worker で動くので、起動が
+      ページを固めることはありません。worker ファイルを書く必要もありません。{' '}
+      <code>startPyodideWorker</code> がそれを起動し、<code>run</code> /{' '}
+      <code>evaluate</code> / <code>install</code> を返します。
+    </Callout>
   </Section>
 
   <Section
@@ -138,9 +162,18 @@ python -m http.server -d src/layer1_wasm/<あなたの slug> 8765
 # requires-python = ">=3.14"
 # dependencies = ["pandas==2.3.3"]
 # ///
-import pandas as pd
-# … 同じ再現ロジック …
+"""… どんなバグで、このファイルをどう走らせるか …"""
+
+# ← ここの本体は REPRO_CODE と 1 文字も違わない同じテキスト
+
+if mismatch:
+    print("verdict=reproduced — …", file=sys.stderr)
+    sys.exit(0)
+else:
+    print("verdict=unreproduced — …", file=sys.stderr)
+    sys.exit(1)
 `}</code></pre>
+    <p>本体は <code>REPRO_CODE</code> と<strong>同一</strong>に保ちます。 追加してよいのは PEP 723 ヘッダ、docstring、<code>verdict=</code> 行と exit code だけです。 これがあって初めて native 実行はブラウザ側の検算になり、似ているだけの別スクリプトになりません。 native ファイルにリポジトリの formatter をかけ、その結果を文字列リテラル側にも反映してください。 さもないと次の autofix で 2 つが乖離します。</p>
     <p><code>mise exec uv -- uv run repro.py</code> で ephemeral venv が組まれて走ります。Ruby、PHP、Rust も同様で、既存レシピの <code>repro.rb</code> / <code>repro.php</code> / <code>Cargo.toml</code>{' '} が雛形になります。</p>
   </Section>
 


### PR DESCRIPTION
The page that teaches how to write a reproduction was the last one still
describing the way we stopped writing them.

## A contributor following this guide would write a broken recipe

`write-your-first-reproduction` told them to end `REPRO_CODE` in a bare
expression for the page to pick up:

```python
result = {
  "left": ...,
  "right": ...,
  "mismatch": <left> != <right>,
}
result          ← nothing reads this
```

Since #409 the driver reads a **named global**, so this script produces
`bug not reproduced — the script left no `result` mapping behind`.

The same section said `repro.ts` imports from `../_shared/loader.js`.
`loadVivariumPyodide` was deleted in #413 when the Pyodide worker moved
into `_shared`; recipes import `pyodide-worker-client.js` now. The
import in the guide does not resolve.

Both locales, on the public site.

## Section 4 — the reproduction body

Now states the two rules that make a page readable, because both are
easy to get wrong and neither is obvious from the surrounding frame:

- **Write ordinary code and `print` what happened.** The pane shows the
  script's real stdout. Do not end the script in a bare expression —
  nothing reads it.
- **Leave the machine-readable values in a global named `result`** (or
  `results` for a list of rows). The verdict and the Contract v1
  envelope are built from that.

The example prints a comparison instead of trailing a dict, and notes
that the driver deletes `result` before every run — so a visitor who
edits the script in the browser and drops the assignment gets
`unreproduced` rather than the previous run's answer.

The imports now name `startPyodideWorker` from
`pyodide-worker-client.js`, with `ruby_loader.js` / `php_loader.js` /
`rust_loader.js` beside it. A callout says Pyodide runs in a worker
shared by every Python recipe and there is no worker file to write —
which is what a reader coming from an older recipe would otherwise go
looking for.

## Section 6 — the native variant

Said "same reproduction logic", which reads as advice. It is a rule:
the body must be **character-for-character identical** to `REPRO_CODE`,
with only the PEP 723 header, the docstring and the `verdict=` line plus
exit code extra. That identity is the whole reason the native run counts
as a check on the browser one rather than a second script that merely
looks similar. The section now says so, and warns to run the formatter
over the native file and mirror the result back into the string literal,
which is the drift that actually happens.

## Verification

Both pages rendered in the browser:

| check | EN | JA |
|---|---|---|
| references `_shared/loader.js` | no | no |
| references `pyodide-worker-client.js` | yes | yes |
| bare trailing expression in any code block | no | no |
| print-based example | yes | yes |
| `verdict=` / exit tail in the native block | yes | yes |

`docs:build` (site builds clean), `docs:check`, `markdown:check`, docs
unit suite 130 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
