### PR TITLE
fix(build): stop hardcoding the Windows binaries in local tooling

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,13 +3,13 @@
   "configurations": [
     {
       "name": "vivarium-docs",
-      "runtimeExecutable": "C:\\Users\\Jam\\AppData\\Local\\mise\\installs\\bun\\1.4.0\\bin\\bun.exe",
+      "runtimeExecutable": "bun",
       "runtimeArgs": ["--cwd=docs", "run", "dev"],
       "port": 3000
     },
     {
       "name": "vivarium-layer1",
-      "runtimeExecutable": "C:\\Users\\Jam\\AppData\\Local\\mise\\installs\\uv\\0.12.9\\uv.exe",
+      "runtimeExecutable": "uv",
       "runtimeArgs": ["run", "--no-project", "--python", "3.13", "python", "-m", "http.server", "8767", "--directory", "src/layer1_wasm"],
       "port": 8767
     }

--- a/scripts/verify-recipe.sh
+++ b/scripts/verify-recipe.sh
@@ -22,7 +22,9 @@ fi
 echo "==> [1/6] ensure docs/ deps installed (ajv-cli ships there as devDep)"
 (cd docs && bun install --frozen-lockfile)
 ajv_bin_dir="$(cd docs/node_modules/.bin && pwd)"
-export AJV_BIN="${ajv_bin_dir}/ajv.exe"
+AJV_BIN="${ajv_bin_dir}/ajv"
+[ -x "${AJV_BIN}" ] || AJV_BIN="${AJV_BIN}.exe"
+export AJV_BIN
 
 echo "==> [2/6] docker build ${slug}"
 tag="vivarium-${slug}:dev"


### PR DESCRIPTION

Two spots pinned a Windows-only path because mise's PATH handling was
broken under Git Bash. jdx/mise#12696 removed that pre-conversion and
shipped in 2026.9.2; verified on a Windows box that a task's PATH now
survives out to a native grandchild process, so neither spot has to
name a `.exe` any more.

verify-recipe.sh set AJV_BIN to `<dir>/ajv.exe` unconditionally. bun
writes an `.exe` shim on Windows and an extensionless one everywhere
else, so on Linux and macOS the export pointed at a file that does not
exist — and because it was set at all, it also defeated the
`${AJV_BIN:-ajv}` fallback in capture-layer2-verdict.sh. It now probes
for the extensionless name and falls back to `.exe`, so both platforms
get a path that exists.

.claude/launch.json named absolute per-developer mise install paths
with the tool version baked in. bun and uv are both `latest` in
mise.toml, so every upgrade broke it with ENOENT: 1.3.14 -> 1.4.0 and
0.11.14 -> 0.12.8 -> 0.12.9 were three commits that only chased the
path. `bun` and `uv` resolve on PATH instead.

That also settles the tracking question #198 left open. Its commit
message said the file "cannot be team-shared as-is" and would be
gitignored, but the ignore line never landed and the file stayed
tracked with a username in it. With the paths gone there is nothing
developer-specific left, so it stays tracked and .gitignore is
untouched.

shellcheck passes. Confirmed on Linux that the probe selects the
extensionless ajv; the Windows leg still needs a run on the Windows
box.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
