### PR TITLE
fix(build): expand the lint globs on Windows

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -369,12 +369,14 @@ description = "ShellCheck — scripts/ (read-only)"
 # Only scripts/. A recipe's repro.sh reproduces a shell footgun, so it
 # trips the check that detects that footgun — SC2155 and SC2038 are the
 # bugs two Layer 2 recipes exist to demonstrate.
+shell = "bash -c"  # the default Windows shell passes the glob through unexpanded
 run = "shellcheck scripts/*.sh"
 
 [tasks."actions:check"]
 description = "actionlint — workflow syntax + ShellCheck over every run: block (read-only)"
 # Paths are explicit because actionlint finds workflows via `.git`,
 # which this repository does not have.
+shell = "bash -c"  # the default Windows shell passes the glob through unexpanded
 run = "actionlint .github/workflows/*.yml"
 
 [tasks."markdown:check:fix"]


### PR DESCRIPTION

shell:check and actions:check pass scripts/*.sh and
.github/workflows/*.yml to shellcheck and actionlint. mise's default
Windows shell does not expand a glob, and neither tool expands one
itself, so both tasks failed locally with the pattern taken as a
literal filename:

    scripts/*.sh: openBinaryFile: invalid argument (Invalid argument)
    could not read ".github/workflows/*.yml"

Running them under bash makes both pass. Linux CI already used a shell
that expands the glob, so its behaviour is unchanged.

This was previously recorded as a mise defect awaiting an upstream fix.
Re-measured on mise 2026.9.2: it is not one. The genuine mise defect
from the same investigation -- a POSIX-form PATH handed to children of
a bash -c task, which broke the cmd.exe grandchildren in ci:repro and
rust:check -- is fixed in that release.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
