### PR TITLE
docs(guide): correct how the non-Python native variants are run

### DIFF
--- a/docs/site/en/guide/write-your-first-reproduction.mdx
+++ b/docs/site/en/guide/write-your-first-reproduction.mdx
@@ -174,7 +174,12 @@ else:
     sys.exit(1)
 `}</code></pre>
     <p>Keep the body <strong>identical</strong> to <code>REPRO_CODE</code>. Only the PEP 723 header, the docstring, and the{' '} <code>verdict=</code> line plus exit code are extra — that is what makes the native run a check on the browser one rather than a second script that merely looks similar. Run the repo's formatter over the native file and mirror whatever it does back into the string literal, or the next autofix pass will drift them apart.</p>
-    <p><code>mise exec uv -- uv run repro.py</code> spins up an ephemeral venv and runs it. Ruby, PHP, and Rust use the same pattern — existing recipes' <code>repro.rb</code> /{' '} <code>repro.php</code> / <code>Cargo.toml</code> are good starting points.</p>
+    <p><code>mise exec uv -- uv run repro.py</code> spins up an ephemeral venv and runs it. The other languages share the idea, not the mechanism:</p>
+    <ul>
+      <li><strong>Ruby</strong> — a plain <code>repro.rb</code> the interpreter runs; there is no PEP 723 equivalent. Run it with{' '} <code>mise run repro:native:ruby</code> rather than{' '} <code>mise exec ruby</code>, because the version pin lives on the task. See <code><ExampleSlug layer={1} language="ruby" fallback="<ruby-slug>" /></code>.</li>
+      <li><strong>Rust</strong> — no companion file at all. The crate that compiles to <code>repro.wasm</code> <em>is</em> the native CLI, so{' '} <code>mise run repro:native:rust</code> runs the same{' '} <code>src/repro.rs</code> the page runs. See{' '} <code><ExampleSlug layer={1} language="rust" fallback="<rust-slug>" /></code>.</li>
+    </ul>
+    <p><code>mise run repro:native</code> runs all of them. No php-wasm recipe has been authored yet, so there is no <code>repro.php</code> to copy —{' '} <code>_shared/php_loader.ts</code> is in place for whoever writes the first one.</p>
   </Section>
 
   <Section

--- a/docs/site/ja/guide/write-your-first-reproduction.mdx
+++ b/docs/site/ja/guide/write-your-first-reproduction.mdx
@@ -174,7 +174,12 @@ else:
     sys.exit(1)
 `}</code></pre>
     <p>本体は <code>REPRO_CODE</code> と<strong>同一</strong>に保ちます。 追加してよいのは PEP 723 ヘッダ、docstring、<code>verdict=</code> 行と exit code だけです。 これがあって初めて native 実行はブラウザ側の検算になり、似ているだけの別スクリプトになりません。 native ファイルにリポジトリの formatter をかけ、その結果を文字列リテラル側にも反映してください。 さもないと次の autofix で 2 つが乖離します。</p>
-    <p><code>mise exec uv -- uv run repro.py</code> で ephemeral venv が組まれて走ります。Ruby、PHP、Rust も同様で、既存レシピの <code>repro.rb</code> / <code>repro.php</code> / <code>Cargo.toml</code>{' '} が雛形になります。</p>
+    <p><code>mise exec uv -- uv run repro.py</code> で ephemeral venv が組まれて走ります。他の言語も考え方は同じですが、仕組みは共有していません:</p>
+    <ul>
+      <li><strong>Ruby</strong> — インタプリタがそのまま走らせる <code>repro.rb</code> で、PEP 723 に相当するものはありません。 <code>mise exec ruby</code> ではなく{' '} <code>mise run repro:native:ruby</code> で実行してください。 バージョンのピンがタスク側にあるためです。 <code><ExampleSlug layer={1} language="ruby" fallback="<ruby-slug>" /></code> を参照。</li>
+      <li><strong>Rust</strong> — コンパニオンファイルはありません。<code>repro.wasm</code> にコンパイルされる crate <em>そのもの</em>が native CLI なので、{' '} <code>mise run repro:native:rust</code> はページが走らせるのと同じ{' '} <code>src/repro.rs</code> を実行します。 <code><ExampleSlug layer={1} language="rust" fallback="<rust-slug>" /></code> を参照。</li>
+    </ul>
+    <p><code>mise run repro:native</code> で全部まとめて走ります。 php-wasm のレシピはまだ書かれていないので、雛形にする <code>repro.php</code> は存在しません。 <code>_shared/php_loader.ts</code> は最初の 1 本を書く人のために用意されています。</p>
   </Section>
 
   <Section


### PR DESCRIPTION
Flagged by the review on #416 as pre-existing and out of that PR's
scope.

## What the line claimed

> `mise exec uv -- uv run repro.py` spins up an ephemeral venv and runs
> it. Ruby, PHP, and Rust use the same pattern — existing recipes'
> `repro.rb` / `repro.php` / `Cargo.toml` are good starting points.

Three things wrong in one sentence.

**`repro.php` does not exist.** No php-wasm recipe has been authored, so
`_shared/php_loader.ts` has zero consumers and there is nothing to copy
from. The guide pointed a reader at a file that has never existed.

**Ruby does not share the mechanism.** `repro.rb` is run by the
interpreter; there is no PEP 723 equivalent. And it has to go through
`mise run repro:native:ruby` rather than `mise exec ruby`, because the
version pin lives on the task — the same trap the `ruby-21709` README
was corrected for in #411.

**Rust has no companion file at all.** The crate that compiles to
`repro.wasm` *is* the native CLI, so the native run executes the very
`src/repro.rs` the page runs. Naming `Cargo.toml` as a "starting point"
describes a file to copy, where the real answer is that there is nothing
extra to write — which is the more useful thing to know.

## What it says now

Python keeps its uv + PEP 723 companion. Ruby and Rust each get a line
saying what they actually do and which task runs them, with the recipe
slug resolved from the catalogue rather than hard-coded. `mise run
repro:native` runs all of them. PHP is stated plainly as waiting for its
first recipe, with a pointer to the loader that is already in place for
whoever writes it.

## Verification

Both documented tasks were run rather than assumed:

| task | result |
|---|---|
| `mise run repro:native:rust` | prints the regex-779 table, `verdict=reproduced`, exit 0 |
| `mise run repro:native:ruby` | prints the ruby-21709 table on Ruby 4.0.6, exit 0 |

Both rendered pages checked in the browser: `repro:native:ruby`,
`repro:native:rust` and `repro:native` all appear, `ExampleSlug`
resolves to `ruby-21709` and `regex-779`, and the old "Ruby, PHP, and
Rust use the same pattern" claim is gone from each locale.

`docs:build`, `docs:check`, `markdown:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
